### PR TITLE
#13 | Criar recurso Permissions com estrutura inicial e endpoints

### DIFF
--- a/AuthService.Tests/PermissionsApiTests.cs
+++ b/AuthService.Tests/PermissionsApiTests.cs
@@ -1,0 +1,329 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AuthService.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AuthService.Tests;
+
+public class PermissionsApiTests : IAsyncLifetime
+{
+    private WebAppFactory _factory = null!;
+    private HttpClient _client = null!;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    public Task InitializeAsync()
+    {
+        _factory = new WebAppFactory();
+        _client = _factory.CreateClient();
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private async Task<Guid> CreateSystemAsync(string code, string name = "Sistema")
+    {
+        var r = await _client.PostAsJsonAsync("/systems", new { name, code, description = (string?)null }, JsonOptions);
+        r.EnsureSuccessStatusCode();
+        var dto = await r.Content.ReadFromJsonAsync<RefDto>(JsonOptions);
+        Assert.NotNull(dto);
+        return dto.Id;
+    }
+
+    private async Task<Guid> CreatePermissionTypeAsync(string code, string name = "Tipo")
+    {
+        var r = await _client.PostAsJsonAsync("/permission-types", new { name, code, description = (string?)null }, JsonOptions);
+        r.EnsureSuccessStatusCode();
+        var dto = await r.Content.ReadFromJsonAsync<RefDto>(JsonOptions);
+        Assert.NotNull(dto);
+        return dto.Id;
+    }
+
+    private static object PermCreateBody(Guid systemId, Guid permissionTypeId, string? description = null) =>
+        new { systemId, permissionTypeId, description };
+
+    private static object PermUpdateBody(Guid systemId, Guid permissionTypeId, string? description = null) =>
+        new { systemId, permissionTypeId, description };
+
+    [Fact]
+    public async Task Create_Post_WithValidReferences_ReturnsCreated_UtcAndNullDeletedAt()
+    {
+        var sysId = await CreateSystemAsync("PERM_SYS_1");
+        var typeId = await CreatePermissionTypeAsync("PERM_TYPE_1");
+
+        var response = await _client.PostAsJsonAsync("/permissions",
+            PermCreateBody(sysId, typeId, "Opcional"), JsonOptions);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var dto = await response.Content.ReadFromJsonAsync<PermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+        Assert.Equal(sysId, dto.SystemId);
+        Assert.Equal(typeId, dto.PermissionTypeId);
+        Assert.Equal("Opcional", dto.Description);
+        Assert.Null(dto.DeletedAt);
+        Assert.True(dto.CreatedAt > DateTime.MinValue);
+        Assert.True(dto.UpdatedAt > DateTime.MinValue);
+    }
+
+    [Fact]
+    public async Task Create_WithoutDescription_NormalizesToNull()
+    {
+        var sysId = await CreateSystemAsync("PERM_SYS_ND");
+        var typeId = await CreatePermissionTypeAsync("PERM_TYPE_ND");
+
+        var response = await _client.PostAsJsonAsync("/permissions",
+            PermCreateBody(sysId, typeId, "   "), JsonOptions);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var dto = await response.Content.ReadFromJsonAsync<PermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+        Assert.Null(dto.Description);
+    }
+
+    [Fact]
+    public async Task Create_WithInvalidSystemId_ReturnsBadRequest()
+    {
+        var typeId = await CreatePermissionTypeAsync("PERM_TYPE_INV_S");
+
+        var response = await _client.PostAsJsonAsync("/permissions",
+            PermCreateBody(Guid.NewGuid(), typeId), JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_WithInvalidPermissionTypeId_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("PERM_SYS_INV_T");
+
+        var response = await _client.PostAsJsonAsync("/permissions",
+            PermCreateBody(sysId, Guid.NewGuid()), JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_DescriptionExceedsMaxLength_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("PERM_SYS_LEN");
+        var typeId = await CreatePermissionTypeAsync("PERM_TYPE_LEN");
+        var longDesc = new string('d', 501);
+
+        var response = await _client.PostAsJsonAsync("/permissions",
+            PermCreateBody(sysId, typeId, longDesc), JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Restore_ActivePermission_ReturnsNotFound()
+    {
+        var sysId = await CreateSystemAsync("PERM_SYS_AR");
+        var typeId = await CreatePermissionTypeAsync("PERM_TYPE_AR");
+        var create = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch, $"/permissions/{dto.Id}/restore"));
+        Assert.Equal(HttpStatusCode.NotFound, patch.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsOnlyActivePermissions()
+    {
+        var sysId = await CreateSystemAsync("PERM_SYS_GA");
+        var typeId = await CreatePermissionTypeAsync("PERM_TYPE_GA");
+        await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId, null), JsonOptions);
+
+        var other = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId, "b"), JsonOptions);
+        var toDelete = await other.Content.ReadFromJsonAsync<PermissionDto>(JsonOptions);
+        Assert.NotNull(toDelete);
+        await _client.DeleteAsync($"/permissions/{toDelete.Id}");
+
+        var listResp = await _client.GetAsync("/permissions");
+        listResp.EnsureSuccessStatusCode();
+        var list = await listResp.Content.ReadFromJsonAsync<List<PermissionDto>>(JsonOptions);
+        Assert.NotNull(list);
+        Assert.All(list, p => Assert.Null(p.DeletedAt));
+        Assert.Single(list);
+    }
+
+    [Fact]
+    public async Task GetById_Active_ReturnsOk_Deleted_Returns404()
+    {
+        var sysId = await CreateSystemAsync("PERM_SYS_G1");
+        var typeId = await CreatePermissionTypeAsync("PERM_TYPE_G1");
+        var create = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        Assert.Equal(HttpStatusCode.OK, (await _client.GetAsync($"/permissions/{dto.Id}")).StatusCode);
+
+        await _client.DeleteAsync($"/permissions/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/permissions/{dto.Id}")).StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_Active_ReturnsOk_Deleted_Returns404()
+    {
+        var sysId = await CreateSystemAsync("PERM_SYS_U1");
+        var typeId = await CreatePermissionTypeAsync("PERM_TYPE_U1");
+        var create = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId, "a"), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        var putOk = await _client.PutAsJsonAsync($"/permissions/{dto.Id}",
+            PermUpdateBody(sysId, typeId, "b"), JsonOptions);
+        Assert.Equal(HttpStatusCode.OK, putOk.StatusCode);
+
+        await _client.DeleteAsync($"/permissions/{dto.Id}");
+        var put404 = await _client.PutAsJsonAsync($"/permissions/{dto.Id}",
+            PermUpdateBody(sysId, typeId, "c"), JsonOptions);
+        Assert.Equal(HttpStatusCode.NotFound, put404.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_WithInvalidSystemId_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("PERM_SYS_UINV");
+        var typeId = await CreatePermissionTypeAsync("PERM_TYPE_UINV");
+        var create = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        var put = await _client.PutAsJsonAsync($"/permissions/{dto.Id}",
+            PermUpdateBody(Guid.NewGuid(), typeId), JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_SoftDelete_ThenDeleteAgain_Returns404()
+    {
+        var sysId = await CreateSystemAsync("PERM_SYS_D1");
+        var typeId = await CreatePermissionTypeAsync("PERM_TYPE_D1");
+        var create = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        Assert.Equal(HttpStatusCode.NoContent, (await _client.DeleteAsync($"/permissions/{dto.Id}")).StatusCode);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var row = await db.Permissions.IgnoreQueryFilters().SingleAsync(p => p.Id == dto.Id);
+            Assert.NotNull(row.DeletedAt);
+        }
+
+        Assert.Equal(HttpStatusCode.NotFound, (await _client.DeleteAsync($"/permissions/{dto.Id}")).StatusCode);
+    }
+
+    [Fact]
+    public async Task Restore_Deleted_ThenGetByIdWorks()
+    {
+        var sysId = await CreateSystemAsync("PERM_SYS_R1");
+        var typeId = await CreatePermissionTypeAsync("PERM_TYPE_R1");
+        var create = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        await _client.DeleteAsync($"/permissions/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/permissions/{dto.Id}")).StatusCode);
+
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch, $"/permissions/{dto.Id}/restore"));
+        Assert.Equal(HttpStatusCode.OK, patch.StatusCode);
+
+        var getOk = await _client.GetAsync($"/permissions/{dto.Id}");
+        Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
+        var restored = await getOk.Content.ReadFromJsonAsync<PermissionDto>(JsonOptions);
+        Assert.NotNull(restored);
+        Assert.Null(restored.DeletedAt);
+    }
+
+    [Fact]
+    public async Task Create_WithDeletedSystem_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("PERM_SYS_DELSYS");
+        var typeId = await CreatePermissionTypeAsync("PERM_TYPE_DELSYS");
+        await _client.DeleteAsync($"/systems/{sysId}");
+
+        var response = await _client.PostAsJsonAsync("/permissions",
+            PermCreateBody(sysId, typeId), JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_AndGetById_ExcludeWhenSystemSoftDeleted()
+    {
+        var sysId = await CreateSystemAsync("PERM_SYS_ORPH");
+        var typeId = await CreatePermissionTypeAsync("PERM_TYPE_ORPH");
+        var create = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        await _client.DeleteAsync($"/systems/{sysId}");
+
+        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/permissions/{dto.Id}")).StatusCode);
+
+        var listResp = await _client.GetAsync("/permissions");
+        listResp.EnsureSuccessStatusCode();
+        var list = await listResp.Content.ReadFromJsonAsync<List<PermissionDto>>(JsonOptions);
+        Assert.NotNull(list);
+        Assert.DoesNotContain(list, p => p.Id == dto.Id);
+    }
+
+    [Fact]
+    public async Task GetAll_AndGetById_ExcludeWhenPermissionTypeSoftDeleted()
+    {
+        var sysId = await CreateSystemAsync("PERM_SYS_PT");
+        var typeId = await CreatePermissionTypeAsync("PERM_TYPE_PT");
+        var create = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        await _client.DeleteAsync($"/permission-types/{typeId}");
+
+        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/permissions/{dto.Id}")).StatusCode);
+
+        var listResp = await _client.GetAsync("/permissions");
+        listResp.EnsureSuccessStatusCode();
+        var list = await listResp.Content.ReadFromJsonAsync<List<PermissionDto>>(JsonOptions);
+        Assert.NotNull(list);
+        Assert.DoesNotContain(list, p => p.Id == dto.Id);
+    }
+
+    [Fact]
+    public async Task Restore_WhenSystemSoftDeleted_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("PERM_SYS_RSYS");
+        var typeId = await CreatePermissionTypeAsync("PERM_TYPE_RSYS");
+        var create = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        await _client.DeleteAsync($"/permissions/{dto.Id}");
+        await _client.DeleteAsync($"/systems/{sysId}");
+
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch, $"/permissions/{dto.Id}/restore"));
+        Assert.Equal(HttpStatusCode.BadRequest, patch.StatusCode);
+    }
+
+    private sealed record RefDto(Guid Id);
+
+    private sealed record PermissionDto(
+        Guid Id,
+        Guid SystemId,
+        Guid PermissionTypeId,
+        string? Description,
+        DateTime CreatedAt,
+        DateTime UpdatedAt,
+        DateTime? DeletedAt);
+}

--- a/AuthService.Tests/PermissionsApiTests.cs
+++ b/AuthService.Tests/PermissionsApiTests.cs
@@ -316,6 +316,34 @@ public class PermissionsApiTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.BadRequest, patch.StatusCode);
     }
 
+    [Fact]
+    public async Task Create_WithDeletedPermissionType_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("PERM_SYS_DELPT");
+        var typeId = await CreatePermissionTypeAsync("PERM_TYPE_DELPT");
+        await _client.DeleteAsync($"/permission-types/{typeId}");
+
+        var response = await _client.PostAsJsonAsync("/permissions",
+            PermCreateBody(sysId, typeId), JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Restore_WhenPermissionTypeSoftDeleted_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("PERM_SYS_RPT");
+        var typeId = await CreatePermissionTypeAsync("PERM_TYPE_RPT");
+        var create = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        await _client.DeleteAsync($"/permissions/{dto.Id}");
+        await _client.DeleteAsync($"/permission-types/{typeId}");
+
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch, $"/permissions/{dto.Id}/restore"));
+        Assert.Equal(HttpStatusCode.BadRequest, patch.StatusCode);
+    }
+
     private sealed record RefDto(Guid Id);
 
     private sealed record PermissionDto(

--- a/AuthService/Controllers/Permissions/PermissionsController.cs
+++ b/AuthService/Controllers/Permissions/PermissionsController.cs
@@ -58,10 +58,10 @@ public class PermissionsController : ControllerBase
     private static PermissionResponse ToResponse(AppPermission e) =>
         new(e.Id, e.SystemId, e.PermissionTypeId, e.Description, e.CreatedAt, e.UpdatedAt, e.DeletedAt);
 
-    private static void ValidateDescription(ModelStateDictionary modelState, string? descriptionOrNull)
+    private static void ValidateDescription(ModelStateDictionary modelState, string? descriptionOrNull, string descriptionPropertyKey)
     {
         if (descriptionOrNull is { Length: > 500 })
-            modelState.AddModelError(nameof(CreatePermissionRequest.Description), "Description deve ter no máximo 500 caracteres.");
+            modelState.AddModelError(descriptionPropertyKey, "Description deve ter no máximo 500 caracteres.");
     }
 
     private static bool IsForeignKeyViolation(DbUpdateException ex)
@@ -113,7 +113,7 @@ public class PermissionsController : ControllerBase
         }
 
         var description = string.IsNullOrWhiteSpace(request.Description) ? null : request.Description.Trim();
-        ValidateDescription(ModelState, description);
+        ValidateDescription(ModelState, description, nameof(CreatePermissionRequest.Description));
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);
 
@@ -197,7 +197,7 @@ public class PermissionsController : ControllerBase
         }
 
         var description = string.IsNullOrWhiteSpace(request.Description) ? null : request.Description.Trim();
-        ValidateDescription(ModelState, description);
+        ValidateDescription(ModelState, description, nameof(UpdatePermissionRequest.Description));
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);
 

--- a/AuthService/Controllers/Permissions/PermissionsController.cs
+++ b/AuthService/Controllers/Permissions/PermissionsController.cs
@@ -1,0 +1,286 @@
+using System.ComponentModel.DataAnnotations;
+using AuthService.Data;
+using AuthService.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+
+namespace AuthService.Controllers.Permissions;
+
+[ApiController]
+[Route("permissions")]
+public class PermissionsController : ControllerBase
+{
+    private readonly AppDbContext _db;
+    private readonly ILogger<PermissionsController> _logger;
+
+    public PermissionsController(AppDbContext db, ILogger<PermissionsController> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public class CreatePermissionRequest
+    {
+        [Required(ErrorMessage = "SystemId é obrigatório.")]
+        public Guid SystemId { get; set; }
+
+        [Required(ErrorMessage = "PermissionTypeId é obrigatório.")]
+        public Guid PermissionTypeId { get; set; }
+
+        [MaxLength(500, ErrorMessage = "Description deve ter no máximo 500 caracteres.")]
+        public string? Description { get; set; }
+    }
+
+    public class UpdatePermissionRequest
+    {
+        [Required(ErrorMessage = "SystemId é obrigatório.")]
+        public Guid SystemId { get; set; }
+
+        [Required(ErrorMessage = "PermissionTypeId é obrigatório.")]
+        public Guid PermissionTypeId { get; set; }
+
+        [MaxLength(500, ErrorMessage = "Description deve ter no máximo 500 caracteres.")]
+        public string? Description { get; set; }
+    }
+
+    public record PermissionResponse(
+        Guid Id,
+        Guid SystemId,
+        Guid PermissionTypeId,
+        string? Description,
+        DateTime CreatedAt,
+        DateTime UpdatedAt,
+        DateTime? DeletedAt
+    );
+
+    private static PermissionResponse ToResponse(AppPermission e) =>
+        new(e.Id, e.SystemId, e.PermissionTypeId, e.Description, e.CreatedAt, e.UpdatedAt, e.DeletedAt);
+
+    private static void ValidateDescription(ModelStateDictionary modelState, string? descriptionOrNull)
+    {
+        if (descriptionOrNull is { Length: > 500 })
+            modelState.AddModelError(nameof(CreatePermissionRequest.Description), "Description deve ter no máximo 500 caracteres.");
+    }
+
+    private static bool IsForeignKeyViolation(DbUpdateException ex)
+    {
+        for (Exception? e = ex; e != null; e = e.InnerException)
+        {
+            if (e is SqlException sql)
+                return sql.Number == 547;
+        }
+
+        return false;
+    }
+
+    private async Task<bool> SystemExistsAndActiveAsync(Guid systemId) =>
+        systemId != Guid.Empty && await _db.Systems.AnyAsync(s => s.Id == systemId);
+
+    private async Task<bool> PermissionTypeExistsAndActiveAsync(Guid permissionTypeId) =>
+        permissionTypeId != Guid.Empty && await _db.PermissionTypes.AnyAsync(t => t.Id == permissionTypeId);
+
+    /// <summary>Permissões ativas cujo sistema e tipo de permissão ainda estão ativos.</summary>
+    private IQueryable<AppPermission> ActivePermissionsWithActiveParents() =>
+        _db.Permissions.Where(p =>
+            _db.Systems.Any(s => s.Id == p.SystemId)
+            && _db.PermissionTypes.Any(t => t.Id == p.PermissionTypeId));
+
+    private IActionResult InvalidReferencesResult(bool systemOk, bool typeOk)
+    {
+        if (!systemOk)
+            ModelState.AddModelError(nameof(CreatePermissionRequest.SystemId), "SystemId inválido ou sistema inativo.");
+        if (!typeOk)
+            ModelState.AddModelError(nameof(CreatePermissionRequest.PermissionTypeId), "PermissionTypeId inválido ou tipo de permissão inativo.");
+        return ValidationProblem(ModelState);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreatePermissionRequest request)
+    {
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        var systemOk = await SystemExistsAndActiveAsync(request.SystemId);
+        var typeOk = await PermissionTypeExistsAndActiveAsync(request.PermissionTypeId);
+        if (!systemOk || !typeOk)
+        {
+            _logger.LogWarning(
+                "Criação de permissão rejeitada: SystemId {SystemId} ok={SystemOk}, PermissionTypeId {TypeId} ok={TypeOk}.",
+                request.SystemId, systemOk, request.PermissionTypeId, typeOk);
+            return InvalidReferencesResult(systemOk, typeOk);
+        }
+
+        var description = string.IsNullOrWhiteSpace(request.Description) ? null : request.Description.Trim();
+        ValidateDescription(ModelState, description);
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        var now = DateTime.UtcNow;
+        var entity = new AppPermission
+        {
+            SystemId = request.SystemId,
+            PermissionTypeId = request.PermissionTypeId,
+            Description = description,
+            CreatedAt = now,
+            UpdatedAt = now,
+            DeletedAt = null
+        };
+        _db.Permissions.Add(entity);
+
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex) when (IsForeignKeyViolation(ex))
+        {
+            _logger.LogWarning(ex, "Violação de FK ao criar permissão.");
+            var s = await SystemExistsAndActiveAsync(request.SystemId);
+            var t = await PermissionTypeExistsAndActiveAsync(request.PermissionTypeId);
+            return InvalidReferencesResult(s, t);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro inesperado ao persistir nova permissão.");
+            throw;
+        }
+
+        _logger.LogInformation("Permissão criada: {PermissionId}.", entity.Id);
+        return CreatedAtAction(nameof(GetById), new { id = entity.Id }, ToResponse(entity));
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll()
+    {
+        var list = await ActivePermissionsWithActiveParents()
+            .OrderBy(p => p.CreatedAt)
+            .Select(p => new PermissionResponse(
+                p.Id,
+                p.SystemId,
+                p.PermissionTypeId,
+                p.Description,
+                p.CreatedAt,
+                p.UpdatedAt,
+                p.DeletedAt))
+            .ToListAsync();
+        return Ok(list);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetById(Guid id)
+    {
+        var entity = await ActivePermissionsWithActiveParents().FirstOrDefaultAsync(p => p.Id == id);
+        if (entity is null)
+            return NotFound(new { message = "Permissão não encontrada." });
+        return Ok(ToResponse(entity));
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> UpdateById(Guid id, [FromBody] UpdatePermissionRequest request)
+    {
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        var entity = await _db.Permissions.FirstOrDefaultAsync(p => p.Id == id);
+        if (entity is null)
+            return NotFound(new { message = "Permissão não encontrada." });
+
+        var systemOk = await SystemExistsAndActiveAsync(request.SystemId);
+        var typeOk = await PermissionTypeExistsAndActiveAsync(request.PermissionTypeId);
+        if (!systemOk || !typeOk)
+        {
+            _logger.LogWarning(
+                "Atualização de permissão {PermissionId} rejeitada: System ok={SystemOk}, Type ok={TypeOk}.",
+                id, systemOk, typeOk);
+            return InvalidReferencesResult(systemOk, typeOk);
+        }
+
+        var description = string.IsNullOrWhiteSpace(request.Description) ? null : request.Description.Trim();
+        ValidateDescription(ModelState, description);
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        entity.SystemId = request.SystemId;
+        entity.PermissionTypeId = request.PermissionTypeId;
+        entity.Description = description;
+        entity.UpdatedAt = DateTime.UtcNow;
+
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex) when (IsForeignKeyViolation(ex))
+        {
+            _logger.LogWarning(ex, "Violação de FK ao atualizar permissão {PermissionId}.", id);
+            var s = await SystemExistsAndActiveAsync(request.SystemId);
+            var t = await PermissionTypeExistsAndActiveAsync(request.PermissionTypeId);
+            return InvalidReferencesResult(s, t);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro inesperado ao persistir atualização da permissão {PermissionId}.", id);
+            throw;
+        }
+
+        _logger.LogInformation("Permissão atualizada: {PermissionId}.", id);
+        return Ok(ToResponse(entity));
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> DeleteById(Guid id)
+    {
+        var entity = await _db.Permissions.FirstOrDefaultAsync(p => p.Id == id);
+        if (entity is null)
+            return NotFound(new { message = "Permissão não encontrada." });
+
+        entity.DeletedAt = DateTime.UtcNow;
+        entity.UpdatedAt = DateTime.UtcNow;
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro inesperado ao excluir (soft) permissão {PermissionId}.", id);
+            throw;
+        }
+
+        _logger.LogInformation("Permissão excluída (soft): {PermissionId}.", id);
+        return NoContent();
+    }
+
+    [HttpPatch("{id:guid}/restore")]
+    public async Task<IActionResult> RestoreById(Guid id)
+    {
+        var entity = await _db.Permissions
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(p => p.Id == id && p.DeletedAt != null);
+
+        if (entity is null)
+            return NotFound(new { message = "Permissão não encontrada ou não está deletada." });
+
+        if (!await SystemExistsAndActiveAsync(entity.SystemId) || !await PermissionTypeExistsAndActiveAsync(entity.PermissionTypeId))
+        {
+            return BadRequest(new
+            {
+                message = "Não é possível restaurar a permissão: o sistema ou o tipo de permissão vinculado está inativo."
+            });
+        }
+
+        entity.DeletedAt = null;
+        entity.UpdatedAt = DateTime.UtcNow;
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro inesperado ao restaurar permissão {PermissionId}.", id);
+            throw;
+        }
+
+        _logger.LogInformation("Permissão restaurada: {PermissionId}.", id);
+        return Ok(ToResponse(entity));
+    }
+}

--- a/AuthService/Data/AppDbContext.cs
+++ b/AuthService/Data/AppDbContext.cs
@@ -11,6 +11,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<AppRoute> Routes => Set<AppRoute>();
     public DbSet<AppPermissionType> PermissionTypes => Set<AppPermissionType>();
     public DbSet<AppRole> Roles => Set<AppRole>();
+    public DbSet<AppPermission> Permissions => Set<AppPermission>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -21,6 +22,19 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             .WithMany()
             .HasForeignKey(r => r.SystemId)
             .OnDelete(DeleteBehavior.Restrict);
+
+        modelBuilder.Entity<AppPermission>(entity =>
+        {
+            entity.HasOne<AppSystem>()
+                .WithMany()
+                .HasForeignKey(p => p.SystemId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity.HasOne<AppPermissionType>()
+                .WithMany()
+                .HasForeignKey(p => p.PermissionTypeId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
 
         foreach (var entityType in modelBuilder.Model.GetEntityTypes())
         {

--- a/AuthService/Data/Migrations/20260329140000_CreatePermissionsTable.Designer.cs
+++ b/AuthService/Data/Migrations/20260329140000_CreatePermissionsTable.Designer.cs
@@ -4,6 +4,7 @@ using AuthService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AuthService.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260329140000_CreatePermissionsTable")]
+    partial class CreatePermissionsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AuthService/Data/Migrations/20260329140000_CreatePermissionsTable.cs
+++ b/AuthService/Data/Migrations/20260329140000_CreatePermissionsTable.cs
@@ -1,0 +1,66 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AuthService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class CreatePermissionsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Permissions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    SystemId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PermissionTypeId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Permissions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Permissions_PermissionTypes_PermissionTypeId",
+                        column: x => x.PermissionTypeId,
+                        principalTable: "PermissionTypes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Permissions_Systems_SystemId",
+                        column: x => x.SystemId,
+                        principalTable: "Systems",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Permissions_DeletedAt",
+                table: "Permissions",
+                column: "DeletedAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Permissions_PermissionTypeId",
+                table: "Permissions",
+                column: "PermissionTypeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Permissions_SystemId",
+                table: "Permissions",
+                column: "SystemId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Permissions");
+        }
+    }
+}

--- a/AuthService/Models/AppPermission.cs
+++ b/AuthService/Models/AppPermission.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace AuthService.Models;
+
+[Index(nameof(DeletedAt), Name = "IX_Permissions_DeletedAt")]
+[Index(nameof(SystemId), Name = "IX_Permissions_SystemId")]
+[Index(nameof(PermissionTypeId), Name = "IX_Permissions_PermissionTypeId")]
+[Table("Permissions")]
+public class AppPermission : ISoftDelete
+{
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    public Guid SystemId { get; set; }
+
+    [Required]
+    public Guid PermissionTypeId { get; set; }
+
+    [StringLength(500)]
+    public string? Description { get; set; }
+
+    [Required]
+    public DateTime CreatedAt { get; set; }
+
+    [Required]
+    public DateTime UpdatedAt { get; set; }
+
+    public DateTime? DeletedAt { get; set; }
+}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ O AuthService concentra a gestão de permissões e padroniza como perfis, usuár
 
 ### Implementado hoje
 
-- CRUD com *soft delete* e restore para **`/systems`**, **`/users`**, **`/routes`**, **`/permission-types`** e **`/roles`**.
+- CRUD com *soft delete* e restore para **`/systems`**, **`/users`**, **`/routes`**, **`/permission-types`**, **`/roles`** e **`/permissions`**.
 - **`/routes`** está vinculada a **sistema ativo** (`systemId`); leituras e restore respeitam o sistema pai não deletado.
 - Testes de integração com SQL Server real (criação e descarte de banco por execução).
 
@@ -144,11 +144,26 @@ Mesmo padrão de *soft delete* e **404** para deletados que **`/systems`**. `Cod
 | `DELETE` | `/roles/{id}` | *Soft delete*. |
 | `PATCH` | `/roles/{id}/restore` | Restaura registro deletado. |
 
+### Permissions (`/permissions`)
+
+Vinculadas a **sistema** e **tipo de permissão** existentes e ativos (`systemId`, `permissionTypeId`). *Soft delete* e **404** como em `/systems`. Corpo: `systemId`, `permissionTypeId`, `description` (opcional, máx. 500 caracteres).
+
+Nos **`GET`**, só aparecem permissões cujo **sistema** e **tipo de permissão** ainda estão ativos. **`PATCH .../restore`** exige ambos ativos.
+
+| Método | Rota | Descrição |
+|--------|------|-----------|
+| `POST` | `/permissions` | Cria (`systemId` e `permissionTypeId` obrigatórios e ativos). |
+| `GET` | `/permissions` | Lista permissões ativas com sistema e tipo ativos. |
+| `GET` | `/permissions/{id}` | Detalhe (permissão ativa + referências ativas). |
+| `PUT` | `/permissions/{id}` | Atualização completa. |
+| `DELETE` | `/permissions/{id}` | *Soft delete*. |
+| `PATCH` | `/permissions/{id}/restore` | Restaura permissão deletada (referências ativas). |
+
 Em ambiente **Development**, a especificação OpenAPI fica em **`/openapi/v1.json`**.
 
 ## Testes de integração
 
-A suite usa **SQL Server real**. Cada execução cria um banco dedicado (`auth_svc_it_<guid>`), aplica **migrations** e faz **DROP DATABASE** ao terminar (adequado para rodar testes em paralelo). Há cobertura para **`/systems`**, **`/users`**, **`/routes`**, **`/permission-types`** e **`/roles`**.
+A suite usa **SQL Server real**. Cada execução cria um banco dedicado (`auth_svc_it_<guid>`), aplica **migrations** e faz **DROP DATABASE** ao terminar (adequado para rodar testes em paralelo). Há cobertura para **`/systems`**, **`/users`**, **`/routes`**, **`/permission-types`**, **`/roles`** e **`/permissions`**.
 
 Defina a connection string **sem** `Database` / `Initial Catalog`:
 


### PR DESCRIPTION
## Resumo
Implementa o recurso **Permissions** com persistência (EF + SQL Server), CRUD via API REST e testes de integração, seguindo o padrão de Routes/Roles (soft delete, validação de referências ativas).

## Alterações realizadas
- README: seção Permissions (`/permissions`) e menção na lista de recursos implementados e na suite de testes
- Modelo `AppPermission` e `DbSet` em `AppDbContext` com FKs Restrict para `Systems` e `PermissionTypes`
- Migration `CreatePermissionsTable` com índices `IX_Permissions_DeletedAt`, `IX_Permissions_SystemId`, `IX_Permissions_PermissionTypeId`
- `PermissionsController` em `/permissions`: POST, GET, GET by id, PUT, DELETE (soft), PATCH restore
- Filtro de leitura: apenas permissões cujo sistema e tipo de permissão estão ativos (não soft-deleted)
- `ILogger` em operações de escrita e mensagens de erro claras (404/400/ValidationProblem)
- **Nota:** a issue cita o nome `PermisseionTypeId` (typo); na implementação foi usado `PermissionTypeId`, consistente com a entidade `PermissionTypes` e com C#

## Impacto de segurança
- Superfície alinhada às demais rotas do serviço: endpoints REST sem camada adicional de autenticação/autorização no controller (mesmo modelo já vigente no projeto).
- Entrada validada por atributos de modelo e checagens de referências ativas; persistência via EF com parâmetros (sem SQL concatenado).
- Logs orientados a IDs e eventos operacionais, sem dados sensíveis explícitos no diff.

## Riscos
- Migração nova: exige `dotnet ef database update` (ou perfil `migrate` do docker-compose) em ambientes existentes
- Comportamento de listagem/get alinhado a Routes: registros ficam invisíveis se o sistema ou o tipo de permissão for soft-deleted

## Evidências de teste
- `docker compose --profile test run --rm test`: **90 testes passando** (inclui `PermissionsApiTests`)
- `dotnet build AuthService.Tests/AuthService.Tests.csproj -c Release` (container SDK 10.0): sucesso
- `dotnet format` com `--verify-no-changes` em AuthService e AuthService.Tests: sem alterações necessárias

Closes #13
