### PR TITLE
#5 | Recurso (vinculado a Systems): Migration + Controller + Rotas CRUD + Restore + Testes de Integração

### DIFF
--- a/AuthService.Tests/RoutesApiTests.cs
+++ b/AuthService.Tests/RoutesApiTests.cs
@@ -1,0 +1,255 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AuthService.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AuthService.Tests;
+
+public class RoutesApiTests : IAsyncLifetime
+{
+    private WebAppFactory _factory = null!;
+    private HttpClient _client = null!;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    public Task InitializeAsync()
+    {
+        _factory = new WebAppFactory();
+        _client = _factory.CreateClient();
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private async Task<Guid> CreateSystemAsync(string code, string name = "Sistema")
+    {
+        var r = await _client.PostAsJsonAsync("/systems", new { name, code, description = (string?)null }, JsonOptions);
+        r.EnsureSuccessStatusCode();
+        var dto = await r.Content.ReadFromJsonAsync<SystemRefDto>(JsonOptions);
+        Assert.NotNull(dto);
+        return dto.Id;
+    }
+
+    private static object RouteCreateBody(Guid systemId, string name, string code, string? description = null) =>
+        new { systemId, name, code, description };
+
+    private static object RouteUpdateBody(Guid systemId, string name, string code, string? description = null) =>
+        new { systemId, name, code, description };
+
+    [Fact]
+    public async Task Create_Post_WithValidSystemId_ReturnsCreated_UtcAndNullDeletedAt()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_1");
+
+        var response = await _client.PostAsJsonAsync("/routes",
+            RouteCreateBody(sysId, "Rota A", "ROUTE_A", "Opcional"), JsonOptions);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var dto = await response.Content.ReadFromJsonAsync<RouteDto>(JsonOptions);
+        Assert.NotNull(dto);
+        Assert.Equal(sysId, dto.SystemId);
+        Assert.Null(dto.DeletedAt);
+        Assert.Equal("ROUTE_A", dto.Code);
+        Assert.Equal("Opcional", dto.Description);
+        Assert.True(dto.CreatedAt > DateTime.MinValue);
+        Assert.True(dto.UpdatedAt > DateTime.MinValue);
+    }
+
+    [Fact]
+    public async Task Create_WithInvalidSystemId_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsJsonAsync("/routes",
+            RouteCreateBody(Guid.NewGuid(), "X", "CODE_X"), JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_DuplicateCode_ReturnsConflict()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_DUP");
+        await _client.PostAsJsonAsync("/routes", RouteCreateBody(sysId, "A", "DUP_CODE"), JsonOptions);
+
+        var response = await _client.PostAsJsonAsync("/routes", RouteCreateBody(sysId, "B", "DUP_CODE"), JsonOptions);
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_DuplicateCode_NormalizesWhitespace_ReturnsConflict()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_WS");
+        await _client.PostAsJsonAsync("/routes", RouteCreateBody(sysId, "A", "ABC_RT"), JsonOptions);
+
+        var response = await _client.PostAsJsonAsync("/routes",
+            RouteCreateBody(sysId, "B", "  ABC_RT  "), JsonOptions);
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_ConcurrentSameCode_OneCreatedOneConflict()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_CONC");
+        const string code = "CONC_RT";
+        var t1 = _client.PostAsJsonAsync("/routes", RouteCreateBody(sysId, "A", code), JsonOptions);
+        var t2 = _client.PostAsJsonAsync("/routes", RouteCreateBody(sysId, "B", code), JsonOptions);
+        await Task.WhenAll(t1, t2);
+        var statuses = new[] { (await t1).StatusCode, (await t2).StatusCode };
+        Assert.Contains(HttpStatusCode.Created, statuses);
+        Assert.Contains(HttpStatusCode.Conflict, statuses);
+    }
+
+    [Fact]
+    public async Task Create_WhitespaceOnlyName_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_WN");
+        var response = await _client.PostAsJsonAsync("/routes",
+            RouteCreateBody(sysId, "   ", "C1"), JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsOnlyActiveRoutes()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_GA");
+        await _client.PostAsJsonAsync("/routes", RouteCreateBody(sysId, "Ativa", "RT_ATIVA"), JsonOptions);
+
+        var other = await _client.PostAsJsonAsync("/routes", RouteCreateBody(sysId, "Outra", "RT_OUTRA"), JsonOptions);
+        var otherDto = await other.Content.ReadFromJsonAsync<RouteDto>(JsonOptions);
+        Assert.NotNull(otherDto);
+        await _client.DeleteAsync($"/routes/{otherDto.Id}");
+
+        var listResp = await _client.GetAsync("/routes");
+        listResp.EnsureSuccessStatusCode();
+        var list = await listResp.Content.ReadFromJsonAsync<List<RouteDto>>(JsonOptions);
+        Assert.NotNull(list);
+        Assert.All(list, r => Assert.Null(r.DeletedAt));
+        Assert.Contains(list, r => r.Code == "RT_ATIVA");
+        Assert.DoesNotContain(list, r => r.Code == "RT_OUTRA");
+    }
+
+    [Fact]
+    public async Task GetById_Active_ReturnsOk_Deleted_Returns404()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_G1");
+        var create = await _client.PostAsJsonAsync("/routes", RouteCreateBody(sysId, "S", "RT_G1"), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RouteDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        Assert.Equal(HttpStatusCode.OK, (await _client.GetAsync($"/routes/{dto.Id}")).StatusCode);
+
+        await _client.DeleteAsync($"/routes/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/routes/{dto.Id}")).StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_Active_ReturnsOk_Deleted_Returns404()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_U1");
+        var create = await _client.PostAsJsonAsync("/routes", RouteCreateBody(sysId, "S", "RT_U1"), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RouteDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        var putOk = await _client.PutAsJsonAsync($"/routes/{dto.Id}",
+            RouteUpdateBody(sysId, "S2", "RT_U1", null), JsonOptions);
+        Assert.Equal(HttpStatusCode.OK, putOk.StatusCode);
+
+        await _client.DeleteAsync($"/routes/{dto.Id}");
+        var put404 = await _client.PutAsJsonAsync($"/routes/{dto.Id}",
+            RouteUpdateBody(sysId, "S3", "RT_U1"), JsonOptions);
+        Assert.Equal(HttpStatusCode.NotFound, put404.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_WithInvalidSystemId_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_UINV");
+        var create = await _client.PostAsJsonAsync("/routes", RouteCreateBody(sysId, "S", "RT_INV"), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RouteDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        var put = await _client.PutAsJsonAsync($"/routes/{dto.Id}",
+            RouteUpdateBody(Guid.NewGuid(), "S", "RT_INV"), JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_SoftDelete_ThenDeleteAgain_Returns404()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_D1");
+        var create = await _client.PostAsJsonAsync("/routes", RouteCreateBody(sysId, "S", "RT_D1"), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RouteDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        Assert.Equal(HttpStatusCode.NoContent, (await _client.DeleteAsync($"/routes/{dto.Id}")).StatusCode);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var row = await db.Routes.IgnoreQueryFilters().SingleAsync(r => r.Id == dto.Id);
+            Assert.NotNull(row.DeletedAt);
+        }
+
+        Assert.Equal(HttpStatusCode.NotFound, (await _client.DeleteAsync($"/routes/{dto.Id}")).StatusCode);
+    }
+
+    [Fact]
+    public async Task Restore_Deleted_ThenAppearsInGetAll_AndGetByIdWorks()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_R1");
+        var create = await _client.PostAsJsonAsync("/routes", RouteCreateBody(sysId, "S", "RT_R1"), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RouteDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        await _client.DeleteAsync($"/routes/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/routes/{dto.Id}")).StatusCode);
+
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch, $"/routes/{dto.Id}/restore"));
+        Assert.Equal(HttpStatusCode.OK, patch.StatusCode);
+
+        var getOk = await _client.GetAsync($"/routes/{dto.Id}");
+        Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
+        var restored = await getOk.Content.ReadFromJsonAsync<RouteDto>(JsonOptions);
+        Assert.NotNull(restored);
+        Assert.Null(restored.DeletedAt);
+
+        var listResp = await _client.GetAsync("/routes");
+        listResp.EnsureSuccessStatusCode();
+        var list = await listResp.Content.ReadFromJsonAsync<List<RouteDto>>(JsonOptions);
+        Assert.NotNull(list);
+        Assert.Contains(list, r => r.Id == dto.Id);
+    }
+
+    [Fact]
+    public async Task Create_WithDeletedSystem_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_DELSYS");
+        await _client.DeleteAsync($"/systems/{sysId}");
+
+        var response = await _client.PostAsJsonAsync("/routes",
+            RouteCreateBody(sysId, "R", "RT_DELSYS"), JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    private sealed record SystemRefDto(Guid Id);
+
+    private sealed record RouteDto(
+        Guid Id,
+        Guid SystemId,
+        string Name,
+        string Code,
+        string? Description,
+        DateTime CreatedAt,
+        DateTime UpdatedAt,
+        DateTime? DeletedAt);
+}

--- a/AuthService.Tests/RoutesApiTests.cs
+++ b/AuthService.Tests/RoutesApiTests.cs
@@ -184,6 +184,15 @@ public class RoutesApiTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Update_NonExistentId_WithInvalidSystemId_Returns404()
+    {
+        var missingId = Guid.NewGuid();
+        var put = await _client.PutAsJsonAsync($"/routes/{missingId}",
+            RouteUpdateBody(Guid.NewGuid(), "S", "RT_NO404"), JsonOptions);
+        Assert.Equal(HttpStatusCode.NotFound, put.StatusCode);
+    }
+
+    [Fact]
     public async Task Delete_SoftDelete_ThenDeleteAgain_Returns404()
     {
         var sysId = await CreateSystemAsync("RT_SYS_D1");
@@ -239,6 +248,42 @@ public class RoutesApiTests : IAsyncLifetime
         var response = await _client.PostAsJsonAsync("/routes",
             RouteCreateBody(sysId, "R", "RT_DELSYS"), JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_AndGetById_ExcludeRoutesWhenSystemSoftDeleted()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_ORPH");
+        var create = await _client.PostAsJsonAsync("/routes",
+            RouteCreateBody(sysId, "R", "RT_ORPH"), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RouteDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        await _client.DeleteAsync($"/systems/{sysId}");
+
+        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/routes/{dto.Id}")).StatusCode);
+
+        var listResp = await _client.GetAsync("/routes");
+        listResp.EnsureSuccessStatusCode();
+        var list = await listResp.Content.ReadFromJsonAsync<List<RouteDto>>(JsonOptions);
+        Assert.NotNull(list);
+        Assert.DoesNotContain(list, r => r.Id == dto.Id);
+    }
+
+    [Fact]
+    public async Task Restore_WhenSystemSoftDeleted_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_RSYS");
+        var create = await _client.PostAsJsonAsync("/routes",
+            RouteCreateBody(sysId, "S", "RT_RSYS"), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RouteDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        await _client.DeleteAsync($"/routes/{dto.Id}");
+        await _client.DeleteAsync($"/systems/{sysId}");
+
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch, $"/routes/{dto.Id}/restore"));
+        Assert.Equal(HttpStatusCode.BadRequest, patch.StatusCode);
     }
 
     private sealed record SystemRefDto(Guid Id);

--- a/AuthService/Controllers/Routes/RoutesController.cs
+++ b/AuthService/Controllers/Routes/RoutesController.cs
@@ -126,6 +126,10 @@ public class RoutesController : ControllerBase
     private async Task<bool> SystemExistsAndActiveAsync(Guid systemId) =>
         systemId != Guid.Empty && await _db.Systems.AnyAsync(s => s.Id == systemId);
 
+    /// <summary>Routes ativas cujo sistema pai ainda está ativo (leitura alinhada a POST/PUT).</summary>
+    private IQueryable<AppRoute> ActiveRoutesWithActiveSystem() =>
+        _db.Routes.Where(r => _db.Systems.Any(s => s.Id == r.SystemId));
+
     private IActionResult InvalidSystemIdResult()
     {
         ModelState.AddModelError(nameof(CreateRouteRequest.SystemId), "SystemId inválido ou sistema inativo.");
@@ -184,7 +188,7 @@ public class RoutesController : ControllerBase
     [HttpGet]
     public async Task<IActionResult> GetAll()
     {
-        var list = await _db.Routes
+        var list = await ActiveRoutesWithActiveSystem()
             .OrderBy(r => r.CreatedAt)
             .Select(r => new RouteResponse(
                 r.Id,
@@ -202,7 +206,7 @@ public class RoutesController : ControllerBase
     [HttpGet("{id:guid}")]
     public async Task<IActionResult> GetById(Guid id)
     {
-        var entity = await _db.Routes.FirstOrDefaultAsync(r => r.Id == id);
+        var entity = await ActiveRoutesWithActiveSystem().FirstOrDefaultAsync(r => r.Id == id);
         if (entity is null)
             return NotFound(new { message = "Route não encontrada." });
         return Ok(ToResponse(entity));
@@ -214,6 +218,10 @@ public class RoutesController : ControllerBase
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);
 
+        var entity = await _db.Routes.FirstOrDefaultAsync(r => r.Id == id);
+        if (entity is null)
+            return NotFound(new { message = "Route não encontrada." });
+
         if (!await SystemExistsAndActiveAsync(request.SystemId))
             return InvalidSystemIdResult();
 
@@ -224,10 +232,6 @@ public class RoutesController : ControllerBase
         ValidateNormalizedFields(ModelState, name, code, description);
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);
-
-        var entity = await _db.Routes.FirstOrDefaultAsync(r => r.Id == id);
-        if (entity is null)
-            return NotFound(new { message = "Route não encontrada." });
 
         if (await _db.Routes.IgnoreQueryFilters().AnyAsync(r => r.Id != id && r.Code == code))
             return new ConflictObjectResult(new { message = "Já existe outra route com este Code." });
@@ -276,6 +280,14 @@ public class RoutesController : ControllerBase
 
         if (entity is null)
             return NotFound(new { message = "Route não encontrada ou não está deletada." });
+
+        if (!await SystemExistsAndActiveAsync(entity.SystemId))
+        {
+            return BadRequest(new
+            {
+                message = "Não é possível restaurar a route: o sistema vinculado está inativo ou foi removido."
+            });
+        }
 
         entity.DeletedAt = null;
         entity.UpdatedAt = DateTime.UtcNow;

--- a/AuthService/Controllers/Routes/RoutesController.cs
+++ b/AuthService/Controllers/Routes/RoutesController.cs
@@ -1,0 +1,285 @@
+using System.ComponentModel.DataAnnotations;
+using AuthService.Data;
+using AuthService.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+
+namespace AuthService.Controllers.Routes;
+
+[ApiController]
+[Route("routes")]
+public class RoutesController : ControllerBase
+{
+    private readonly AppDbContext _db;
+
+    public RoutesController(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public class CreateRouteRequest
+    {
+        [Required(ErrorMessage = "SystemId é obrigatório.")]
+        public Guid SystemId { get; set; }
+
+        [Required(ErrorMessage = "Name é obrigatório.")]
+        [MaxLength(80, ErrorMessage = "Name deve ter no máximo 80 caracteres.")]
+        public string Name { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Code é obrigatório.")]
+        [MaxLength(50, ErrorMessage = "Code deve ter no máximo 50 caracteres.")]
+        public string Code { get; set; } = string.Empty;
+
+        [MaxLength(500, ErrorMessage = "Description deve ter no máximo 500 caracteres.")]
+        public string? Description { get; set; }
+    }
+
+    public class UpdateRouteRequest
+    {
+        [Required(ErrorMessage = "SystemId é obrigatório.")]
+        public Guid SystemId { get; set; }
+
+        [Required(ErrorMessage = "Name é obrigatório.")]
+        [MaxLength(80, ErrorMessage = "Name deve ter no máximo 80 caracteres.")]
+        public string Name { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Code é obrigatório.")]
+        [MaxLength(50, ErrorMessage = "Code deve ter no máximo 50 caracteres.")]
+        public string Code { get; set; } = string.Empty;
+
+        [MaxLength(500, ErrorMessage = "Description deve ter no máximo 500 caracteres.")]
+        public string? Description { get; set; }
+    }
+
+    public record RouteResponse(
+        Guid Id,
+        Guid SystemId,
+        string Name,
+        string Code,
+        string? Description,
+        DateTime CreatedAt,
+        DateTime UpdatedAt,
+        DateTime? DeletedAt
+    );
+
+    private static RouteResponse ToResponse(AppRoute r) =>
+        new(r.Id, r.SystemId, r.Name, r.Code, r.Description, r.CreatedAt, r.UpdatedAt, r.DeletedAt);
+
+    private static void ValidateNormalizedFields(
+        ModelStateDictionary modelState,
+        string name,
+        string code,
+        string? descriptionOrNull)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            modelState.AddModelError(nameof(CreateRouteRequest.Name), "Name é obrigatório e não pode ser apenas espaços.");
+
+        if (string.IsNullOrWhiteSpace(code))
+            modelState.AddModelError(nameof(CreateRouteRequest.Code), "Code é obrigatório e não pode ser apenas espaços.");
+
+        if (name.Length > 80)
+            modelState.AddModelError(nameof(CreateRouteRequest.Name), "Name deve ter no máximo 80 caracteres.");
+
+        if (code.Length > 50)
+            modelState.AddModelError(nameof(CreateRouteRequest.Code), "Code deve ter no máximo 50 caracteres.");
+
+        if (descriptionOrNull is { Length: > 500 })
+            modelState.AddModelError(nameof(CreateRouteRequest.Description), "Description deve ter no máximo 500 caracteres.");
+    }
+
+    private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+    {
+        for (Exception? e = ex; e != null; e = e.InnerException)
+        {
+            if (e is SqlException sql)
+                return sql.Number is 2601 or 2627;
+        }
+
+        var text = string.Join(" ", GetExceptionMessages(ex));
+        return text.Contains("UNIQUE", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("unique constraint", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("duplicate key", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsForeignKeyViolation(DbUpdateException ex)
+    {
+        for (Exception? e = ex; e != null; e = e.InnerException)
+        {
+            if (e is SqlException sql)
+                return sql.Number == 547;
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<string> GetExceptionMessages(Exception ex)
+    {
+        for (Exception? e = ex; e != null; e = e.InnerException)
+            yield return e.Message;
+    }
+
+    private static IActionResult CodeConflictResult() =>
+        new ConflictObjectResult(new { message = "Já existe uma route com este Code." });
+
+    private async Task<bool> SystemExistsAndActiveAsync(Guid systemId) =>
+        systemId != Guid.Empty && await _db.Systems.AnyAsync(s => s.Id == systemId);
+
+    private IActionResult InvalidSystemIdResult()
+    {
+        ModelState.AddModelError(nameof(CreateRouteRequest.SystemId), "SystemId inválido ou sistema inativo.");
+        return ValidationProblem(ModelState);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateRouteRequest request)
+    {
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        if (!await SystemExistsAndActiveAsync(request.SystemId))
+            return InvalidSystemIdResult();
+
+        var name = request.Name.Trim();
+        var code = request.Code.Trim();
+        var description = string.IsNullOrWhiteSpace(request.Description) ? null : request.Description.Trim();
+
+        ValidateNormalizedFields(ModelState, name, code, description);
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        if (await _db.Routes.IgnoreQueryFilters().AnyAsync(r => r.Code == code))
+            return CodeConflictResult();
+
+        var now = DateTime.UtcNow;
+        var entity = new AppRoute
+        {
+            SystemId = request.SystemId,
+            Name = name,
+            Code = code,
+            Description = description,
+            CreatedAt = now,
+            UpdatedAt = now,
+            DeletedAt = null
+        };
+        _db.Routes.Add(entity);
+
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+        {
+            return CodeConflictResult();
+        }
+        catch (DbUpdateException ex) when (IsForeignKeyViolation(ex))
+        {
+            return InvalidSystemIdResult();
+        }
+
+        return CreatedAtAction(nameof(GetById), new { id = entity.Id }, ToResponse(entity));
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll()
+    {
+        var list = await _db.Routes
+            .OrderBy(r => r.CreatedAt)
+            .Select(r => new RouteResponse(
+                r.Id,
+                r.SystemId,
+                r.Name,
+                r.Code,
+                r.Description,
+                r.CreatedAt,
+                r.UpdatedAt,
+                r.DeletedAt))
+            .ToListAsync();
+        return Ok(list);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetById(Guid id)
+    {
+        var entity = await _db.Routes.FirstOrDefaultAsync(r => r.Id == id);
+        if (entity is null)
+            return NotFound(new { message = "Route não encontrada." });
+        return Ok(ToResponse(entity));
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> UpdateById(Guid id, [FromBody] UpdateRouteRequest request)
+    {
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        if (!await SystemExistsAndActiveAsync(request.SystemId))
+            return InvalidSystemIdResult();
+
+        var name = request.Name.Trim();
+        var code = request.Code.Trim();
+        var description = string.IsNullOrWhiteSpace(request.Description) ? null : request.Description.Trim();
+
+        ValidateNormalizedFields(ModelState, name, code, description);
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        var entity = await _db.Routes.FirstOrDefaultAsync(r => r.Id == id);
+        if (entity is null)
+            return NotFound(new { message = "Route não encontrada." });
+
+        if (await _db.Routes.IgnoreQueryFilters().AnyAsync(r => r.Id != id && r.Code == code))
+            return new ConflictObjectResult(new { message = "Já existe outra route com este Code." });
+
+        entity.SystemId = request.SystemId;
+        entity.Name = name;
+        entity.Code = code;
+        entity.Description = description;
+        entity.UpdatedAt = DateTime.UtcNow;
+
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+        {
+            return new ConflictObjectResult(new { message = "Já existe outra route com este Code." });
+        }
+        catch (DbUpdateException ex) when (IsForeignKeyViolation(ex))
+        {
+            return InvalidSystemIdResult();
+        }
+
+        return Ok(ToResponse(entity));
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> DeleteById(Guid id)
+    {
+        var entity = await _db.Routes.FirstOrDefaultAsync(r => r.Id == id);
+        if (entity is null)
+            return NotFound(new { message = "Route não encontrada." });
+
+        entity.DeletedAt = DateTime.UtcNow;
+        entity.UpdatedAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpPatch("{id:guid}/restore")]
+    public async Task<IActionResult> RestoreById(Guid id)
+    {
+        var entity = await _db.Routes
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(r => r.Id == id && r.DeletedAt != null);
+
+        if (entity is null)
+            return NotFound(new { message = "Route não encontrada ou não está deletada." });
+
+        entity.DeletedAt = null;
+        entity.UpdatedAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+        return Ok(ToResponse(entity));
+    }
+}

--- a/AuthService/Data/AppDbContext.cs
+++ b/AuthService/Data/AppDbContext.cs
@@ -8,10 +8,18 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
 {
     public DbSet<User> Users => Set<User>();
     public DbSet<AppSystem> Systems => Set<AppSystem>();
+    public DbSet<AppRoute> Routes => Set<AppRoute>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<AppRoute>()
+            .HasOne<AppSystem>()
+            .WithMany()
+            .HasForeignKey(r => r.SystemId)
+            .OnDelete(DeleteBehavior.Restrict);
+
         foreach (var entityType in modelBuilder.Model.GetEntityTypes())
         {
             if (typeof(ISoftDelete).IsAssignableFrom(entityType.ClrType))

--- a/AuthService/Data/Migrations/20260328190000_CreateRoutesTable.Designer.cs
+++ b/AuthService/Data/Migrations/20260328190000_CreateRoutesTable.Designer.cs
@@ -4,6 +4,7 @@ using AuthService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AuthService.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260328190000_CreateRoutesTable")]
+    partial class CreateRoutesTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AuthService/Data/Migrations/20260328190000_CreateRoutesTable.cs
+++ b/AuthService/Data/Migrations/20260328190000_CreateRoutesTable.cs
@@ -1,0 +1,62 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AuthService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class CreateRoutesTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Routes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    SystemId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(80)", maxLength: 80, nullable: false),
+                    Code = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Routes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Routes_Systems_SystemId",
+                        column: x => x.SystemId,
+                        principalTable: "Systems",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Routes_DeletedAt",
+                table: "Routes",
+                column: "DeletedAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Routes_SystemId",
+                table: "Routes",
+                column: "SystemId");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_Routes_Code",
+                table: "Routes",
+                column: "Code",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Routes");
+        }
+    }
+}

--- a/AuthService/Models/AppRoute.cs
+++ b/AuthService/Models/AppRoute.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace AuthService.Models;
+
+[Index(nameof(Code), IsUnique = true, Name = "UX_Routes_Code")]
+[Index(nameof(DeletedAt), Name = "IX_Routes_DeletedAt")]
+[Table("Routes")]
+public class AppRoute : ISoftDelete
+{
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    public Guid SystemId { get; set; }
+
+    [Required]
+    [StringLength(80)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(50)]
+    public string Code { get; set; } = string.Empty;
+
+    [StringLength(500)]
+    public string? Description { get; set; }
+
+    [Required]
+    public DateTime CreatedAt { get; set; }
+
+    [Required]
+    public DateTime UpdatedAt { get; set; }
+
+    public DateTime? DeletedAt { get; set; }
+}

--- a/README.md
+++ b/README.md
@@ -89,16 +89,16 @@ Mesmo padrão de **soft delete** e **404** para registros deletados que `/system
 
 ### Cadastro de routes (`/routes`)
 
-Vinculadas a um **sistema** existente e ativo (`systemId`). Mesmo padrão de soft delete e **404** para deletados que `/systems`. `Code` é único globalmente. Corpo: `systemId`, `name`, `code`, `description` (opcional).
+Vinculadas a um **sistema** existente e ativo (`systemId`). Mesmo padrão de soft delete e **404** para deletados que `/systems`. `Code` é único globalmente. Corpo: `systemId`, `name`, `code`, `description` (opcional). Em **leitura** (`GET`), só entram routes cujo sistema pai ainda está ativo; se o sistema for *soft-deleted*, a route deixa de aparecer até o sistema ser restaurado. **Restore** da route exige sistema ativo.
 
 | Método | Rota | Descrição |
 |--------|------|-----------|
 | `POST` | `/routes` | Cria route (`systemId` deve ser sistema ativo). |
-| `GET` | `/routes` | Lista apenas routes ativas. |
-| `GET` | `/routes/{id}` | Detalhe (ativa). |
+| `GET` | `/routes` | Lista routes ativas com sistema pai ativo. |
+| `GET` | `/routes/{id}` | Detalhe (route ativa e sistema pai ativo). |
 | `PUT` | `/routes/{id}` | Atualização completa. |
 | `DELETE` | `/routes/{id}` | *Soft delete*. |
-| `PATCH` | `/routes/{id}/restore` | Restaura route deletada. |
+| `PATCH` | `/routes/{id}/restore` | Restaura route deletada (sistema vinculado deve estar ativo). |
 
 Em desenvolvimento, a documentação OpenAPI fica em `/openapi/v1.json` quando `Development`.
 

--- a/README.md
+++ b/README.md
@@ -87,11 +87,24 @@ Mesmo padrão de **soft delete** e **404** para registros deletados que `/system
 | `DELETE` | `/users/{id}` | *Soft delete*. |
 | `PATCH` | `/users/{id}/restore` | Restaura registro deletado. |
 
+### Cadastro de routes (`/routes`)
+
+Vinculadas a um **sistema** existente e ativo (`systemId`). Mesmo padrão de soft delete e **404** para deletados que `/systems`. `Code` é único globalmente. Corpo: `systemId`, `name`, `code`, `description` (opcional).
+
+| Método | Rota | Descrição |
+|--------|------|-----------|
+| `POST` | `/routes` | Cria route (`systemId` deve ser sistema ativo). |
+| `GET` | `/routes` | Lista apenas routes ativas. |
+| `GET` | `/routes/{id}` | Detalhe (ativa). |
+| `PUT` | `/routes/{id}` | Atualização completa. |
+| `DELETE` | `/routes/{id}` | *Soft delete*. |
+| `PATCH` | `/routes/{id}/restore` | Restaura route deletada. |
+
 Em desenvolvimento, a documentação OpenAPI fica em `/openapi/v1.json` quando `Development`.
 
 ## Testes de integração
 
-Os testes usam **SQL Server real**. Cada caso cria um banco dedicado (`auth_svc_it_<guid>`), roda **migrations** e faz **DROP DATABASE** ao terminar (seguro para paralelismo). Há suites para **`/systems`** e **`/users`** com o mesmo estilo de cenários (incluindo soft delete e conflito de unicidade).
+Os testes usam **SQL Server real**. Cada caso cria um banco dedicado (`auth_svc_it_<guid>`), roda **migrations** e faz **DROP DATABASE** ao terminar (seguro para paralelismo). Há suites para **`/systems`**, **`/users`** e **`/routes`** (incluindo soft delete, unicidade e FK de `systemId`).
 
 **Variável obrigatória** (connection string **sem** `Database` / `Initial Catalog`):
 


### PR DESCRIPTION
feat(routes): CRUD, soft delete, restore e vínculo obrigatório com Systems

### Contexto
Implementa a issue #5: entidade de rotas por sistema, persistência via EF Core e API REST alinhada aos padrões de Systems/Users.

### Mudanças
- **feat(db):** tabela `Routes`, FK para `Systems` com `OnDelete(Restrict)`, índices e soft delete
- **feat(api):** `RoutesController` em `/routes` — POST, GET (lista ativos), GET por id, PUT, DELETE, PATCH restore
- **feat(validation):** `SystemId` obrigatório; sistema deve existir e estar ativo; `Code` único; trim e `ValidationProblem` como nos demais controllers
- **test:** `RoutesApiTests` (integração com SQL Server de teste)
- **docs:** README com endpoints `/routes`

### Commits
- `feat(routes): CRUD + restore vinculado a Systems (#5)`

Closes #5