### PR TITLE
#11 | Criar recurso Roles com estrutura inicial e endpoints

### DIFF
--- a/AuthService.Tests/RolesApiTests.cs
+++ b/AuthService.Tests/RolesApiTests.cs
@@ -114,6 +114,38 @@ public class RolesApiTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Create_NameExceedsMaxLength_ReturnsBadRequest()
+    {
+        var name81 = new string('n', 81);
+        var response = await _client.PostAsJsonAsync("/roles",
+            new { name = name81, code = "ROLE_LEN_NAME" }, JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_CodeExceedsMaxLength_ReturnsBadRequest()
+    {
+        var code51 = new string('c', 51);
+        var response = await _client.PostAsJsonAsync("/roles",
+            new { name = "Nome válido", code = code51 }, JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Restore só aplica a linhas soft-deleted; role ativo não é encontrado pela query e retorna 404.
+    /// </summary>
+    [Fact]
+    public async Task Restore_ActiveRole_ReturnsNotFound()
+    {
+        var create = await _client.PostAsJsonAsync("/roles", new { name = "Ativo", code = "ROLE_ACTIVE_R" }, JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RoleDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch, $"/roles/{dto.Id}/restore"));
+        Assert.Equal(HttpStatusCode.NotFound, patch.StatusCode);
+    }
+
+    [Fact]
     public async Task Put_WhitespaceOnlyName_ReturnsBadRequest()
     {
         var create = await _client.PostAsJsonAsync("/roles", new { name = "S", code = "ROLE_W1" }, JsonOptions);

--- a/AuthService.Tests/RolesApiTests.cs
+++ b/AuthService.Tests/RolesApiTests.cs
@@ -1,0 +1,229 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AuthService.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AuthService.Tests;
+
+public class RolesApiTests : IAsyncLifetime
+{
+    private WebAppFactory _factory = null!;
+    private HttpClient _client = null!;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    public Task InitializeAsync()
+    {
+        _factory = new WebAppFactory();
+        _client = _factory.CreateClient();
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Create_Post_ReturnsCreated_WithUtcTimestamps_AndNullDeletedAt()
+    {
+        var body = new { name = "Administrador", code = "ROLE_ADMIN" };
+        var response = await _client.PostAsJsonAsync("/roles", body, JsonOptions);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var dto = await response.Content.ReadFromJsonAsync<RoleDto>(JsonOptions);
+        Assert.NotNull(dto);
+        Assert.NotEqual(Guid.Empty, dto.Id);
+        Assert.Null(dto.DeletedAt);
+        Assert.Equal("Administrador", dto.Name);
+        Assert.Equal("ROLE_ADMIN", dto.Code);
+        Assert.True(dto.CreatedAt > DateTime.MinValue);
+        Assert.True(dto.UpdatedAt > DateTime.MinValue);
+    }
+
+    [Fact]
+    public async Task Create_DuplicateCode_ReturnsConflict()
+    {
+        await _client.PostAsJsonAsync("/roles", new { name = "A", code = "ROLE_ABC" }, JsonOptions);
+
+        var response = await _client.PostAsJsonAsync("/roles", new { name = "B", code = "ROLE_ABC" }, JsonOptions);
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_DuplicateCode_NormalizesWhitespace_ReturnsConflict()
+    {
+        await _client.PostAsJsonAsync("/roles", new { name = "A", code = "ROLE_WS" }, JsonOptions);
+
+        var response = await _client.PostAsJsonAsync("/roles",
+            new { name = "B", code = "  ROLE_WS  " }, JsonOptions);
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_DuplicateCode_NormalizesWhitespace_ReturnsConflict()
+    {
+        await _client.PostAsJsonAsync("/roles", new { name = "A", code = "ROLE_CA" }, JsonOptions);
+        var b = await _client.PostAsJsonAsync("/roles", new { name = "B", code = "ROLE_CB" }, JsonOptions);
+        var dtoB = await b.Content.ReadFromJsonAsync<RoleDto>(JsonOptions);
+        Assert.NotNull(dtoB);
+
+        var put = await _client.PutAsJsonAsync($"/roles/{dtoB.Id}",
+            new { name = "B2", code = "  ROLE_CA  " }, JsonOptions);
+        Assert.Equal(HttpStatusCode.Conflict, put.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_ConcurrentSameCode_OneCreatedOneConflict()
+    {
+        const string code = "ROLE_CONCURRENT";
+        var bodyA = new { name = "A", code };
+        var bodyB = new { name = "B", code };
+        var t1 = _client.PostAsJsonAsync("/roles", bodyA, JsonOptions);
+        var t2 = _client.PostAsJsonAsync("/roles", bodyB, JsonOptions);
+        await Task.WhenAll(t1, t2);
+
+        var r1 = await t1;
+        var r2 = await t2;
+        var statuses = new[] { r1.StatusCode, r2.StatusCode };
+        Assert.Contains(HttpStatusCode.Created, statuses);
+        Assert.Contains(HttpStatusCode.Conflict, statuses);
+    }
+
+    [Fact]
+    public async Task Create_WhitespaceOnlyName_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsJsonAsync("/roles", new { name = "   ", code = "ROLE_X1" }, JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_WhitespaceOnlyCode_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsJsonAsync("/roles", new { name = "N1", code = "\t  " }, JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Put_WhitespaceOnlyName_ReturnsBadRequest()
+    {
+        var create = await _client.PostAsJsonAsync("/roles", new { name = "S", code = "ROLE_W1" }, JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RoleDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        var put = await _client.PutAsJsonAsync($"/roles/{dto.Id}",
+            new { name = "   ", code = "ROLE_W1" }, JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsOnlyActiveRoles()
+    {
+        await _client.PostAsJsonAsync("/roles", new { name = "Ativo", code = "ROLE_ATIVO" }, JsonOptions);
+
+        var other = await _client.PostAsJsonAsync("/roles", new { name = "Outro", code = "ROLE_OUTRO" }, JsonOptions);
+        var toDelete = await other.Content.ReadFromJsonAsync<RoleDto>(JsonOptions);
+        Assert.NotNull(toDelete);
+        await _client.DeleteAsync($"/roles/{toDelete.Id}");
+
+        var listResp = await _client.GetAsync("/roles");
+        listResp.EnsureSuccessStatusCode();
+        var list = await listResp.Content.ReadFromJsonAsync<List<RoleDto>>(JsonOptions);
+        Assert.NotNull(list);
+        Assert.All(list, r => Assert.Null(r.DeletedAt));
+        Assert.Contains(list, r => r.Code == "ROLE_ATIVO");
+        Assert.DoesNotContain(list, r => r.Code == "ROLE_OUTRO");
+    }
+
+    [Fact]
+    public async Task GetById_Active_ReturnsOk_Deleted_Returns404()
+    {
+        var create = await _client.PostAsJsonAsync("/roles", new { name = "S", code = "ROLE_S1" }, JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RoleDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        var getOk = await _client.GetAsync($"/roles/{dto.Id}");
+        Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
+
+        await _client.DeleteAsync($"/roles/{dto.Id}");
+        var get404 = await _client.GetAsync($"/roles/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_Active_ReturnsOk_Deleted_Returns404()
+    {
+        var create = await _client.PostAsJsonAsync("/roles", new { name = "S", code = "ROLE_U1" }, JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RoleDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        var putOk = await _client.PutAsJsonAsync($"/roles/{dto.Id}",
+            new { name = "S2", code = "ROLE_U1" }, JsonOptions);
+        Assert.Equal(HttpStatusCode.OK, putOk.StatusCode);
+
+        await _client.DeleteAsync($"/roles/{dto.Id}");
+        var put404 = await _client.PutAsJsonAsync($"/roles/{dto.Id}",
+            new { name = "S3", code = "ROLE_U1" }, JsonOptions);
+        Assert.Equal(HttpStatusCode.NotFound, put404.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_SoftDelete_ThenDeleteAgain_Returns404()
+    {
+        var create = await _client.PostAsJsonAsync("/roles", new { name = "S", code = "ROLE_D1" }, JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RoleDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        var del1 = await _client.DeleteAsync($"/roles/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, del1.StatusCode);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var row = await db.Roles.IgnoreQueryFilters().SingleAsync(r => r.Id == dto.Id);
+            Assert.NotNull(row.DeletedAt);
+        }
+
+        var del2 = await _client.DeleteAsync($"/roles/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, del2.StatusCode);
+    }
+
+    [Fact]
+    public async Task Restore_Deleted_ThenOperationsWorkAgain()
+    {
+        var create = await _client.PostAsJsonAsync("/roles", new { name = "S", code = "ROLE_R1" }, JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RoleDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        await _client.DeleteAsync($"/roles/{dto.Id}");
+
+        var get404 = await _client.GetAsync($"/roles/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
+
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch, $"/roles/{dto.Id}/restore"));
+        Assert.Equal(HttpStatusCode.OK, patch.StatusCode);
+
+        var getOk = await _client.GetAsync($"/roles/{dto.Id}");
+        Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
+        var restored = await getOk.Content.ReadFromJsonAsync<RoleDto>(JsonOptions);
+        Assert.NotNull(restored);
+        Assert.Null(restored.DeletedAt);
+    }
+
+    private sealed record RoleDto(
+        Guid Id,
+        string Name,
+        string Code,
+        DateTime CreatedAt,
+        DateTime UpdatedAt,
+        DateTime? DeletedAt);
+}

--- a/AuthService/Controllers/Health/HealthController.cs
+++ b/AuthService/Controllers/Health/HealthController.cs
@@ -9,7 +9,8 @@ public class HealthController : ControllerBase
     [HttpGet]
     public ActionResult<object> Get()
     {
-        return Ok(new {
+        return Ok(new
+        {
             status = "ok",
             message = "API is running",
             timestamp = DateTime.UtcNow

--- a/AuthService/Controllers/Roles/RolesController.cs
+++ b/AuthService/Controllers/Roles/RolesController.cs
@@ -13,10 +13,12 @@ namespace AuthService.Controllers.Roles;
 public class RolesController : ControllerBase
 {
     private readonly AppDbContext _db;
+    private readonly ILogger<RolesController> _logger;
 
-    public RolesController(AppDbContext db)
+    public RolesController(AppDbContext db, ILogger<RolesController> logger)
     {
         _db = db;
+        _logger = logger;
     }
 
     public class CreateRoleRequest
@@ -108,7 +110,10 @@ public class RolesController : ControllerBase
             return ValidationProblem(ModelState);
 
         if (await _db.Roles.IgnoreQueryFilters().AnyAsync(r => r.Code == code))
+        {
+            _logger.LogWarning("Conflito ao criar role: já existe Code {Code}.", code);
             return UniqueConflictResult();
+        }
 
         var now = DateTime.UtcNow;
         var entity = new AppRole
@@ -127,9 +132,16 @@ public class RolesController : ControllerBase
         }
         catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
         {
+            _logger.LogWarning(ex, "Conflito de unicidade ao criar role com Code {Code}.", code);
             return UniqueConflictResult();
         }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro inesperado ao persistir novo role (Code {Code}).", code);
+            throw;
+        }
 
+        _logger.LogInformation("Role criado: {RoleId}, Code {Code}.", entity.Id, code);
         return CreatedAtAction(nameof(GetById), new { id = entity.Id }, ToResponse(entity));
     }
 
@@ -176,7 +188,10 @@ public class RolesController : ControllerBase
             return NotFound(new { message = "Role não encontrado." });
 
         if (await _db.Roles.IgnoreQueryFilters().AnyAsync(r => r.Id != id && r.Code == code))
+        {
+            _logger.LogWarning("Conflito ao atualizar role {RoleId}: Code {Code} já em uso.", id, code);
             return new ConflictObjectResult(new { message = "Já existe outro role com este Code." });
+        }
 
         entity.Name = name;
         entity.Code = code;
@@ -188,9 +203,16 @@ public class RolesController : ControllerBase
         }
         catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
         {
+            _logger.LogWarning(ex, "Conflito de unicidade ao atualizar role {RoleId} para Code {Code}.", id, code);
             return new ConflictObjectResult(new { message = "Já existe outro role com este Code." });
         }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro inesperado ao persistir atualização do role {RoleId}.", id);
+            throw;
+        }
 
+        _logger.LogInformation("Role atualizado: {RoleId}.", id);
         return Ok(ToResponse(entity));
     }
 
@@ -203,7 +225,17 @@ public class RolesController : ControllerBase
 
         entity.DeletedAt = DateTime.UtcNow;
         entity.UpdatedAt = DateTime.UtcNow;
-        await _db.SaveChangesAsync();
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro inesperado ao excluir (soft) role {RoleId}.", id);
+            throw;
+        }
+
+        _logger.LogInformation("Role excluído (soft): {RoleId}.", id);
         return NoContent();
     }
 
@@ -219,7 +251,17 @@ public class RolesController : ControllerBase
 
         entity.DeletedAt = null;
         entity.UpdatedAt = DateTime.UtcNow;
-        await _db.SaveChangesAsync();
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro inesperado ao restaurar role {RoleId}.", id);
+            throw;
+        }
+
+        _logger.LogInformation("Role restaurado: {RoleId}.", id);
         return Ok(ToResponse(entity));
     }
 }

--- a/AuthService/Controllers/Roles/RolesController.cs
+++ b/AuthService/Controllers/Roles/RolesController.cs
@@ -1,0 +1,225 @@
+using System.ComponentModel.DataAnnotations;
+using AuthService.Data;
+using AuthService.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+
+namespace AuthService.Controllers.Roles;
+
+[ApiController]
+[Route("roles")]
+public class RolesController : ControllerBase
+{
+    private readonly AppDbContext _db;
+
+    public RolesController(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public class CreateRoleRequest
+    {
+        [Required(ErrorMessage = "Name é obrigatório.")]
+        [MaxLength(80, ErrorMessage = "Name deve ter no máximo 80 caracteres.")]
+        public string Name { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Code é obrigatório.")]
+        [MaxLength(50, ErrorMessage = "Code deve ter no máximo 50 caracteres.")]
+        public string Code { get; set; } = string.Empty;
+    }
+
+    public class UpdateRoleRequest
+    {
+        [Required(ErrorMessage = "Name é obrigatório.")]
+        [MaxLength(80, ErrorMessage = "Name deve ter no máximo 80 caracteres.")]
+        public string Name { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Code é obrigatório.")]
+        [MaxLength(50, ErrorMessage = "Code deve ter no máximo 50 caracteres.")]
+        public string Code { get; set; } = string.Empty;
+    }
+
+    public record RoleResponse(
+        Guid Id,
+        string Name,
+        string Code,
+        DateTime CreatedAt,
+        DateTime UpdatedAt,
+        DateTime? DeletedAt
+    );
+
+    private static RoleResponse ToResponse(AppRole e) =>
+        new(e.Id, e.Name, e.Code, e.CreatedAt, e.UpdatedAt, e.DeletedAt);
+
+    private static void ValidateNormalizedFields(
+        ModelStateDictionary modelState,
+        string name,
+        string code)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            modelState.AddModelError(nameof(CreateRoleRequest.Name), "Name é obrigatório e não pode ser apenas espaços.");
+
+        if (string.IsNullOrWhiteSpace(code))
+            modelState.AddModelError(nameof(CreateRoleRequest.Code), "Code é obrigatório e não pode ser apenas espaços.");
+
+        if (name.Length > 80)
+            modelState.AddModelError(nameof(CreateRoleRequest.Name), "Name deve ter no máximo 80 caracteres.");
+
+        if (code.Length > 50)
+            modelState.AddModelError(nameof(CreateRoleRequest.Code), "Code deve ter no máximo 50 caracteres.");
+    }
+
+    private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+    {
+        for (Exception? e = ex; e != null; e = e.InnerException)
+        {
+            if (e is SqlException sql)
+                return sql.Number is 2601 or 2627;
+        }
+
+        var text = string.Join(" ", GetExceptionMessages(ex));
+        return text.Contains("UNIQUE", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("unique constraint", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("duplicate key", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IEnumerable<string> GetExceptionMessages(Exception ex)
+    {
+        for (Exception? e = ex; e != null; e = e.InnerException)
+            yield return e.Message;
+    }
+
+    private static IActionResult UniqueConflictResult() =>
+        new ConflictObjectResult(new { message = "Já existe um role com este Code." });
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateRoleRequest request)
+    {
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        var name = request.Name.Trim();
+        var code = request.Code.Trim();
+
+        ValidateNormalizedFields(ModelState, name, code);
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        if (await _db.Roles.IgnoreQueryFilters().AnyAsync(r => r.Code == code))
+            return UniqueConflictResult();
+
+        var now = DateTime.UtcNow;
+        var entity = new AppRole
+        {
+            Name = name,
+            Code = code,
+            CreatedAt = now,
+            UpdatedAt = now,
+            DeletedAt = null
+        };
+        _db.Roles.Add(entity);
+
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+        {
+            return UniqueConflictResult();
+        }
+
+        return CreatedAtAction(nameof(GetById), new { id = entity.Id }, ToResponse(entity));
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll()
+    {
+        var list = await _db.Roles
+            .OrderBy(r => r.CreatedAt)
+            .Select(r => new RoleResponse(
+                r.Id,
+                r.Name,
+                r.Code,
+                r.CreatedAt,
+                r.UpdatedAt,
+                r.DeletedAt))
+            .ToListAsync();
+        return Ok(list);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetById(Guid id)
+    {
+        var entity = await _db.Roles.FirstOrDefaultAsync(r => r.Id == id);
+        if (entity is null)
+            return NotFound(new { message = "Role não encontrado." });
+        return Ok(ToResponse(entity));
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> UpdateById(Guid id, [FromBody] UpdateRoleRequest request)
+    {
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        var name = request.Name.Trim();
+        var code = request.Code.Trim();
+
+        ValidateNormalizedFields(ModelState, name, code);
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        var entity = await _db.Roles.FirstOrDefaultAsync(r => r.Id == id);
+        if (entity is null)
+            return NotFound(new { message = "Role não encontrado." });
+
+        if (await _db.Roles.IgnoreQueryFilters().AnyAsync(r => r.Id != id && r.Code == code))
+            return new ConflictObjectResult(new { message = "Já existe outro role com este Code." });
+
+        entity.Name = name;
+        entity.Code = code;
+        entity.UpdatedAt = DateTime.UtcNow;
+
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+        {
+            return new ConflictObjectResult(new { message = "Já existe outro role com este Code." });
+        }
+
+        return Ok(ToResponse(entity));
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> DeleteById(Guid id)
+    {
+        var entity = await _db.Roles.FirstOrDefaultAsync(r => r.Id == id);
+        if (entity is null)
+            return NotFound(new { message = "Role não encontrado." });
+
+        entity.DeletedAt = DateTime.UtcNow;
+        entity.UpdatedAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpPatch("{id:guid}/restore")]
+    public async Task<IActionResult> RestoreById(Guid id)
+    {
+        var entity = await _db.Roles
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(r => r.Id == id && r.DeletedAt != null);
+
+        if (entity is null)
+            return NotFound(new { message = "Role não encontrado ou não está deletado." });
+
+        entity.DeletedAt = null;
+        entity.UpdatedAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+        return Ok(ToResponse(entity));
+    }
+}

--- a/AuthService/Data/AppDbContext.cs
+++ b/AuthService/Data/AppDbContext.cs
@@ -10,6 +10,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<AppSystem> Systems => Set<AppSystem>();
     public DbSet<AppRoute> Routes => Set<AppRoute>();
     public DbSet<AppPermissionType> PermissionTypes => Set<AppPermissionType>();
+    public DbSet<AppRole> Roles => Set<AppRole>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/AuthService/Data/Migrations/20260329130100_CreateRolesTable.Designer.cs
+++ b/AuthService/Data/Migrations/20260329130100_CreateRolesTable.Designer.cs
@@ -4,6 +4,7 @@ using AuthService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AuthService.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260329130100_CreateRolesTable")]
+    partial class CreateRolesTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AuthService/Data/Migrations/20260329130100_CreateRolesTable.cs
+++ b/AuthService/Data/Migrations/20260329130100_CreateRolesTable.cs
@@ -1,0 +1,49 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AuthService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class CreateRolesTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Roles",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(80)", maxLength: 80, nullable: false),
+                    Code = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Roles", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Roles_DeletedAt",
+                table: "Roles",
+                column: "DeletedAt");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_Roles_Code",
+                table: "Roles",
+                column: "Code",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Roles");
+        }
+    }
+}

--- a/AuthService/Models/AppRole.cs
+++ b/AuthService/Models/AppRole.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace AuthService.Models;
+
+[Index(nameof(Code), IsUnique = true, Name = "UX_Roles_Code")]
+[Index(nameof(DeletedAt), Name = "IX_Roles_DeletedAt")]
+[Table("Roles")]
+public class AppRole : ISoftDelete
+{
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    [StringLength(80)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(50)]
+    public string Code { get; set; } = string.Empty;
+
+    [Required]
+    public DateTime CreatedAt { get; set; }
+
+    [Required]
+    public DateTime UpdatedAt { get; set; }
+
+    public DateTime? DeletedAt { get; set; }
+}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ O AuthService concentra a gestão de permissões e padroniza como perfis, usuár
 
 ### Implementado hoje
 
-- CRUD com *soft delete* e restore para **`/systems`**, **`/users`**, **`/routes`** e **`/permission-types`**.
+- CRUD com *soft delete* e restore para **`/systems`**, **`/users`**, **`/routes`**, **`/permission-types`** e **`/roles`**.
 - **`/routes`** está vinculada a **sistema ativo** (`systemId`); leituras e restore respeitam o sistema pai não deletado.
 - Testes de integração com SQL Server real (criação e descarte de banco por execução).
 
@@ -131,11 +131,24 @@ Mesmo padrão de *soft delete* e **404** para deletados que **`/systems`**. `Cod
 | `DELETE` | `/permission-types/{id}` | *Soft delete*. |
 | `PATCH` | `/permission-types/{id}/restore` | Restaura registro deletado. |
 
+### Roles (`/roles`)
+
+Mesmo padrão de *soft delete* e **404** para deletados que **`/systems`**. `Code` é **único globalmente**. Corpo: `name`, `code` (obrigatórios).
+
+| Método | Rota | Descrição |
+|--------|------|-----------|
+| `POST` | `/roles` | Cria registro. |
+| `GET` | `/roles` | Lista apenas ativos. |
+| `GET` | `/roles/{id}` | Detalhe (ativo). |
+| `PUT` | `/roles/{id}` | Atualização completa. |
+| `DELETE` | `/roles/{id}` | *Soft delete*. |
+| `PATCH` | `/roles/{id}/restore` | Restaura registro deletado. |
+
 Em ambiente **Development**, a especificação OpenAPI fica em **`/openapi/v1.json`**.
 
 ## Testes de integração
 
-A suite usa **SQL Server real**. Cada execução cria um banco dedicado (`auth_svc_it_<guid>`), aplica **migrations** e faz **DROP DATABASE** ao terminar (adequado para rodar testes em paralelo). Há cobertura para **`/systems`**, **`/users`**, **`/routes`** e **`/permission-types`**.
+A suite usa **SQL Server real**. Cada execução cria um banco dedicado (`auth_svc_it_<guid>`), aplica **migrations** e faz **DROP DATABASE** ao terminar (adequado para rodar testes em paralelo). Há cobertura para **`/systems`**, **`/users`**, **`/routes`**, **`/permission-types`** e **`/roles`**.
 
 Defina a connection string **sem** `Database` / `Initial Catalog`:
 


### PR DESCRIPTION
## Resumo
Implementa o recurso **Roles** com modelo EF, tabela `Roles`, índice único em `Code`, índice em `DeletedAt`, CRUD com soft delete + restore e testes de integração alinhados a `/permission-types`.

## Alterações
- Modelo `AppRole` (`Id`, `Name` max 80, `Code` max 50, `CreatedAt`, `UpdatedAt`, `DeletedAt`) com `ISoftDelete` e filtros globais existentes
- Migration `20260329130100_CreateRolesTable`
- `RolesController` em `/roles` (POST, GET, GET by id, PUT, DELETE, PATCH restore)
- `RolesApiTests`: fluxo principal, conflito de `code`, whitespace, concorrência, soft delete, restore
- README: documentação da API `/roles`

## Riscos
- Necessário aplicar migration em ambientes existentes (`dotnet ef database update` / perfil `migrate` do Compose)
- `dotnet format --verify-no-changes` ainda acusa WHITESPACE pré-existente em `HealthController.cs` (não alterado neste PR)

## Evidências de teste
```
docker compose --profile test run --rm test
# Passed! Failed: 0, Passed: 69, Total: 69
```

```
docker run ... dotnet build AuthService/AuthService.csproj -c Release
docker run ... dotnet build AuthService.Tests/AuthService.Tests.csproj -c Release
# 0 Warning(s), 0 Error(s)
```

Closes #11

Made with [Cursor](https://cursor.com)