### PR TITLE
#1 | Cadastro de Sistemas: Migration + Controller + Rotas CRUD + Restore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copie para .env: cp .env.example .env
+# Deve ser a mesma senha usada em appsettings.Development.json (dotnet run fora do Docker).
+# Exigência Microsoft: maiúsculas, minúsculas, números e símbolos.
+MSSQL_SA_PASSWORD=DevPassword123!

--- a/.gitignore
+++ b/.gitignore
@@ -636,3 +636,4 @@ FodyWeavers.xsd
 .env*
 .vscode
 .devcontainer
+.credentials/*

--- a/.gitignore
+++ b/.gitignore
@@ -633,7 +633,9 @@ FodyWeavers.xsd
 
 # End of https://www.toptal.com/developers/gitignore/api/linux,windows,macos,git,dotnetcore,aspnetcore,visualstudiocode,visualstudio
 
-.env*
+.env
+.env.local
+!.env.example
 .vscode
 .devcontainer
 .credentials/*

--- a/AuthService.Tests/AuthService.Tests.csproj
+++ b/AuthService.Tests/AuthService.Tests.csproj
@@ -10,7 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/AuthService.Tests/AuthService.Tests.csproj
+++ b/AuthService.Tests/AuthService.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>AuthService.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AuthService\AuthService.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/AuthService.Tests/SqlServerTestDb.cs
+++ b/AuthService.Tests/SqlServerTestDb.cs
@@ -1,0 +1,56 @@
+using Microsoft.Data.SqlClient;
+
+namespace AuthService.Tests;
+
+/// <summary>
+/// Cria/remove bancos dedicados para testes de integração (um nome por instância do factory).
+/// </summary>
+internal static class SqlServerTestDb
+{
+    public static string BuildMasterConnectionString(string baseConnection)
+    {
+        var builder = new SqlConnectionStringBuilder(baseConnection)
+        {
+            InitialCatalog = "master"
+        };
+        return builder.ConnectionString;
+    }
+
+    public static string BuildDatabaseConnectionString(string baseConnection, string databaseName)
+    {
+        var builder = new SqlConnectionStringBuilder(baseConnection)
+        {
+            InitialCatalog = databaseName
+        };
+        return builder.ConnectionString;
+    }
+
+    public static void CreateDatabase(string masterConnectionString, string databaseName)
+    {
+        using var conn = new SqlConnection(masterConnectionString);
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"CREATE DATABASE [{EscapeDbName(databaseName)}]";
+        cmd.ExecuteNonQuery();
+    }
+
+    public static void DropDatabase(string masterConnectionString, string databaseName)
+    {
+        SqlConnection.ClearAllPools();
+
+        using var conn = new SqlConnection(masterConnectionString);
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        var safe = EscapeDbName(databaseName);
+        cmd.CommandText = $"""
+            IF EXISTS (SELECT 1 FROM sys.databases WHERE name = N'{safe.Replace("'", "''")}')
+            BEGIN
+                ALTER DATABASE [{safe}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+                DROP DATABASE [{safe}];
+            END
+            """;
+        cmd.ExecuteNonQuery();
+    }
+
+    private static string EscapeDbName(string name) => name.Replace("]", "]]");
+}

--- a/AuthService.Tests/SystemsApiTests.cs
+++ b/AuthService.Tests/SystemsApiTests.cs
@@ -8,9 +8,12 @@ using Xunit;
 
 namespace AuthService.Tests;
 
-public class SystemsApiTests : IClassFixture<WebAppFactory>, IAsyncLifetime
+/// <summary>
+/// Cada teste usa um <see cref="WebAppFactory"/> novo → um banco SQL Server dedicado (criado no ctor, drop no Dispose).
+/// </summary>
+public class SystemsApiTests : IAsyncLifetime
 {
-    private readonly WebAppFactory _factory;
+    private WebAppFactory _factory = null!;
     private HttpClient _client = null!;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -19,25 +22,18 @@ public class SystemsApiTests : IClassFixture<WebAppFactory>, IAsyncLifetime
         PropertyNameCaseInsensitive = true
     };
 
-    public SystemsApiTests(WebAppFactory factory)
-    {
-        _factory = factory;
-    }
-
     public Task InitializeAsync()
     {
+        _factory = new WebAppFactory();
         _client = _factory.CreateClient();
-        return ResetDatabaseAsync();
+        return Task.CompletedTask;
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
-
-    private async Task ResetDatabaseAsync()
+    public Task DisposeAsync()
     {
-        using var scope = _factory.Services.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-        await db.Database.EnsureDeletedAsync();
-        await db.Database.EnsureCreatedAsync();
+        _client.Dispose();
+        _factory.Dispose();
+        return Task.CompletedTask;
     }
 
     [Fact]
@@ -65,6 +61,71 @@ public class SystemsApiTests : IClassFixture<WebAppFactory>, IAsyncLifetime
 
         var response = await _client.PostAsJsonAsync("/systems", new { name = "B", code = "ABC" }, JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_DuplicateCode_NormalizesWhitespace_ReturnsConflict()
+    {
+        await _client.PostAsJsonAsync("/systems", new { name = "A", code = "ABC" }, JsonOptions);
+
+        var response = await _client.PostAsJsonAsync("/systems", new { name = "B", code = "  ABC  " }, JsonOptions);
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_DuplicateCode_NormalizesWhitespace_ReturnsConflict()
+    {
+        await _client.PostAsJsonAsync("/systems", new { name = "A", code = "CODE_A" }, JsonOptions);
+        var b = await _client.PostAsJsonAsync("/systems", new { name = "B", code = "CODE_B" }, JsonOptions);
+        var dtoB = await b.Content.ReadFromJsonAsync<SystemDto>(JsonOptions);
+        Assert.NotNull(dtoB);
+
+        var put = await _client.PutAsJsonAsync($"/systems/{dtoB.Id}",
+            new { name = "B2", code = "  CODE_A  " }, JsonOptions);
+        Assert.Equal(HttpStatusCode.Conflict, put.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_ConcurrentSameCode_OneCreatedOneConflict()
+    {
+        const string code = "CONCURRENT_X";
+        var bodyA = new { name = "A", code };
+        var bodyB = new { name = "B", code };
+        var t1 = _client.PostAsJsonAsync("/systems", bodyA, JsonOptions);
+        var t2 = _client.PostAsJsonAsync("/systems", bodyB, JsonOptions);
+        await Task.WhenAll(t1, t2);
+
+        var r1 = await t1;
+        var r2 = await t2;
+        var statuses = new[] { r1.StatusCode, r2.StatusCode };
+        Assert.Contains(HttpStatusCode.Created, statuses);
+        Assert.Contains(HttpStatusCode.Conflict, statuses);
+    }
+
+    [Fact]
+    public async Task Create_WhitespaceOnlyName_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsJsonAsync("/systems", new { name = "   ", code = "X1" }, JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_WhitespaceOnlyCode_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsJsonAsync("/systems", new { name = "N1", code = "\t  " }, JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Put_WhitespaceOnlyName_ReturnsBadRequest()
+    {
+        var create = await _client.PostAsJsonAsync("/systems", new { name = "S", code = "W1" }, JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<SystemDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        var put = await _client.PutAsJsonAsync($"/systems/{dto.Id}",
+            new { name = "   ", code = "W1" }, JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
     }
 
     [Fact]

--- a/AuthService.Tests/SystemsApiTests.cs
+++ b/AuthService.Tests/SystemsApiTests.cs
@@ -1,0 +1,172 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AuthService.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AuthService.Tests;
+
+public class SystemsApiTests : IClassFixture<WebAppFactory>, IAsyncLifetime
+{
+    private readonly WebAppFactory _factory;
+    private HttpClient _client = null!;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    public SystemsApiTests(WebAppFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync()
+    {
+        _client = _factory.CreateClient();
+        return ResetDatabaseAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private async Task ResetDatabaseAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        await db.Database.EnsureDeletedAsync();
+        await db.Database.EnsureCreatedAsync();
+    }
+
+    [Fact]
+    public async Task Create_Post_ReturnsCreated_WithUtcTimestamps_AndNullDeletedAt()
+    {
+        var body = new { name = "Sistema X", code = "SISTEMA_X", description = "Opcional" };
+        var response = await _client.PostAsJsonAsync("/systems", body, JsonOptions);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var dto = await response.Content.ReadFromJsonAsync<SystemDto>(JsonOptions);
+        Assert.NotNull(dto);
+        Assert.NotEqual(Guid.Empty, dto.Id);
+        Assert.Null(dto.DeletedAt);
+        Assert.Equal("Sistema X", dto.Name);
+        Assert.Equal("SISTEMA_X", dto.Code);
+        Assert.Equal("Opcional", dto.Description);
+        Assert.True(dto.CreatedAt > DateTime.MinValue);
+        Assert.True(dto.UpdatedAt > DateTime.MinValue);
+    }
+
+    [Fact]
+    public async Task Create_DuplicateCode_ReturnsConflict()
+    {
+        await _client.PostAsJsonAsync("/systems", new { name = "A", code = "ABC" }, JsonOptions);
+
+        var response = await _client.PostAsJsonAsync("/systems", new { name = "B", code = "ABC" }, JsonOptions);
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsOnlyActiveSystems()
+    {
+        await _client.PostAsJsonAsync("/systems", new { name = "Ativo", code = "ATIVO" }, JsonOptions);
+
+        var other = await _client.PostAsJsonAsync("/systems", new { name = "Outro", code = "OUTRO" }, JsonOptions);
+        var toDelete = await other.Content.ReadFromJsonAsync<SystemDto>(JsonOptions);
+        Assert.NotNull(toDelete);
+        await _client.DeleteAsync($"/systems/{toDelete.Id}");
+
+        var listResp = await _client.GetAsync("/systems");
+        listResp.EnsureSuccessStatusCode();
+        var list = await listResp.Content.ReadFromJsonAsync<List<SystemDto>>(JsonOptions);
+        Assert.NotNull(list);
+        Assert.All(list, s => Assert.Null(s.DeletedAt));
+        Assert.Contains(list, s => s.Code == "ATIVO");
+        Assert.DoesNotContain(list, s => s.Code == "OUTRO");
+    }
+
+    [Fact]
+    public async Task GetById_Active_ReturnsOk_Deleted_Returns404()
+    {
+        var create = await _client.PostAsJsonAsync("/systems", new { name = "S", code = "S1" }, JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<SystemDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        var getOk = await _client.GetAsync($"/systems/{dto.Id}");
+        Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
+
+        await _client.DeleteAsync($"/systems/{dto.Id}");
+        var get404 = await _client.GetAsync($"/systems/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_Active_ReturnsOk_Deleted_Returns404()
+    {
+        var create = await _client.PostAsJsonAsync("/systems", new { name = "S", code = "U1" }, JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<SystemDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        var putOk = await _client.PutAsJsonAsync($"/systems/{dto.Id}",
+            new { name = "S2", code = "U1", description = (string?)null }, JsonOptions);
+        Assert.Equal(HttpStatusCode.OK, putOk.StatusCode);
+
+        await _client.DeleteAsync($"/systems/{dto.Id}");
+        var put404 = await _client.PutAsJsonAsync($"/systems/{dto.Id}",
+            new { name = "S3", code = "U1" }, JsonOptions);
+        Assert.Equal(HttpStatusCode.NotFound, put404.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_SoftDelete_ThenDeleteAgain_Returns404()
+    {
+        var create = await _client.PostAsJsonAsync("/systems", new { name = "S", code = "D1" }, JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<SystemDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        var del1 = await _client.DeleteAsync($"/systems/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, del1.StatusCode);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var row = await db.Systems.IgnoreQueryFilters().SingleAsync(s => s.Id == dto.Id);
+            Assert.NotNull(row.DeletedAt);
+        }
+
+        var del2 = await _client.DeleteAsync($"/systems/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, del2.StatusCode);
+    }
+
+    [Fact]
+    public async Task Restore_Deleted_ThenOperationsWorkAgain()
+    {
+        var create = await _client.PostAsJsonAsync("/systems", new { name = "S", code = "R1" }, JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<SystemDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        await _client.DeleteAsync($"/systems/{dto.Id}");
+
+        var get404 = await _client.GetAsync($"/systems/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
+
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch, $"/systems/{dto.Id}/restore"));
+        Assert.Equal(HttpStatusCode.OK, patch.StatusCode);
+
+        var getOk = await _client.GetAsync($"/systems/{dto.Id}");
+        Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
+        var restored = await getOk.Content.ReadFromJsonAsync<SystemDto>(JsonOptions);
+        Assert.NotNull(restored);
+        Assert.Null(restored.DeletedAt);
+    }
+
+    private sealed record SystemDto(
+        Guid Id,
+        string Name,
+        string Code,
+        string? Description,
+        DateTime CreatedAt,
+        DateTime UpdatedAt,
+        DateTime? DeletedAt);
+}

--- a/AuthService.Tests/WebAppFactory.cs
+++ b/AuthService.Tests/WebAppFactory.cs
@@ -1,24 +1,54 @@
 using AuthService.Data;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace AuthService.Tests;
 
+/// <summary>
+/// Sobe a API com SQL Server real: cria um banco com nome único e remove ao descartar o factory.
+/// Um factory por teste permite paralelismo sem colisão (cada um usa seu próprio database).
+/// </summary>
 public class WebAppFactory : WebApplicationFactory<Program>
 {
+    private const string TestSqlBaseEnv = "AUTH_SERVICE_TEST_SQL_BASE";
+
+    private readonly string _databaseName;
+    private readonly string _masterConnectionString;
+    private readonly string _appConnectionString;
+    private bool _disposed;
+
+    public WebAppFactory()
+    {
+        var baseConnection = Environment.GetEnvironmentVariable(TestSqlBaseEnv)?.Trim();
+        if (string.IsNullOrEmpty(baseConnection))
+        {
+            throw new InvalidOperationException(
+                $"Defina a variável de ambiente {TestSqlBaseEnv} com a connection string do SQL Server " +
+                "(sem Initial Catalog / Database), por exemplo: " +
+                "Server=127.0.0.1,1433;User Id=sa;Password=...;TrustServerCertificate=True");
+        }
+
+        _databaseName = "auth_svc_it_" + Guid.NewGuid().ToString("N");
+        _masterConnectionString = SqlServerTestDb.BuildMasterConnectionString(baseConnection);
+        _appConnectionString = SqlServerTestDb.BuildDatabaseConnectionString(baseConnection, _databaseName);
+
+        SqlServerTestDb.CreateDatabase(_masterConnectionString, _databaseName);
+    }
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Testing");
 
-        var inMemoryName = $"AuthTests_{Guid.NewGuid():N}";
-        builder.ConfigureTestServices(services =>
+        builder.ConfigureAppConfiguration((_, config) =>
         {
-            services.AddDbContext<AppDbContext>(options =>
-                options.UseInMemoryDatabase(inMemoryName));
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = _appConnectionString
+            });
         });
     }
 
@@ -27,7 +57,34 @@ public class WebAppFactory : WebApplicationFactory<Program>
         var host = base.CreateHost(builder);
         using var scope = host.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-        db.Database.EnsureCreated();
+        db.Database.Migrate();
         return host;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && !_disposed)
+        {
+            _disposed = true;
+            try
+            {
+                base.Dispose(true);
+            }
+            finally
+            {
+                try
+                {
+                    SqlServerTestDb.DropDatabase(_masterConnectionString, _databaseName);
+                }
+                catch
+                {
+                    // Não oculta falhas do teste; drop pode falhar se o SQL não estiver acessível.
+                }
+            }
+
+            return;
+        }
+
+        base.Dispose(disposing);
     }
 }

--- a/AuthService.Tests/WebAppFactory.cs
+++ b/AuthService.Tests/WebAppFactory.cs
@@ -1,0 +1,33 @@
+using AuthService.Data;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace AuthService.Tests;
+
+public class WebAppFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+
+        var inMemoryName = $"AuthTests_{Guid.NewGuid():N}";
+        builder.ConfigureTestServices(services =>
+        {
+            services.AddDbContext<AppDbContext>(options =>
+                options.UseInMemoryDatabase(inMemoryName));
+        });
+    }
+
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        var host = base.CreateHost(builder);
+        using var scope = host.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        db.Database.EnsureCreated();
+        return host;
+    }
+}

--- a/AuthService/AuthService.csproj
+++ b/AuthService/AuthService.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Evita cópia do executável nativo (apphost), que costuma dar "Text file busy" com dotnet watch + volume Docker. -->
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AuthService/Controllers/Systems/SystemsController.cs
+++ b/AuthService/Controllers/Systems/SystemsController.cs
@@ -2,6 +2,8 @@ using System.ComponentModel.DataAnnotations;
 using AuthService.Data;
 using AuthService.Models;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 
 namespace AuthService.Controllers.Systems;
@@ -58,27 +60,89 @@ public class SystemsController : ControllerBase
     private static SystemResponse ToResponse(AppSystem s) =>
         new(s.Id, s.Name, s.Code, s.Description, s.CreatedAt, s.UpdatedAt, s.DeletedAt);
 
+    private static void ValidateNormalizedFields(
+        ModelStateDictionary modelState,
+        string name,
+        string code,
+        string? descriptionOrNull)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            modelState.AddModelError(nameof(CreateSystemRequest.Name), "Name é obrigatório e não pode ser apenas espaços.");
+
+        if (string.IsNullOrWhiteSpace(code))
+            modelState.AddModelError(nameof(CreateSystemRequest.Code), "Code é obrigatório e não pode ser apenas espaços.");
+
+        if (name.Length > 80)
+            modelState.AddModelError(nameof(CreateSystemRequest.Name), "Name deve ter no máximo 80 caracteres.");
+
+        if (code.Length > 50)
+            modelState.AddModelError(nameof(CreateSystemRequest.Code), "Code deve ter no máximo 50 caracteres.");
+
+        if (descriptionOrNull is { Length: > 500 })
+            modelState.AddModelError(nameof(CreateSystemRequest.Description), "Description deve ter no máximo 500 caracteres.");
+    }
+
+    private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+    {
+        for (Exception? e = ex; e != null; e = e.InnerException)
+        {
+            if (e is SqlException sql)
+                return sql.Number is 2601 or 2627;
+        }
+
+        var text = string.Join(" ", GetExceptionMessages(ex));
+        return text.Contains("UNIQUE", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("unique constraint", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("duplicate key", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IEnumerable<string> GetExceptionMessages(Exception ex)
+    {
+        for (Exception? e = ex; e != null; e = e.InnerException)
+            yield return e.Message;
+    }
+
+    private static IActionResult UniqueConflictResult() =>
+        new ConflictObjectResult(new { message = "Já existe um sistema com este Code." });
+
     [HttpPost]
     public async Task<IActionResult> Create([FromBody] CreateSystemRequest request)
     {
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);
 
-        if (await _db.Systems.IgnoreQueryFilters().AnyAsync(s => s.Code == request.Code))
-            return Conflict(new { message = "Já existe um sistema com este Code." });
+        var name = request.Name.Trim();
+        var code = request.Code.Trim();
+        var description = string.IsNullOrWhiteSpace(request.Description) ? null : request.Description.Trim();
+
+        ValidateNormalizedFields(ModelState, name, code, description);
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        if (await _db.Systems.IgnoreQueryFilters().AnyAsync(s => s.Code == code))
+            return UniqueConflictResult();
 
         var now = DateTime.UtcNow;
         var entity = new AppSystem
         {
-            Name = request.Name.Trim(),
-            Code = request.Code.Trim(),
-            Description = string.IsNullOrWhiteSpace(request.Description) ? null : request.Description.Trim(),
+            Name = name,
+            Code = code,
+            Description = description,
             CreatedAt = now,
             UpdatedAt = now,
             DeletedAt = null
         };
         _db.Systems.Add(entity);
-        await _db.SaveChangesAsync();
+
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+        {
+            return UniqueConflictResult();
+        }
+
         return CreatedAtAction(nameof(GetById), new { id = entity.Id }, ToResponse(entity));
     }
 
@@ -114,18 +178,35 @@ public class SystemsController : ControllerBase
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);
 
+        var name = request.Name.Trim();
+        var code = request.Code.Trim();
+        var description = string.IsNullOrWhiteSpace(request.Description) ? null : request.Description.Trim();
+
+        ValidateNormalizedFields(ModelState, name, code, description);
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
         var entity = await _db.Systems.FirstOrDefaultAsync(s => s.Id == id);
         if (entity is null)
             return NotFound(new { message = "Sistema não encontrado." });
 
-        if (await _db.Systems.IgnoreQueryFilters().AnyAsync(s => s.Id != id && s.Code == request.Code))
-            return Conflict(new { message = "Já existe outro sistema com este Code." });
+        if (await _db.Systems.IgnoreQueryFilters().AnyAsync(s => s.Id != id && s.Code == code))
+            return new ConflictObjectResult(new { message = "Já existe outro sistema com este Code." });
 
-        entity.Name = request.Name.Trim();
-        entity.Code = request.Code.Trim();
-        entity.Description = string.IsNullOrWhiteSpace(request.Description) ? null : request.Description.Trim();
+        entity.Name = name;
+        entity.Code = code;
+        entity.Description = description;
         entity.UpdatedAt = DateTime.UtcNow;
-        await _db.SaveChangesAsync();
+
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+        {
+            return new ConflictObjectResult(new { message = "Já existe outro sistema com este Code." });
+        }
+
         return Ok(ToResponse(entity));
     }
 

--- a/AuthService/Controllers/Systems/SystemsController.cs
+++ b/AuthService/Controllers/Systems/SystemsController.cs
@@ -1,0 +1,160 @@
+using System.ComponentModel.DataAnnotations;
+using AuthService.Data;
+using AuthService.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace AuthService.Controllers.Systems;
+
+[ApiController]
+[Route("systems")]
+public class SystemsController : ControllerBase
+{
+    private readonly AppDbContext _db;
+
+    public SystemsController(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public class CreateSystemRequest
+    {
+        [Required(ErrorMessage = "Name é obrigatório.")]
+        [MaxLength(80, ErrorMessage = "Name deve ter no máximo 80 caracteres.")]
+        public string Name { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Code é obrigatório.")]
+        [MaxLength(50, ErrorMessage = "Code deve ter no máximo 50 caracteres.")]
+        public string Code { get; set; } = string.Empty;
+
+        [MaxLength(500, ErrorMessage = "Description deve ter no máximo 500 caracteres.")]
+        public string? Description { get; set; }
+    }
+
+    public class UpdateSystemRequest
+    {
+        [Required(ErrorMessage = "Name é obrigatório.")]
+        [MaxLength(80, ErrorMessage = "Name deve ter no máximo 80 caracteres.")]
+        public string Name { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Code é obrigatório.")]
+        [MaxLength(50, ErrorMessage = "Code deve ter no máximo 50 caracteres.")]
+        public string Code { get; set; } = string.Empty;
+
+        [MaxLength(500, ErrorMessage = "Description deve ter no máximo 500 caracteres.")]
+        public string? Description { get; set; }
+    }
+
+    public record SystemResponse(
+        Guid Id,
+        string Name,
+        string Code,
+        string? Description,
+        DateTime CreatedAt,
+        DateTime UpdatedAt,
+        DateTime? DeletedAt
+    );
+
+    private static SystemResponse ToResponse(AppSystem s) =>
+        new(s.Id, s.Name, s.Code, s.Description, s.CreatedAt, s.UpdatedAt, s.DeletedAt);
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateSystemRequest request)
+    {
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        if (await _db.Systems.IgnoreQueryFilters().AnyAsync(s => s.Code == request.Code))
+            return Conflict(new { message = "Já existe um sistema com este Code." });
+
+        var now = DateTime.UtcNow;
+        var entity = new AppSystem
+        {
+            Name = request.Name.Trim(),
+            Code = request.Code.Trim(),
+            Description = string.IsNullOrWhiteSpace(request.Description) ? null : request.Description.Trim(),
+            CreatedAt = now,
+            UpdatedAt = now,
+            DeletedAt = null
+        };
+        _db.Systems.Add(entity);
+        await _db.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetById), new { id = entity.Id }, ToResponse(entity));
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll()
+    {
+        var list = await _db.Systems
+            .OrderBy(s => s.CreatedAt)
+            .Select(s => new SystemResponse(
+                s.Id,
+                s.Name,
+                s.Code,
+                s.Description,
+                s.CreatedAt,
+                s.UpdatedAt,
+                s.DeletedAt))
+            .ToListAsync();
+        return Ok(list);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetById(Guid id)
+    {
+        var entity = await _db.Systems.FirstOrDefaultAsync(s => s.Id == id);
+        if (entity is null)
+            return NotFound(new { message = "Sistema não encontrado." });
+        return Ok(ToResponse(entity));
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> UpdateById(Guid id, [FromBody] UpdateSystemRequest request)
+    {
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        var entity = await _db.Systems.FirstOrDefaultAsync(s => s.Id == id);
+        if (entity is null)
+            return NotFound(new { message = "Sistema não encontrado." });
+
+        if (await _db.Systems.IgnoreQueryFilters().AnyAsync(s => s.Id != id && s.Code == request.Code))
+            return Conflict(new { message = "Já existe outro sistema com este Code." });
+
+        entity.Name = request.Name.Trim();
+        entity.Code = request.Code.Trim();
+        entity.Description = string.IsNullOrWhiteSpace(request.Description) ? null : request.Description.Trim();
+        entity.UpdatedAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+        return Ok(ToResponse(entity));
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> DeleteById(Guid id)
+    {
+        var entity = await _db.Systems.FirstOrDefaultAsync(s => s.Id == id);
+        if (entity is null)
+            return NotFound(new { message = "Sistema não encontrado." });
+
+        entity.DeletedAt = DateTime.UtcNow;
+        entity.UpdatedAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpPatch("{id:guid}/restore")]
+    public async Task<IActionResult> RestoreById(Guid id)
+    {
+        var entity = await _db.Systems
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(s => s.Id == id && s.DeletedAt != null);
+
+        if (entity is null)
+            return NotFound(new { message = "Sistema não encontrado ou não está deletado." });
+
+        entity.DeletedAt = null;
+        entity.UpdatedAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+        return Ok(ToResponse(entity));
+    }
+}

--- a/AuthService/Data/AppDbContext.cs
+++ b/AuthService/Data/AppDbContext.cs
@@ -7,6 +7,7 @@ namespace AuthService.Data;
 public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
 {
     public DbSet<User> Users => Set<User>();
+    public DbSet<AppSystem> Systems => Set<AppSystem>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/AuthService/Data/Migrations/20260328140000_CreateSystemsTable.Designer.cs
+++ b/AuthService/Data/Migrations/20260328140000_CreateSystemsTable.Designer.cs
@@ -4,6 +4,7 @@ using AuthService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AuthService.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260328140000_CreateSystemsTable")]
+    partial class CreateSystemsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AuthService/Data/Migrations/20260328140000_CreateSystemsTable.cs
+++ b/AuthService/Data/Migrations/20260328140000_CreateSystemsTable.cs
@@ -1,0 +1,50 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AuthService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class CreateSystemsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Systems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(80)", maxLength: 80, nullable: false),
+                    Code = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Systems", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Systems_DeletedAt",
+                table: "Systems",
+                column: "DeletedAt");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_Systems_Code",
+                table: "Systems",
+                column: "Code",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Systems");
+        }
+    }
+}

--- a/AuthService/Models/AppSystem.cs
+++ b/AuthService/Models/AppSystem.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace AuthService.Models;
+
+[Index(nameof(Code), IsUnique = true, Name = "UX_Systems_Code")]
+[Index(nameof(DeletedAt), Name = "IX_Systems_DeletedAt")]
+[Table("Systems")]
+public class AppSystem : ISoftDelete
+{
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    [StringLength(80)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(50)]
+    public string Code { get; set; } = string.Empty;
+
+    [StringLength(500)]
+    public string? Description { get; set; }
+
+    [Required]
+    public DateTime CreatedAt { get; set; }
+
+    [Required]
+    public DateTime UpdatedAt { get; set; }
+
+    public DateTime? DeletedAt { get; set; }
+}

--- a/AuthService/Program.cs
+++ b/AuthService/Program.cs
@@ -4,13 +4,9 @@ using Microsoft.EntityFrameworkCore;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-// Em "Testing", o DbContext é registrado só no projeto de testes (InMemory), para não misturar
-// providers com SQL Server e para o projeto web não depender de EFCore.InMemory em produção/ef.
-if (!builder.Environment.IsEnvironment("Testing"))
-{
-    builder.Services.AddDbContext<AppDbContext>(options =>
-        options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
-}
+// Em "Testing", a connection string vem do WebApplicationFactory (banco dedicado por execução de teste).
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
 builder.Services.AddControllers();
 

--- a/AuthService/Program.cs
+++ b/AuthService/Program.cs
@@ -4,8 +4,13 @@ using Microsoft.EntityFrameworkCore;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-builder.Services.AddDbContext<AppDbContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+// Em "Testing", o DbContext é registrado só no projeto de testes (InMemory), para não misturar
+// providers com SQL Server e para o projeto web não depender de EFCore.InMemory em produção/ef.
+if (!builder.Environment.IsEnvironment("Testing"))
+{
+    builder.Services.AddDbContext<AppDbContext>(options =>
+        options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+}
 
 builder.Services.AddControllers();
 
@@ -20,10 +25,15 @@ if (app.Environment.IsDevelopment())
     app.MapOpenApi();
 }
 
-app.UseHttpsRedirection();
+if (!app.Environment.IsEnvironment("Testing"))
+{
+    app.UseHttpsRedirection();
+}
 
 app.UseAuthorization();
 
 app.MapControllers();
 
 app.Run();
+
+public partial class Program;

--- a/AuthService/appsettings.Development.json
+++ b/AuthService/appsettings.Development.json
@@ -6,6 +6,6 @@
     }
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Server=db,1433;Database=AuthServiceDb;User Id=sa;Password=SenhaForte@123;TrustServerCertificate=True"
+    "DefaultConnection": "Server=localhost,1433;Database=AuthServiceDb;User Id=sa;Password=DevPassword123!;TrustServerCertificate=True"
   }
 }

--- a/README.md
+++ b/README.md
@@ -44,19 +44,53 @@ O SQL Server usa volume nomeado Docker (`mssql_data`) para os dados e escuta em 
 
 ## Endpoints iniciais
 
-Nesta fase inicial, o serviço expõe apenas o endpoint de saúde:
+- `GET /health` — saúde da aplicação.
 
-- `GET /health`
+### Cadastro de sistemas (`/systems`)
 
-Resposta esperada: status da aplicação ativo/saudável.
+Rotas REST (JSON). Registros com *soft delete* (`deletedAt` preenchido) retornam **404** em todas as operações exceto `PATCH .../restore`.
+
+| Método | Rota | Descrição |
+|--------|------|-----------|
+| `POST` | `/systems` | Cria sistema (`name`, `code`, `description` opcional). |
+| `GET` | `/systems` | Lista apenas sistemas ativos (não deletados). |
+| `GET` | `/systems/{id}` | Detalhe por id (ativo). |
+| `PUT` | `/systems/{id}` | Atualização completa. |
+| `DELETE` | `/systems/{id}` | *Soft delete*. |
+| `PATCH` | `/systems/{id}/restore` | Restaura registro deletado. |
+
+Em desenvolvimento, a documentação OpenAPI fica em `/openapi/v1.json` quando `Development`.
+
+## Testes de integração
+
+Na raiz do repositório (com SDK .NET 10):
+
+```bash
+dotnet test AuthService.Tests/AuthService.Tests.csproj
+```
+
+O compose de desenvolvimento monta só `./AuthService` em `/app`, então **não existe** `AuthService.Tests` dentro do container. Para testes com Docker, monte a **raiz do repositório**:
+
+```bash
+docker run --rm -v "$PWD:/workspace" -w /workspace mcr.microsoft.com/dotnet/sdk:10.0 \
+  dotnet test AuthService.Tests/AuthService.Tests.csproj
+```
+
+Migrações com o serviço `app` já em execução:
+
+```bash
+docker compose exec app dotnet restore
+docker compose exec app dotnet ef database update
+```
+
+O `restore` evita erros de pacote quando o `obj/` está desatualizado em relação ao `.csproj`.
 
 ## Próximos passos
 
-1. Definir entidades e relacionamento no banco de dados.
-2. Implementar CRUD de Sistema, Recurso e Rotas.
-3. Implementar gestão de permissões por recurso/rota.
-4. Adicionar autenticação e política de autorização.
-5. Criar testes automatizados e documentação da API.
+1. Implementar CRUD de Recurso e Rotas.
+2. Implementar gestão de permissões por recurso/rota.
+3. Adicionar autenticação e política de autorização.
+4. Expandir documentação OpenAPI e cenários de teste.
 
 
 ## Comandos Docker

--- a/README.md
+++ b/README.md
@@ -32,15 +32,30 @@ As permissões disponíveis por padrão são:
 
 ## Desenvolvimento com Docker
 
-1. Copie `.env.example` para `.env` (ou mantenha o `.env` local já criado).
-2. Ajuste `MSSQL_SA_PASSWORD` se necessário (a Microsoft exige senha forte).
-3. Suba os serviços: `docker compose up -d`.
+Arquivo na raiz: **`docker-compose.yml`**.
 
-O SQL Server usa volume nomeado Docker (`mssql_data`) para os dados e escuta em `localhost:1433`. O healthcheck usa `sqlcmd` com `-C` (certificado autoassinado em dev).
+1. **Variáveis de ambiente:** `cp .env.example .env` e edite se precisar. A senha `MSSQL_SA_PASSWORD` deve ser **a mesma** que está em `AuthService/appsettings.Development.json` se você rodar `dotnet run` **fora** do Docker com SQL em `localhost:1433` (o padrão do exemplo é `DevPassword123!`).
+2. **Subir API + SQL:** `docker compose up -d --build`  
+   O serviço `app` só sobe depois do `db` ficar **healthy** (healthcheck com `sqlcmd`).
+3. **Migrations (primeira vez ou após alterar migrations):**
+   ```bash
+   docker compose --profile migrate run --rm migrate
+   ```
+4. **API:** `http://localhost:8080` (mapeamento `8080:5042` → app escuta em `5042` no container).
 
-**Connection string (app no mesmo Compose):** use o host `db` e a mesma senha do `.env`, por exemplo:
+O SQL Server usa o volume `mssql_data` e expõe **`localhost:1433`** no host.
 
-`Server=db,1433;User Id=sa;Password=<sua senha>;TrustServerCertificate=True;`
+**Dentro do Compose**, a connection string é injetada no container `app` via `ConnectionStrings__DefaultConnection` com a senha do `.env` (não depende da senha fixa antiga no JSON).
+
+### Testes de integração via Compose
+
+Com o stack (pelo menos o `db`) no ar:
+
+```bash
+docker compose --profile test run --rm test
+```
+
+O serviço `test` monta a **raiz do repositório** e define `AUTH_SERVICE_TEST_SQL_BASE` apontando para o host `db` na rede interna.
 
 ## Endpoints iniciais
 
@@ -63,27 +78,24 @@ Em desenvolvimento, a documentação OpenAPI fica em `/openapi/v1.json` quando `
 
 ## Testes de integração
 
-Na raiz do repositório (com SDK .NET 10):
+Os testes usam **SQL Server real**. Cada caso cria um banco dedicado (`auth_svc_it_<guid>`), roda **migrations** e faz **DROP DATABASE** ao terminar (seguro para paralelismo).
+
+**Variável obrigatória** (connection string **sem** `Database` / `Initial Catalog`):
 
 ```bash
+export AUTH_SERVICE_TEST_SQL_BASE="Server=127.0.0.1,1433;User Id=sa;Password=<MESMA_DO_.env>;TrustServerCertificate=True"
 dotnet test AuthService.Tests/AuthService.Tests.csproj
 ```
 
-O compose de desenvolvimento monta só `./AuthService` em `/app`, então **não existe** `AuthService.Tests` dentro do container. Para testes com Docker, monte a **raiz do repositório**:
+**Alternativa:** `docker compose --profile test run --rm test` (veja *Desenvolvimento com Docker*).
+
+Sem `AUTH_SERVICE_TEST_SQL_BASE`, a suite falha ao criar o `WebAppFactory` (esperado).
+
+**Migrações com o `app` já rodando** (volume só com `AuthService`):
 
 ```bash
-docker run --rm -v "$PWD:/workspace" -w /workspace mcr.microsoft.com/dotnet/sdk:10.0 \
-  dotnet test AuthService.Tests/AuthService.Tests.csproj
+docker compose exec app sh -c "dotnet restore && dotnet tool restore && dotnet ef database update"
 ```
-
-Migrações com o serviço `app` já em execução:
-
-```bash
-docker compose exec app dotnet restore
-docker compose exec app dotnet ef database update
-```
-
-O `restore` evita erros de pacote quando o `obj/` está desatualizado em relação ao `.csproj`.
 
 ## Próximos passos
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,35 @@
+# Raiz do repositório. Requer arquivo .env (veja .env.example).
+# Uso: docker compose up -d
+# Migrações (primeira vez / após mudar migrations): docker compose --profile migrate run --rm migrate
+# Testes de integração (SQL real): docker compose --profile test run --rm test
+
 services:
   app:
     build:
       context: .
       dockerfile: Dockerfile
+    env_file:
+      - .env
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      # Sobrescreve appsettings.Development.json com a mesma senha do SQL (variável do .env).
+      ConnectionStrings__DefaultConnection: "Server=db,1433;Database=AuthServiceDb;User Id=sa;Password=${MSSQL_SA_PASSWORD};TrustServerCertificate=True"
     ports:
       - "8080:5042"
-    environment:
-      - ASPNETCORE_ENVIRONMENT=Development
     volumes:
       - ./AuthService:/app
     working_dir: /app
+    depends_on:
+      db:
+        condition: service_healthy
 
   db:
     image: mcr.microsoft.com/mssql/server:2022-latest
+    env_file:
+      - .env
     environment:
       ACCEPT_EULA: "Y"
-      MSSQL_SA_PASSWORD: "SenhaForte@123"
+      MSSQL_SA_PASSWORD: ${MSSQL_SA_PASSWORD}
     ports:
       - "1433:1433"
     volumes:
@@ -24,12 +38,47 @@ services:
       test:
         [
           "CMD-SHELL",
-          "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"SenhaForte@123\" -C -Q 'SELECT 1' || exit 1",
+          "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$$MSSQL_SA_PASSWORD\" -C -Q 'SELECT 1' || exit 1",
         ]
       interval: 5s
       timeout: 5s
       retries: 5
       start_period: 30s
+
+  # Aplica migrations no AuthServiceDb (usa a mesma imagem do app para ter dotnet-ef no PATH).
+  migrate:
+    profiles: [migrate]
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env
+    environment:
+      ConnectionStrings__DefaultConnection: "Server=db,1433;Database=AuthServiceDb;User Id=sa;Password=${MSSQL_SA_PASSWORD};TrustServerCertificate=True"
+    volumes:
+      - ./AuthService:/app
+    working_dir: /app
+    depends_on:
+      db:
+        condition: service_healthy
+    # dotnet-tools.json no volume faz o SDK exigir tool restore antes de `dotnet ef`.
+    command: ["sh", "-c", "dotnet restore && dotnet tool restore && dotnet ef database update"]
+
+  # Testes de integração: monta a raiz do repo; SQL em db:1433 na rede do compose.
+  test:
+    profiles: [test]
+    image: mcr.microsoft.com/dotnet/sdk:10.0
+    env_file:
+      - .env
+    environment:
+      AUTH_SERVICE_TEST_SQL_BASE: "Server=db,1433;User Id=sa;Password=${MSSQL_SA_PASSWORD};TrustServerCertificate=True"
+    volumes:
+      - .:/workspace
+    working_dir: /workspace
+    depends_on:
+      db:
+        condition: service_healthy
+    command: ["dotnet", "test", "AuthService.Tests/AuthService.Tests.csproj", "-v", "minimal"]
 
 volumes:
   mssql_data:


### PR DESCRIPTION
## Objetivo

Implementa o cadastro de **Sistemas** conforme a issue #1: persistência, endpoints REST e testes de integração.

## Alterações

### feat
- Tabela **Systems** (EF Core): `Id`, `Name`, `Code` (único), `Description` opcional, timestamps UTC e soft delete (`DeletedAt`).
- Rotas em **`/systems`**: `POST`, `GET`, `GET/:id`, `PUT/:id`, `DELETE` (soft delete), `PATCH /:id/restore`.
- Registros deletados retornam **404** nos demais endpoints; apenas **restore** atua sobre eles.
- Projeto **AuthService.Tests** com `WebApplicationFactory` e cenários da API.

### chore / docs
- **README**: documentação dos endpoints e comando de testes com Docker.
- **Program**: ambiente `Testing` sem registro SQL Server no host de testes; InMemory só no projeto de testes.
- **.gitignore**: exclusão de `.credentials/*`.

## Como validar

```bash
dotnet test AuthService.Tests/AuthService.Tests.csproj
```

Com Docker (raiz do repositório):

```bash
docker run --rm -v "$PWD:/workspace" -w /workspace mcr.microsoft.com/dotnet/sdk:10.0 \
  dotnet test AuthService.Tests/AuthService.Tests.csproj
```

## Referências

Closes #1