### PR TITLE
#17 | Criar recurso UserPermissions com estrutura inicial e endpoints

### DIFF
--- a/AuthService.Tests/UserPermissionsApiTests.cs
+++ b/AuthService.Tests/UserPermissionsApiTests.cs
@@ -37,10 +37,10 @@ public class UserPermissionsApiTests : IAsyncLifetime
         int identity = 1, bool active = true) =>
         new { name, email, password, identity, active };
 
-    private async Task<Guid> CreateUserAsync(string emailLocal)
+    private async Task<Guid> CreateUserAsync(string emailLocal, bool active = true)
     {
         var email = $"{emailLocal}@up.test";
-        var r = await _client.PostAsJsonAsync("/users", UserCreateBody("U", email), JsonOptions);
+        var r = await _client.PostAsJsonAsync("/users", UserCreateBody("U", email, active: active), JsonOptions);
         r.EnsureSuccessStatusCode();
         var dto = await r.Content.ReadFromJsonAsync<RefGuidDto>(JsonOptions);
         Assert.NotNull(dto);
@@ -136,6 +136,22 @@ public class UserPermissionsApiTests : IAsyncLifetime
         var response = await _client.PostAsJsonAsync("/users-permissions",
             UserPermissionBody(userId, Guid.NewGuid()), JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_InactiveUser_ReturnsBadRequest_WithInactiveMessage()
+    {
+        var userId = await CreateUserAsync("up_inactive", active: false);
+        var sysId = await CreateSystemAsync("SYS_UP_INACT");
+        var typeId = await CreatePermissionTypeAsync("PT_UP_INACT");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+
+        var response = await _client.PostAsJsonAsync("/users-permissions",
+            UserPermissionBody(userId, permissionId), JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var json = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Usuário inativo", json, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/AuthService.Tests/UserPermissionsApiTests.cs
+++ b/AuthService.Tests/UserPermissionsApiTests.cs
@@ -1,0 +1,341 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AuthService.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AuthService.Tests;
+
+public class UserPermissionsApiTests : IAsyncLifetime
+{
+    private WebAppFactory _factory = null!;
+    private HttpClient _client = null!;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    public Task InitializeAsync()
+    {
+        _factory = new WebAppFactory();
+        _client = _factory.CreateClient();
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private static object UserCreateBody(string name, string email, string password = "SenhaSegura1!",
+        int identity = 1, bool active = true) =>
+        new { name, email, password, identity, active };
+
+    private async Task<Guid> CreateUserAsync(string emailLocal)
+    {
+        var email = $"{emailLocal}@up.test";
+        var r = await _client.PostAsJsonAsync("/users", UserCreateBody("U", email), JsonOptions);
+        r.EnsureSuccessStatusCode();
+        var dto = await r.Content.ReadFromJsonAsync<RefGuidDto>(JsonOptions);
+        Assert.NotNull(dto);
+        return dto.Id;
+    }
+
+    private async Task<Guid> CreateSystemAsync(string code)
+    {
+        var r = await _client.PostAsJsonAsync("/systems",
+            new { name = "S", code, description = (string?)null }, JsonOptions);
+        r.EnsureSuccessStatusCode();
+        var dto = await r.Content.ReadFromJsonAsync<RefGuidDto>(JsonOptions);
+        Assert.NotNull(dto);
+        return dto.Id;
+    }
+
+    private async Task<Guid> CreatePermissionTypeAsync(string code)
+    {
+        var r = await _client.PostAsJsonAsync("/permission-types",
+            new { name = "T", code, description = (string?)null }, JsonOptions);
+        r.EnsureSuccessStatusCode();
+        var dto = await r.Content.ReadFromJsonAsync<RefGuidDto>(JsonOptions);
+        Assert.NotNull(dto);
+        return dto.Id;
+    }
+
+    private async Task<Guid> CreatePermissionAsync(Guid systemId, Guid permissionTypeId)
+    {
+        var r = await _client.PostAsJsonAsync("/permissions",
+            new { systemId, permissionTypeId, description = (string?)null }, JsonOptions);
+        r.EnsureSuccessStatusCode();
+        var dto = await r.Content.ReadFromJsonAsync<RefGuidDto>(JsonOptions);
+        Assert.NotNull(dto);
+        return dto.Id;
+    }
+
+    private static object UserPermissionBody(Guid userId, Guid permissionId) => new { userId, permissionId };
+
+    [Fact]
+    public async Task Create_Post_ReturnsCreated_WithGuidId_UtcAndNullDeletedAt()
+    {
+        var userId = await CreateUserAsync("up_create");
+        var sysId = await CreateSystemAsync("SYS_UP_CREATE");
+        var typeId = await CreatePermissionTypeAsync("PT_UP_CREATE");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+
+        var response = await _client.PostAsJsonAsync("/users-permissions",
+            UserPermissionBody(userId, permissionId), JsonOptions);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var dto = await response.Content.ReadFromJsonAsync<UserPermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+        Assert.NotEqual(Guid.Empty, dto.Id);
+        Assert.Equal(userId, dto.UserId);
+        Assert.Equal(permissionId, dto.PermissionId);
+        Assert.Null(dto.DeletedAt);
+        Assert.True(dto.CreatedAt > DateTime.MinValue);
+        Assert.True(dto.UpdatedAt > DateTime.MinValue);
+    }
+
+    [Fact]
+    public async Task Create_DuplicateUserIdPermissionId_ReturnsConflict()
+    {
+        var userId = await CreateUserAsync("up_dup");
+        var sysId = await CreateSystemAsync("SYS_UP_DUP");
+        var typeId = await CreatePermissionTypeAsync("PT_UP_DUP");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+
+        await _client.PostAsJsonAsync("/users-permissions", UserPermissionBody(userId, permissionId), JsonOptions);
+
+        var response = await _client.PostAsJsonAsync("/users-permissions",
+            UserPermissionBody(userId, permissionId), JsonOptions);
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_InvalidUserId_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("SYS_UP_INV_U");
+        var typeId = await CreatePermissionTypeAsync("PT_UP_INV_U");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+
+        var response = await _client.PostAsJsonAsync("/users-permissions",
+            UserPermissionBody(Guid.NewGuid(), permissionId), JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_InvalidPermissionId_ReturnsBadRequest()
+    {
+        var userId = await CreateUserAsync("up_inv_p");
+
+        var response = await _client.PostAsJsonAsync("/users-permissions",
+            UserPermissionBody(userId, Guid.NewGuid()), JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_ConcurrentSamePair_OneCreatedOneConflict()
+    {
+        var userId = await CreateUserAsync("up_conc");
+        var sysId = await CreateSystemAsync("SYS_UP_CONC");
+        var typeId = await CreatePermissionTypeAsync("PT_UP_CONC");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+        var body = UserPermissionBody(userId, permissionId);
+        var t1 = _client.PostAsJsonAsync("/users-permissions", body, JsonOptions);
+        var t2 = _client.PostAsJsonAsync("/users-permissions", body, JsonOptions);
+        await Task.WhenAll(t1, t2);
+
+        var r1 = await t1;
+        var r2 = await t2;
+        var statuses = new[] { r1.StatusCode, r2.StatusCode };
+        Assert.Contains(HttpStatusCode.Created, statuses);
+        Assert.Contains(HttpStatusCode.Conflict, statuses);
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsOnlyActiveLinks_WithActiveParents()
+    {
+        var userId = await CreateUserAsync("up_list");
+        var sysId = await CreateSystemAsync("SYS_UP_LIST");
+        var typeId = await CreatePermissionTypeAsync("PT_UP_LIST");
+        var permA = await CreatePermissionAsync(sysId, typeId);
+        var permB = await CreatePermissionAsync(sysId, typeId);
+
+        await _client.PostAsJsonAsync("/users-permissions", UserPermissionBody(userId, permA), JsonOptions);
+        var second = await _client.PostAsJsonAsync("/users-permissions", UserPermissionBody(userId, permB), JsonOptions);
+        var secondDto = await second.Content.ReadFromJsonAsync<UserPermissionDto>(JsonOptions);
+        Assert.NotNull(secondDto);
+        await _client.DeleteAsync($"/users-permissions/{secondDto.Id}");
+
+        var listResp = await _client.GetAsync("/users-permissions");
+        listResp.EnsureSuccessStatusCode();
+        var list = await listResp.Content.ReadFromJsonAsync<List<UserPermissionDto>>(JsonOptions);
+        Assert.NotNull(list);
+        Assert.All(list, x => Assert.Null(x.DeletedAt));
+        Assert.Contains(list, x => x.PermissionId == permA);
+        Assert.DoesNotContain(list, x => x.PermissionId == permB);
+    }
+
+    [Fact]
+    public async Task GetById_Active_ReturnsOk_Deleted_Returns404()
+    {
+        var userId = await CreateUserAsync("up_get");
+        var sysId = await CreateSystemAsync("SYS_UP_GET");
+        var typeId = await CreatePermissionTypeAsync("PT_UP_GET");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+        var create = await _client.PostAsJsonAsync("/users-permissions",
+            UserPermissionBody(userId, permissionId), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<UserPermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        var getOk = await _client.GetAsync($"/users-permissions/{dto.Id}");
+        Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
+
+        await _client.DeleteAsync($"/users-permissions/{dto.Id}");
+        var get404 = await _client.GetAsync($"/users-permissions/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
+    }
+
+    [Fact]
+    public async Task Restore_ActiveLink_ReturnsNotFound()
+    {
+        var userId = await CreateUserAsync("up_rs_act");
+        var sysId = await CreateSystemAsync("SYS_UP_RS_ACT");
+        var typeId = await CreatePermissionTypeAsync("PT_UP_RS_ACT");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+        var create = await _client.PostAsJsonAsync("/users-permissions",
+            UserPermissionBody(userId, permissionId), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<UserPermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch,
+            $"/users-permissions/{dto.Id}/restore"));
+        Assert.Equal(HttpStatusCode.NotFound, patch.StatusCode);
+    }
+
+    [Fact]
+    public async Task Restore_Deleted_ThenGetWorksAgain()
+    {
+        var userId = await CreateUserAsync("up_rs_ok");
+        var sysId = await CreateSystemAsync("SYS_UP_RS_OK");
+        var typeId = await CreatePermissionTypeAsync("PT_UP_RS_OK");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+        var create = await _client.PostAsJsonAsync("/users-permissions",
+            UserPermissionBody(userId, permissionId), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<UserPermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        await _client.DeleteAsync($"/users-permissions/{dto.Id}");
+
+        var get404 = await _client.GetAsync($"/users-permissions/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
+
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch,
+            $"/users-permissions/{dto.Id}/restore"));
+        Assert.Equal(HttpStatusCode.OK, patch.StatusCode);
+
+        var getOk = await _client.GetAsync($"/users-permissions/{dto.Id}");
+        Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
+        var restored = await getOk.Content.ReadFromJsonAsync<UserPermissionDto>(JsonOptions);
+        Assert.NotNull(restored);
+        Assert.Null(restored.DeletedAt);
+    }
+
+    [Fact]
+    public async Task Restore_WhenUserDeleted_ReturnsBadRequest()
+    {
+        var userId = await CreateUserAsync("up_rs_bad_u");
+        var sysId = await CreateSystemAsync("SYS_UP_RS_BAD_U");
+        var typeId = await CreatePermissionTypeAsync("PT_UP_RS_BAD_U");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+        var create = await _client.PostAsJsonAsync("/users-permissions",
+            UserPermissionBody(userId, permissionId), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<UserPermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        await _client.DeleteAsync($"/users-permissions/{dto.Id}");
+        await _client.DeleteAsync($"/users/{userId}");
+
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch,
+            $"/users-permissions/{dto.Id}/restore"));
+        Assert.Equal(HttpStatusCode.BadRequest, patch.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_DuplicatePair_ReturnsConflict()
+    {
+        var userId = await CreateUserAsync("up_put_dup");
+        var sysId = await CreateSystemAsync("SYS_UP_PUT");
+        var typeId = await CreatePermissionTypeAsync("PT_UP_PUT");
+        var permA = await CreatePermissionAsync(sysId, typeId);
+        var permB = await CreatePermissionAsync(sysId, typeId);
+
+        await _client.PostAsJsonAsync("/users-permissions", UserPermissionBody(userId, permA), JsonOptions);
+        var b = await _client.PostAsJsonAsync("/users-permissions", UserPermissionBody(userId, permB), JsonOptions);
+        var dtoB = await b.Content.ReadFromJsonAsync<UserPermissionDto>(JsonOptions);
+        Assert.NotNull(dtoB);
+
+        var put = await _client.PutAsJsonAsync($"/users-permissions/{dtoB.Id}",
+            UserPermissionBody(userId, permA), JsonOptions);
+        Assert.Equal(HttpStatusCode.Conflict, put.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_SoftDelete_ThenDeleteAgain_Returns404()
+    {
+        var userId = await CreateUserAsync("up_del");
+        var sysId = await CreateSystemAsync("SYS_UP_DEL");
+        var typeId = await CreatePermissionTypeAsync("PT_UP_DEL");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+        var create = await _client.PostAsJsonAsync("/users-permissions",
+            UserPermissionBody(userId, permissionId), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<UserPermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        var del1 = await _client.DeleteAsync($"/users-permissions/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, del1.StatusCode);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var row = await db.UserPermissions.IgnoreQueryFilters().SingleAsync(up => up.Id == dto.Id);
+            Assert.NotNull(row.DeletedAt);
+        }
+
+        var del2 = await _client.DeleteAsync($"/users-permissions/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, del2.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_HidesLinkWhenPermissionDeleted()
+    {
+        var userId = await CreateUserAsync("up_hide_p");
+        var sysId = await CreateSystemAsync("SYS_UP_HIDE");
+        var typeId = await CreatePermissionTypeAsync("PT_UP_HIDE");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+        await _client.PostAsJsonAsync("/users-permissions", UserPermissionBody(userId, permissionId), JsonOptions);
+
+        await _client.DeleteAsync($"/permissions/{permissionId}");
+
+        var listResp = await _client.GetAsync("/users-permissions");
+        listResp.EnsureSuccessStatusCode();
+        var list = await listResp.Content.ReadFromJsonAsync<List<UserPermissionDto>>(JsonOptions);
+        Assert.NotNull(list);
+        Assert.DoesNotContain(list, x => x.PermissionId == permissionId);
+    }
+
+    private sealed record RefGuidDto(Guid Id);
+
+    private sealed record UserPermissionDto(
+        Guid Id,
+        Guid UserId,
+        Guid PermissionId,
+        DateTime CreatedAt,
+        DateTime UpdatedAt,
+        DateTime? DeletedAt);
+}

--- a/AuthService/Controllers/UsersPermissions/UsersPermissionsController.cs
+++ b/AuthService/Controllers/UsersPermissions/UsersPermissionsController.cs
@@ -1,0 +1,312 @@
+using System.ComponentModel.DataAnnotations;
+using AuthService.Data;
+using AuthService.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+
+namespace AuthService.Controllers.UsersPermissions;
+
+[ApiController]
+[Route("users-permissions")]
+public class UsersPermissionsController : ControllerBase
+{
+    private readonly AppDbContext _db;
+    private readonly ILogger<UsersPermissionsController> _logger;
+
+    public UsersPermissionsController(AppDbContext db, ILogger<UsersPermissionsController> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public class CreateUserPermissionRequest
+    {
+        [Required(ErrorMessage = "UserId é obrigatório.")]
+        public Guid UserId { get; set; }
+
+        [Required(ErrorMessage = "PermissionId é obrigatório.")]
+        public Guid PermissionId { get; set; }
+    }
+
+    public class UpdateUserPermissionRequest
+    {
+        [Required(ErrorMessage = "UserId é obrigatório.")]
+        public Guid UserId { get; set; }
+
+        [Required(ErrorMessage = "PermissionId é obrigatório.")]
+        public Guid PermissionId { get; set; }
+    }
+
+    public record UserPermissionResponse(
+        Guid Id,
+        Guid UserId,
+        Guid PermissionId,
+        DateTime CreatedAt,
+        DateTime UpdatedAt,
+        DateTime? DeletedAt
+    );
+
+    private static UserPermissionResponse ToResponse(AppUserPermission e) =>
+        new(e.Id, e.UserId, e.PermissionId, e.CreatedAt, e.UpdatedAt, e.DeletedAt);
+
+    private static bool IsForeignKeyViolation(DbUpdateException ex)
+    {
+        for (Exception? e = ex; e != null; e = e.InnerException)
+        {
+            if (e is SqlException sql)
+                return sql.Number == 547;
+        }
+
+        return false;
+    }
+
+    private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+    {
+        for (Exception? e = ex; e != null; e = e.InnerException)
+        {
+            if (e is SqlException sql)
+                return sql.Number is 2601 or 2627;
+        }
+
+        var text = string.Join(" ", GetExceptionMessages(ex));
+        return text.Contains("UNIQUE", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("unique constraint", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("duplicate key", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IEnumerable<string> GetExceptionMessages(Exception ex)
+    {
+        for (Exception? e = ex; e != null; e = e.InnerException)
+            yield return e.Message;
+    }
+
+    private async Task<bool> UserExistsAndActiveAsync(Guid userId) =>
+        userId != Guid.Empty && await _db.Users.AnyAsync(u => u.Id == userId);
+
+    private async Task<bool> PermissionExistsAndActiveAsync(Guid permissionId) =>
+        permissionId != Guid.Empty && await _db.Permissions.AnyAsync(p => p.Id == permissionId);
+
+    /// <summary>Vínculos ativos cujo usuário e permissão ainda estão ativos.</summary>
+    private IQueryable<AppUserPermission> ActiveUserPermissionsWithActiveParents() =>
+        _db.UserPermissions.Where(up =>
+            _db.Users.Any(u => u.Id == up.UserId)
+            && _db.Permissions.Any(p => p.Id == up.PermissionId));
+
+    private IActionResult InvalidReferencesResult(bool userOk, bool permissionOk)
+    {
+        if (!userOk)
+            ModelState.AddModelError(nameof(CreateUserPermissionRequest.UserId), "UserId inválido ou usuário inativo.");
+        if (!permissionOk)
+            ModelState.AddModelError(nameof(CreateUserPermissionRequest.PermissionId),
+                "PermissionId inválido ou permissão inativa.");
+        return ValidationProblem(ModelState);
+    }
+
+    private static IActionResult UniquePairConflictResult() =>
+        new ConflictObjectResult(new { message = "Já existe vínculo entre este usuário e esta permissão." });
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateUserPermissionRequest request)
+    {
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        var userOk = await UserExistsAndActiveAsync(request.UserId);
+        var permissionOk = await PermissionExistsAndActiveAsync(request.PermissionId);
+        if (!userOk || !permissionOk)
+        {
+            _logger.LogWarning(
+                "Criação de users-permissions rejeitada: UserId {UserId} ok={UserOk}, PermissionId {PermissionId} ok={PermOk}.",
+                request.UserId, userOk, request.PermissionId, permissionOk);
+            return InvalidReferencesResult(userOk, permissionOk);
+        }
+
+        if (await _db.UserPermissions.IgnoreQueryFilters()
+                .AnyAsync(up => up.UserId == request.UserId && up.PermissionId == request.PermissionId))
+        {
+            _logger.LogWarning(
+                "Conflito ao criar vínculo usuário-permissão: UserId {UserId}, PermissionId {PermissionId}.",
+                request.UserId, request.PermissionId);
+            return UniquePairConflictResult();
+        }
+
+        var now = DateTime.UtcNow;
+        var entity = new AppUserPermission
+        {
+            UserId = request.UserId,
+            PermissionId = request.PermissionId,
+            CreatedAt = now,
+            UpdatedAt = now,
+            DeletedAt = null
+        };
+        _db.UserPermissions.Add(entity);
+
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+        {
+            _logger.LogWarning(ex, "Conflito de unicidade ao criar vínculo UserId {UserId}, PermissionId {PermissionId}.",
+                request.UserId, request.PermissionId);
+            return UniquePairConflictResult();
+        }
+        catch (DbUpdateException ex) when (IsForeignKeyViolation(ex))
+        {
+            _logger.LogWarning(ex, "Violação de FK ao criar vínculo usuário-permissão.");
+            var u = await UserExistsAndActiveAsync(request.UserId);
+            var p = await PermissionExistsAndActiveAsync(request.PermissionId);
+            return InvalidReferencesResult(u, p);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro inesperado ao persistir novo vínculo usuário-permissão.");
+            throw;
+        }
+
+        _logger.LogInformation("Vínculo usuário-permissão criado: {UserPermissionId}.", entity.Id);
+        return CreatedAtAction(nameof(GetById), new { id = entity.Id }, ToResponse(entity));
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll()
+    {
+        var list = await ActiveUserPermissionsWithActiveParents()
+            .OrderBy(up => up.CreatedAt)
+            .Select(up => new UserPermissionResponse(
+                up.Id,
+                up.UserId,
+                up.PermissionId,
+                up.CreatedAt,
+                up.UpdatedAt,
+                up.DeletedAt))
+            .ToListAsync();
+        return Ok(list);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetById(Guid id)
+    {
+        var entity = await ActiveUserPermissionsWithActiveParents().FirstOrDefaultAsync(up => up.Id == id);
+        if (entity is null)
+            return NotFound(new { message = "Vínculo usuário-permissão não encontrado." });
+        return Ok(ToResponse(entity));
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> UpdateById(Guid id, [FromBody] UpdateUserPermissionRequest request)
+    {
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        var entity = await _db.UserPermissions.FirstOrDefaultAsync(up => up.Id == id);
+        if (entity is null)
+            return NotFound(new { message = "Vínculo usuário-permissão não encontrado." });
+
+        var userOk = await UserExistsAndActiveAsync(request.UserId);
+        var permissionOk = await PermissionExistsAndActiveAsync(request.PermissionId);
+        if (!userOk || !permissionOk)
+        {
+            _logger.LogWarning(
+                "Atualização de vínculo {UserPermissionId} rejeitada: User ok={UserOk}, Permission ok={PermOk}.",
+                id, userOk, permissionOk);
+            return InvalidReferencesResult(userOk, permissionOk);
+        }
+
+        if (await _db.UserPermissions.IgnoreQueryFilters()
+                .AnyAsync(up => up.Id != id && up.UserId == request.UserId && up.PermissionId == request.PermissionId))
+        {
+            _logger.LogWarning(
+                "Conflito ao atualizar vínculo {UserPermissionId}: par UserId/PermissionId já existe.", id);
+            return UniquePairConflictResult();
+        }
+
+        entity.UserId = request.UserId;
+        entity.PermissionId = request.PermissionId;
+        entity.UpdatedAt = DateTime.UtcNow;
+
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+        {
+            _logger.LogWarning(ex, "Conflito de unicidade ao atualizar vínculo {UserPermissionId}.", id);
+            return UniquePairConflictResult();
+        }
+        catch (DbUpdateException ex) when (IsForeignKeyViolation(ex))
+        {
+            _logger.LogWarning(ex, "Violação de FK ao atualizar vínculo {UserPermissionId}.", id);
+            var u = await UserExistsAndActiveAsync(request.UserId);
+            var p = await PermissionExistsAndActiveAsync(request.PermissionId);
+            return InvalidReferencesResult(u, p);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro inesperado ao persistir atualização do vínculo {UserPermissionId}.", id);
+            throw;
+        }
+
+        _logger.LogInformation("Vínculo usuário-permissão atualizado: {UserPermissionId}.", id);
+        return Ok(ToResponse(entity));
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> DeleteById(Guid id)
+    {
+        var entity = await _db.UserPermissions.FirstOrDefaultAsync(up => up.Id == id);
+        if (entity is null)
+            return NotFound(new { message = "Vínculo usuário-permissão não encontrado." });
+
+        entity.DeletedAt = DateTime.UtcNow;
+        entity.UpdatedAt = DateTime.UtcNow;
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro inesperado ao excluir (soft) vínculo {UserPermissionId}.", id);
+            throw;
+        }
+
+        _logger.LogInformation("Vínculo usuário-permissão excluído (soft): {UserPermissionId}.", id);
+        return NoContent();
+    }
+
+    [HttpPatch("{id:guid}/restore")]
+    public async Task<IActionResult> RestoreById(Guid id)
+    {
+        var entity = await _db.UserPermissions
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(up => up.Id == id && up.DeletedAt != null);
+
+        if (entity is null)
+            return NotFound(new { message = "Vínculo usuário-permissão não encontrado ou não está deletado." });
+
+        if (!await UserExistsAndActiveAsync(entity.UserId) || !await PermissionExistsAndActiveAsync(entity.PermissionId))
+        {
+            return BadRequest(new
+            {
+                message = "Não é possível restaurar o vínculo: o usuário ou a permissão vinculada está inativa."
+            });
+        }
+
+        entity.DeletedAt = null;
+        entity.UpdatedAt = DateTime.UtcNow;
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro inesperado ao restaurar vínculo {UserPermissionId}.", id);
+            throw;
+        }
+
+        _logger.LogInformation("Vínculo usuário-permissão restaurado: {UserPermissionId}.", id);
+        return Ok(ToResponse(entity));
+    }
+}

--- a/AuthService/Controllers/UsersPermissions/UsersPermissionsController.cs
+++ b/AuthService/Controllers/UsersPermissions/UsersPermissionsController.cs
@@ -82,8 +82,31 @@ public class UsersPermissionsController : ControllerBase
             yield return e.Message;
     }
 
-    private async Task<bool> UserExistsAndActiveAsync(Guid userId) =>
-        userId != Guid.Empty && await _db.Users.AnyAsync(u => u.Id == userId);
+    private enum UserRefStatus
+    {
+        Ok,
+        NotFoundOrRemoved,
+        Inactive
+    }
+
+    private async Task<UserRefStatus> GetUserRefStatusAsync(Guid userId)
+    {
+        if (userId == Guid.Empty)
+            return UserRefStatus.NotFoundOrRemoved;
+
+        var row = await _db.Users.IgnoreQueryFilters()
+            .Where(u => u.Id == userId)
+            .Select(u => new { u.DeletedAt, u.Active })
+            .FirstOrDefaultAsync();
+
+        if (row is null)
+            return UserRefStatus.NotFoundOrRemoved;
+        if (row.DeletedAt != null)
+            return UserRefStatus.NotFoundOrRemoved;
+        if (!row.Active)
+            return UserRefStatus.Inactive;
+        return UserRefStatus.Ok;
+    }
 
     private async Task<bool> PermissionExistsAndActiveAsync(Guid permissionId) =>
         permissionId != Guid.Empty && await _db.Permissions.AnyAsync(p => p.Id == permissionId);
@@ -91,18 +114,45 @@ public class UsersPermissionsController : ControllerBase
     /// <summary>Vínculos ativos cujo usuário e permissão ainda estão ativos.</summary>
     private IQueryable<AppUserPermission> ActiveUserPermissionsWithActiveParents() =>
         _db.UserPermissions.Where(up =>
-            _db.Users.Any(u => u.Id == up.UserId)
+            _db.Users.Any(u => u.Id == up.UserId && u.Active)
             && _db.Permissions.Any(p => p.Id == up.PermissionId));
 
-    private IActionResult InvalidReferencesResult(bool userOk, bool permissionOk)
+    private IActionResult InvalidReferencesResult(
+        string userIdKey,
+        string permissionIdKey,
+        UserRefStatus userStatus,
+        bool permissionOk)
     {
-        if (!userOk)
-            ModelState.AddModelError(nameof(CreateUserPermissionRequest.UserId), "UserId inválido ou usuário inativo.");
+        if (userStatus != UserRefStatus.Ok)
+        {
+            var message = userStatus == UserRefStatus.Inactive
+                ? "Usuário inativo."
+                : "UserId inválido ou usuário não encontrado.";
+            ModelState.AddModelError(userIdKey, message);
+        }
+
         if (!permissionOk)
-            ModelState.AddModelError(nameof(CreateUserPermissionRequest.PermissionId),
+        {
+            ModelState.AddModelError(permissionIdKey,
                 "PermissionId inválido ou permissão inativa.");
+        }
+
         return ValidationProblem(ModelState);
     }
+
+    private IActionResult InvalidReferencesResultForCreate(UserRefStatus userStatus, bool permissionOk) =>
+        InvalidReferencesResult(
+            nameof(CreateUserPermissionRequest.UserId),
+            nameof(CreateUserPermissionRequest.PermissionId),
+            userStatus,
+            permissionOk);
+
+    private IActionResult InvalidReferencesResultForUpdate(UserRefStatus userStatus, bool permissionOk) =>
+        InvalidReferencesResult(
+            nameof(UpdateUserPermissionRequest.UserId),
+            nameof(UpdateUserPermissionRequest.PermissionId),
+            userStatus,
+            permissionOk);
 
     private static IActionResult UniquePairConflictResult() =>
         new ConflictObjectResult(new { message = "Já existe vínculo entre este usuário e esta permissão." });
@@ -113,14 +163,14 @@ public class UsersPermissionsController : ControllerBase
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);
 
-        var userOk = await UserExistsAndActiveAsync(request.UserId);
+        var userStatus = await GetUserRefStatusAsync(request.UserId);
         var permissionOk = await PermissionExistsAndActiveAsync(request.PermissionId);
-        if (!userOk || !permissionOk)
+        if (userStatus != UserRefStatus.Ok || !permissionOk)
         {
             _logger.LogWarning(
-                "Criação de users-permissions rejeitada: UserId {UserId} ok={UserOk}, PermissionId {PermissionId} ok={PermOk}.",
-                request.UserId, userOk, request.PermissionId, permissionOk);
-            return InvalidReferencesResult(userOk, permissionOk);
+                "Criação de users-permissions rejeitada: UserId {UserId} status={UserStatus}, PermissionId {PermissionId} ok={PermOk}.",
+                request.UserId, userStatus, request.PermissionId, permissionOk);
+            return InvalidReferencesResultForCreate(userStatus, permissionOk);
         }
 
         if (await _db.UserPermissions.IgnoreQueryFilters()
@@ -156,9 +206,9 @@ public class UsersPermissionsController : ControllerBase
         catch (DbUpdateException ex) when (IsForeignKeyViolation(ex))
         {
             _logger.LogWarning(ex, "Violação de FK ao criar vínculo usuário-permissão.");
-            var u = await UserExistsAndActiveAsync(request.UserId);
+            var u = await GetUserRefStatusAsync(request.UserId);
             var p = await PermissionExistsAndActiveAsync(request.PermissionId);
-            return InvalidReferencesResult(u, p);
+            return InvalidReferencesResultForCreate(u, p);
         }
         catch (Exception ex)
         {
@@ -205,14 +255,14 @@ public class UsersPermissionsController : ControllerBase
         if (entity is null)
             return NotFound(new { message = "Vínculo usuário-permissão não encontrado." });
 
-        var userOk = await UserExistsAndActiveAsync(request.UserId);
+        var userStatus = await GetUserRefStatusAsync(request.UserId);
         var permissionOk = await PermissionExistsAndActiveAsync(request.PermissionId);
-        if (!userOk || !permissionOk)
+        if (userStatus != UserRefStatus.Ok || !permissionOk)
         {
             _logger.LogWarning(
-                "Atualização de vínculo {UserPermissionId} rejeitada: User ok={UserOk}, Permission ok={PermOk}.",
-                id, userOk, permissionOk);
-            return InvalidReferencesResult(userOk, permissionOk);
+                "Atualização de vínculo {UserPermissionId} rejeitada: User status={UserStatus}, Permission ok={PermOk}.",
+                id, userStatus, permissionOk);
+            return InvalidReferencesResultForUpdate(userStatus, permissionOk);
         }
 
         if (await _db.UserPermissions.IgnoreQueryFilters()
@@ -239,9 +289,9 @@ public class UsersPermissionsController : ControllerBase
         catch (DbUpdateException ex) when (IsForeignKeyViolation(ex))
         {
             _logger.LogWarning(ex, "Violação de FK ao atualizar vínculo {UserPermissionId}.", id);
-            var u = await UserExistsAndActiveAsync(request.UserId);
+            var u = await GetUserRefStatusAsync(request.UserId);
             var p = await PermissionExistsAndActiveAsync(request.PermissionId);
-            return InvalidReferencesResult(u, p);
+            return InvalidReferencesResultForUpdate(u, p);
         }
         catch (Exception ex)
         {
@@ -286,7 +336,8 @@ public class UsersPermissionsController : ControllerBase
         if (entity is null)
             return NotFound(new { message = "Vínculo usuário-permissão não encontrado ou não está deletado." });
 
-        if (!await UserExistsAndActiveAsync(entity.UserId) || !await PermissionExistsAndActiveAsync(entity.PermissionId))
+        if (await GetUserRefStatusAsync(entity.UserId) != UserRefStatus.Ok
+            || !await PermissionExistsAndActiveAsync(entity.PermissionId))
         {
             return BadRequest(new
             {

--- a/AuthService/Data/AppDbContext.cs
+++ b/AuthService/Data/AppDbContext.cs
@@ -13,6 +13,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<AppRole> Roles => Set<AppRole>();
     public DbSet<AppPermission> Permissions => Set<AppPermission>();
     public DbSet<AppUserRole> UserRoles => Set<AppUserRole>();
+    public DbSet<AppUserPermission> UserPermissions => Set<AppUserPermission>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -47,6 +48,19 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             entity.HasOne<AppRole>()
                 .WithMany()
                 .HasForeignKey(e => e.RoleId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<AppUserPermission>(entity =>
+        {
+            entity.HasOne<User>()
+                .WithMany()
+                .HasForeignKey(e => e.UserId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity.HasOne<AppPermission>()
+                .WithMany()
+                .HasForeignKey(e => e.PermissionId)
                 .OnDelete(DeleteBehavior.Restrict);
         });
 

--- a/AuthService/Data/Migrations/20260329160000_CreateUserPermissionsTable.Designer.cs
+++ b/AuthService/Data/Migrations/20260329160000_CreateUserPermissionsTable.Designer.cs
@@ -4,6 +4,7 @@ using AuthService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AuthService.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260329160000_CreateUserPermissionsTable")]
+    partial class CreateUserPermissionsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AuthService/Data/Migrations/20260329160000_CreateUserPermissionsTable.cs
+++ b/AuthService/Data/Migrations/20260329160000_CreateUserPermissionsTable.cs
@@ -1,0 +1,71 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AuthService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class CreateUserPermissionsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserPermissions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PermissionId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserPermissions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserPermissions_Permissions_PermissionId",
+                        column: x => x.PermissionId,
+                        principalTable: "Permissions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_UserPermissions_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserPermissions_DeletedAt",
+                table: "UserPermissions",
+                column: "DeletedAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserPermissions_PermissionId",
+                table: "UserPermissions",
+                column: "PermissionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserPermissions_UserId",
+                table: "UserPermissions",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_UserPermissions_UserId_PermissionId",
+                table: "UserPermissions",
+                columns: new[] { "UserId", "PermissionId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserPermissions");
+        }
+    }
+}

--- a/AuthService/Models/AppUserPermission.cs
+++ b/AuthService/Models/AppUserPermission.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace AuthService.Models;
+
+[Index(nameof(DeletedAt), Name = "IX_UserPermissions_DeletedAt")]
+[Index(nameof(UserId), Name = "IX_UserPermissions_UserId")]
+[Index(nameof(PermissionId), Name = "IX_UserPermissions_PermissionId")]
+[Index(nameof(UserId), nameof(PermissionId), IsUnique = true, Name = "UX_UserPermissions_UserId_PermissionId")]
+[Table("UserPermissions")]
+public class AppUserPermission : ISoftDelete
+{
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    public Guid UserId { get; set; }
+
+    [Required]
+    public Guid PermissionId { get; set; }
+
+    [Required]
+    public DateTime CreatedAt { get; set; }
+
+    [Required]
+    public DateTime UpdatedAt { get; set; }
+
+    public DateTime? DeletedAt { get; set; }
+}


### PR DESCRIPTION
## Summary
- Implementa o recurso `/users-permissions` com entidade `AppUserPermission`, migration, controller e regras de soft delete/restore.
- Adiciona validações de referências ativas (`User` e `Permission`) e tratamento de conflito para unicidade `(UserId, PermissionId)`.
- Inclui testes de integração dedicados (`UserPermissionsApiTests`) cobrindo fluxo principal, cenários de erro e contratos HTTP.

## Alterações realizadas
- `AuthService/Models/AppUserPermission.cs` (novo)
- `AuthService/Data/AppDbContext.cs`
- `AuthService/Data/Migrations/20260329160000_CreateUserPermissionsTable.cs` (novo)
- `AuthService/Data/Migrations/20260329160000_CreateUserPermissionsTable.Designer.cs` (novo)
- `AuthService/Data/Migrations/AppDbContextModelSnapshot.cs`
- `AuthService/Controllers/UsersPermissions/UsersPermissionsController.cs` (novo)
- `AuthService.Tests/UserPermissionsApiTests.cs` (novo)

## Riscos
- Mudança de schema exige aplicação da migration em todos os ambientes.
- Unicidade de `(UserId, PermissionId)` inclui registros soft-deleted (recriação do mesmo par deve seguir restore).

## Evidências de teste
- `docker compose --profile test run --rm test`
- Resultado: `Passed: 116, Failed: 0, Total: 116`

## Test plan
- [x] Criar vínculo user-permission válido
- [x] Validar 400 para referências inexistentes/inativas
- [x] Validar 409 para duplicidade de vínculo
- [x] Validar comportamento de soft delete e restore
- [x] Validar contratos de resposta e listagem

Closes #17

Made with [Cursor](https://cursor.com)