### PR TITLE
#19 | Criar recurso RolePermissions com estrutura inicial e endpoints

### DIFF
--- a/AuthService.Tests/RolePermissionsApiTests.cs
+++ b/AuthService.Tests/RolePermissionsApiTests.cs
@@ -1,0 +1,355 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AuthService.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AuthService.Tests;
+
+public class RolePermissionsApiTests : IAsyncLifetime
+{
+    private WebAppFactory _factory = null!;
+    private HttpClient _client = null!;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    public Task InitializeAsync()
+    {
+        _factory = new WebAppFactory();
+        _client = _factory.CreateClient();
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private async Task<Guid> CreateRoleAsync(string code)
+    {
+        var r = await _client.PostAsJsonAsync("/roles",
+            new { name = "R", code, }, JsonOptions);
+        r.EnsureSuccessStatusCode();
+        var dto = await r.Content.ReadFromJsonAsync<RefGuidDto>(JsonOptions);
+        Assert.NotNull(dto);
+        return dto.Id;
+    }
+
+    private async Task<Guid> CreateSystemAsync(string code)
+    {
+        var r = await _client.PostAsJsonAsync("/systems",
+            new { name = "S", code, description = (string?)null }, JsonOptions);
+        r.EnsureSuccessStatusCode();
+        var dto = await r.Content.ReadFromJsonAsync<RefGuidDto>(JsonOptions);
+        Assert.NotNull(dto);
+        return dto.Id;
+    }
+
+    private async Task<Guid> CreatePermissionTypeAsync(string code)
+    {
+        var r = await _client.PostAsJsonAsync("/permission-types",
+            new { name = "T", code, description = (string?)null }, JsonOptions);
+        r.EnsureSuccessStatusCode();
+        var dto = await r.Content.ReadFromJsonAsync<RefGuidDto>(JsonOptions);
+        Assert.NotNull(dto);
+        return dto.Id;
+    }
+
+    private async Task<Guid> CreatePermissionAsync(Guid systemId, Guid permissionTypeId)
+    {
+        var r = await _client.PostAsJsonAsync("/permissions",
+            new { systemId, permissionTypeId, description = (string?)null }, JsonOptions);
+        r.EnsureSuccessStatusCode();
+        var dto = await r.Content.ReadFromJsonAsync<RefGuidDto>(JsonOptions);
+        Assert.NotNull(dto);
+        return dto.Id;
+    }
+
+    private static object RolePermissionBody(Guid roleId, Guid permissionId) => new { roleId, permissionId };
+
+    [Fact]
+    public async Task Create_Post_ReturnsCreated_WithGuidId_UtcAndNullDeletedAt()
+    {
+        var roleId = await CreateRoleAsync("RP_CREATE");
+        var sysId = await CreateSystemAsync("SYS_RP_CREATE");
+        var typeId = await CreatePermissionTypeAsync("PT_RP_CREATE");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+
+        var response = await _client.PostAsJsonAsync("/roles-permissions",
+            RolePermissionBody(roleId, permissionId), JsonOptions);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var dto = await response.Content.ReadFromJsonAsync<RolePermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+        Assert.NotEqual(Guid.Empty, dto.Id);
+        Assert.Equal(roleId, dto.RoleId);
+        Assert.Equal(permissionId, dto.PermissionId);
+        Assert.Null(dto.DeletedAt);
+        Assert.True(dto.CreatedAt > DateTime.MinValue);
+        Assert.True(dto.UpdatedAt > DateTime.MinValue);
+    }
+
+    [Fact]
+    public async Task Create_DuplicateRoleIdPermissionId_ReturnsConflict()
+    {
+        var roleId = await CreateRoleAsync("RP_DUP");
+        var sysId = await CreateSystemAsync("SYS_RP_DUP");
+        var typeId = await CreatePermissionTypeAsync("PT_RP_DUP");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+
+        await _client.PostAsJsonAsync("/roles-permissions", RolePermissionBody(roleId, permissionId), JsonOptions);
+
+        var response = await _client.PostAsJsonAsync("/roles-permissions",
+            RolePermissionBody(roleId, permissionId), JsonOptions);
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_InvalidRoleId_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("SYS_RP_INV_R");
+        var typeId = await CreatePermissionTypeAsync("PT_RP_INV_R");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+
+        var response = await _client.PostAsJsonAsync("/roles-permissions",
+            RolePermissionBody(Guid.NewGuid(), permissionId), JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_InvalidPermissionId_ReturnsBadRequest()
+    {
+        var roleId = await CreateRoleAsync("RP_INV_P");
+
+        var response = await _client.PostAsJsonAsync("/roles-permissions",
+            RolePermissionBody(roleId, Guid.NewGuid()), JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_ConcurrentSamePair_OneCreatedOneConflict()
+    {
+        var roleId = await CreateRoleAsync("RP_CONC");
+        var sysId = await CreateSystemAsync("SYS_RP_CONC");
+        var typeId = await CreatePermissionTypeAsync("PT_RP_CONC");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+        var body = RolePermissionBody(roleId, permissionId);
+        var t1 = _client.PostAsJsonAsync("/roles-permissions", body, JsonOptions);
+        var t2 = _client.PostAsJsonAsync("/roles-permissions", body, JsonOptions);
+        await Task.WhenAll(t1, t2);
+
+        var r1 = await t1;
+        var r2 = await t2;
+        var statuses = new[] { r1.StatusCode, r2.StatusCode };
+        Assert.Contains(HttpStatusCode.Created, statuses);
+        Assert.Contains(HttpStatusCode.Conflict, statuses);
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsOnlyActiveLinks_WithActiveParents()
+    {
+        var roleId = await CreateRoleAsync("RP_LIST");
+        var sysId = await CreateSystemAsync("SYS_RP_LIST");
+        var typeId = await CreatePermissionTypeAsync("PT_RP_LIST");
+        var permA = await CreatePermissionAsync(sysId, typeId);
+        var permB = await CreatePermissionAsync(sysId, typeId);
+
+        await _client.PostAsJsonAsync("/roles-permissions", RolePermissionBody(roleId, permA), JsonOptions);
+        var second = await _client.PostAsJsonAsync("/roles-permissions", RolePermissionBody(roleId, permB), JsonOptions);
+        var secondDto = await second.Content.ReadFromJsonAsync<RolePermissionDto>(JsonOptions);
+        Assert.NotNull(secondDto);
+        await _client.DeleteAsync($"/roles-permissions/{secondDto.Id}");
+
+        var listResp = await _client.GetAsync("/roles-permissions");
+        listResp.EnsureSuccessStatusCode();
+        var list = await listResp.Content.ReadFromJsonAsync<List<RolePermissionDto>>(JsonOptions);
+        Assert.NotNull(list);
+        Assert.All(list, x => Assert.Null(x.DeletedAt));
+        Assert.Contains(list, x => x.PermissionId == permA);
+        Assert.DoesNotContain(list, x => x.PermissionId == permB);
+    }
+
+    [Fact]
+    public async Task GetById_Active_ReturnsOk_Deleted_Returns404()
+    {
+        var roleId = await CreateRoleAsync("RP_GET");
+        var sysId = await CreateSystemAsync("SYS_RP_GET");
+        var typeId = await CreatePermissionTypeAsync("PT_RP_GET");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+        var create = await _client.PostAsJsonAsync("/roles-permissions",
+            RolePermissionBody(roleId, permissionId), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RolePermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        var getOk = await _client.GetAsync($"/roles-permissions/{dto.Id}");
+        Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
+
+        await _client.DeleteAsync($"/roles-permissions/{dto.Id}");
+        var get404 = await _client.GetAsync($"/roles-permissions/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
+    }
+
+    [Fact]
+    public async Task Restore_ActiveLink_ReturnsNotFound()
+    {
+        var roleId = await CreateRoleAsync("RP_RS_ACT");
+        var sysId = await CreateSystemAsync("SYS_RP_RS_ACT");
+        var typeId = await CreatePermissionTypeAsync("PT_RP_RS_ACT");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+        var create = await _client.PostAsJsonAsync("/roles-permissions",
+            RolePermissionBody(roleId, permissionId), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RolePermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch,
+            $"/roles-permissions/{dto.Id}/restore"));
+        Assert.Equal(HttpStatusCode.NotFound, patch.StatusCode);
+    }
+
+    [Fact]
+    public async Task Restore_Deleted_ThenGetWorksAgain()
+    {
+        var roleId = await CreateRoleAsync("RP_RS_OK");
+        var sysId = await CreateSystemAsync("SYS_RP_RS_OK");
+        var typeId = await CreatePermissionTypeAsync("PT_RP_RS_OK");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+        var create = await _client.PostAsJsonAsync("/roles-permissions",
+            RolePermissionBody(roleId, permissionId), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RolePermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        await _client.DeleteAsync($"/roles-permissions/{dto.Id}");
+
+        var get404 = await _client.GetAsync($"/roles-permissions/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
+
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch,
+            $"/roles-permissions/{dto.Id}/restore"));
+        Assert.Equal(HttpStatusCode.OK, patch.StatusCode);
+
+        var getOk = await _client.GetAsync($"/roles-permissions/{dto.Id}");
+        Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
+        var restored = await getOk.Content.ReadFromJsonAsync<RolePermissionDto>(JsonOptions);
+        Assert.NotNull(restored);
+        Assert.Null(restored.DeletedAt);
+    }
+
+    [Fact]
+    public async Task Restore_WhenRoleDeleted_ReturnsBadRequest()
+    {
+        var roleId = await CreateRoleAsync("RP_RS_BAD_R");
+        var sysId = await CreateSystemAsync("SYS_RP_RS_BAD_R");
+        var typeId = await CreatePermissionTypeAsync("PT_RP_RS_BAD_R");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+        var create = await _client.PostAsJsonAsync("/roles-permissions",
+            RolePermissionBody(roleId, permissionId), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RolePermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        await _client.DeleteAsync($"/roles-permissions/{dto.Id}");
+        await _client.DeleteAsync($"/roles/{roleId}");
+
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch,
+            $"/roles-permissions/{dto.Id}/restore"));
+        Assert.Equal(HttpStatusCode.BadRequest, patch.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_DuplicatePair_ReturnsConflict()
+    {
+        var roleId = await CreateRoleAsync("RP_PUT_DUP");
+        var sysId = await CreateSystemAsync("SYS_RP_PUT");
+        var typeId = await CreatePermissionTypeAsync("PT_RP_PUT");
+        var permA = await CreatePermissionAsync(sysId, typeId);
+        var permB = await CreatePermissionAsync(sysId, typeId);
+
+        await _client.PostAsJsonAsync("/roles-permissions", RolePermissionBody(roleId, permA), JsonOptions);
+        var b = await _client.PostAsJsonAsync("/roles-permissions", RolePermissionBody(roleId, permB), JsonOptions);
+        var dtoB = await b.Content.ReadFromJsonAsync<RolePermissionDto>(JsonOptions);
+        Assert.NotNull(dtoB);
+
+        var put = await _client.PutAsJsonAsync($"/roles-permissions/{dtoB.Id}",
+            RolePermissionBody(roleId, permA), JsonOptions);
+        Assert.Equal(HttpStatusCode.Conflict, put.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_SoftDelete_ThenDeleteAgain_Returns404()
+    {
+        var roleId = await CreateRoleAsync("RP_DEL");
+        var sysId = await CreateSystemAsync("SYS_RP_DEL");
+        var typeId = await CreatePermissionTypeAsync("PT_RP_DEL");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+        var create = await _client.PostAsJsonAsync("/roles-permissions",
+            RolePermissionBody(roleId, permissionId), JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RolePermissionDto>(JsonOptions);
+        Assert.NotNull(dto);
+
+        var del1 = await _client.DeleteAsync($"/roles-permissions/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, del1.StatusCode);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var row = await db.RolePermissions.IgnoreQueryFilters().SingleAsync(rp => rp.Id == dto.Id);
+            Assert.NotNull(row.DeletedAt);
+        }
+
+        var del2 = await _client.DeleteAsync($"/roles-permissions/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, del2.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_HidesLinkWhenPermissionDeleted()
+    {
+        var roleId = await CreateRoleAsync("RP_HIDE_P");
+        var sysId = await CreateSystemAsync("SYS_RP_HIDE");
+        var typeId = await CreatePermissionTypeAsync("PT_RP_HIDE");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+        await _client.PostAsJsonAsync("/roles-permissions", RolePermissionBody(roleId, permissionId), JsonOptions);
+
+        await _client.DeleteAsync($"/permissions/{permissionId}");
+
+        var listResp = await _client.GetAsync("/roles-permissions");
+        listResp.EnsureSuccessStatusCode();
+        var list = await listResp.Content.ReadFromJsonAsync<List<RolePermissionDto>>(JsonOptions);
+        Assert.NotNull(list);
+        Assert.DoesNotContain(list, x => x.PermissionId == permissionId);
+    }
+
+    [Fact]
+    public async Task GetAll_HidesLinkWhenRoleDeleted()
+    {
+        var roleId = await CreateRoleAsync("RP_HIDE_R");
+        var sysId = await CreateSystemAsync("SYS_RP_HIDE_R");
+        var typeId = await CreatePermissionTypeAsync("PT_RP_HIDE_R");
+        var permissionId = await CreatePermissionAsync(sysId, typeId);
+        await _client.PostAsJsonAsync("/roles-permissions", RolePermissionBody(roleId, permissionId), JsonOptions);
+
+        await _client.DeleteAsync($"/roles/{roleId}");
+
+        var listResp = await _client.GetAsync("/roles-permissions");
+        listResp.EnsureSuccessStatusCode();
+        var list = await listResp.Content.ReadFromJsonAsync<List<RolePermissionDto>>(JsonOptions);
+        Assert.NotNull(list);
+        Assert.DoesNotContain(list, x => x.RoleId == roleId);
+    }
+
+    private sealed record RefGuidDto(Guid Id);
+
+    private sealed record RolePermissionDto(
+        Guid Id,
+        Guid RoleId,
+        Guid PermissionId,
+        DateTime CreatedAt,
+        DateTime UpdatedAt,
+        DateTime? DeletedAt);
+}

--- a/AuthService/Controllers/RolePermissions/RolePermissionsController.cs
+++ b/AuthService/Controllers/RolePermissions/RolePermissionsController.cs
@@ -1,0 +1,358 @@
+using System.ComponentModel.DataAnnotations;
+using AuthService.Data;
+using AuthService.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+
+namespace AuthService.Controllers.RolePermissions;
+
+[ApiController]
+[Route("roles-permissions")]
+public class RolePermissionsController : ControllerBase
+{
+    private readonly AppDbContext _db;
+    private readonly ILogger<RolePermissionsController> _logger;
+
+    public RolePermissionsController(AppDbContext db, ILogger<RolePermissionsController> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public class CreateRolePermissionRequest
+    {
+        [Required(ErrorMessage = "RoleId é obrigatório.")]
+        public Guid RoleId { get; set; }
+
+        [Required(ErrorMessage = "PermissionId é obrigatório.")]
+        public Guid PermissionId { get; set; }
+    }
+
+    public class UpdateRolePermissionRequest
+    {
+        [Required(ErrorMessage = "RoleId é obrigatório.")]
+        public Guid RoleId { get; set; }
+
+        [Required(ErrorMessage = "PermissionId é obrigatório.")]
+        public Guid PermissionId { get; set; }
+    }
+
+    public record RolePermissionResponse(
+        Guid Id,
+        Guid RoleId,
+        Guid PermissionId,
+        DateTime CreatedAt,
+        DateTime UpdatedAt,
+        DateTime? DeletedAt
+    );
+
+    private static RolePermissionResponse ToResponse(AppRolePermission e) =>
+        new(e.Id, e.RoleId, e.PermissionId, e.CreatedAt, e.UpdatedAt, e.DeletedAt);
+
+    private static bool IsForeignKeyViolation(DbUpdateException ex)
+    {
+        for (Exception? e = ex; e != null; e = e.InnerException)
+        {
+            if (e is SqlException sql)
+                return sql.Number == 547;
+        }
+
+        return false;
+    }
+
+    private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+    {
+        for (Exception? e = ex; e != null; e = e.InnerException)
+        {
+            if (e is SqlException sql)
+                return sql.Number is 2601 or 2627;
+        }
+
+        var text = string.Join(" ", GetExceptionMessages(ex));
+        return text.Contains("UNIQUE", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("unique constraint", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("duplicate key", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IEnumerable<string> GetExceptionMessages(Exception ex)
+    {
+        for (Exception? e = ex; e != null; e = e.InnerException)
+            yield return e.Message;
+    }
+
+    private enum RoleRefStatus
+    {
+        Ok,
+        NotFoundOrRemoved
+    }
+
+    private async Task<RoleRefStatus> GetRoleRefStatusAsync(Guid roleId)
+    {
+        if (roleId == Guid.Empty)
+            return RoleRefStatus.NotFoundOrRemoved;
+
+        var row = await _db.Roles.IgnoreQueryFilters()
+            .Where(r => r.Id == roleId)
+            .Select(r => new { r.DeletedAt })
+            .FirstOrDefaultAsync();
+
+        if (row is null)
+            return RoleRefStatus.NotFoundOrRemoved;
+        if (row.DeletedAt != null)
+            return RoleRefStatus.NotFoundOrRemoved;
+        return RoleRefStatus.Ok;
+    }
+
+    private async Task<bool> PermissionExistsAndActiveAsync(Guid permissionId) =>
+        permissionId != Guid.Empty && await _db.Permissions.AnyAsync(p => p.Id == permissionId);
+
+    /// <summary>Vínculos ativos cujo papel e permissão ainda estão ativos.</summary>
+    private IQueryable<AppRolePermission> ActiveRolePermissionsWithActiveParents() =>
+        _db.RolePermissions.Where(rp =>
+            _db.Roles.Any(r => r.Id == rp.RoleId)
+            && _db.Permissions.Any(p => p.Id == rp.PermissionId));
+
+    private IActionResult InvalidReferencesResult(
+        string roleIdKey,
+        string permissionIdKey,
+        RoleRefStatus roleStatus,
+        bool permissionOk)
+    {
+        if (roleStatus != RoleRefStatus.Ok)
+        {
+            ModelState.AddModelError(roleIdKey,
+                "RoleId inválido ou papel não encontrado.");
+        }
+
+        if (!permissionOk)
+        {
+            ModelState.AddModelError(permissionIdKey,
+                "PermissionId inválido ou permissão inativa.");
+        }
+
+        return ValidationProblem(ModelState);
+    }
+
+    private IActionResult InvalidReferencesResultForCreate(RoleRefStatus roleStatus, bool permissionOk) =>
+        InvalidReferencesResult(
+            nameof(CreateRolePermissionRequest.RoleId),
+            nameof(CreateRolePermissionRequest.PermissionId),
+            roleStatus,
+            permissionOk);
+
+    private IActionResult InvalidReferencesResultForUpdate(RoleRefStatus roleStatus, bool permissionOk) =>
+        InvalidReferencesResult(
+            nameof(UpdateRolePermissionRequest.RoleId),
+            nameof(UpdateRolePermissionRequest.PermissionId),
+            roleStatus,
+            permissionOk);
+
+    private static IActionResult UniquePairConflictResult() =>
+        new ConflictObjectResult(new { message = "Já existe vínculo entre este papel e esta permissão." });
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateRolePermissionRequest request)
+    {
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        var roleStatus = await GetRoleRefStatusAsync(request.RoleId);
+        var permissionOk = await PermissionExistsAndActiveAsync(request.PermissionId);
+        if (roleStatus != RoleRefStatus.Ok || !permissionOk)
+        {
+            _logger.LogWarning(
+                "Criação de roles-permissions rejeitada: RoleId {RoleId} status={RoleStatus}, PermissionId {PermissionId} ok={PermOk}.",
+                request.RoleId, roleStatus, request.PermissionId, permissionOk);
+            return InvalidReferencesResultForCreate(roleStatus, permissionOk);
+        }
+
+        if (await _db.RolePermissions.IgnoreQueryFilters()
+                .AnyAsync(rp => rp.RoleId == request.RoleId && rp.PermissionId == request.PermissionId))
+        {
+            _logger.LogWarning(
+                "Conflito ao criar vínculo papel-permissão: RoleId {RoleId}, PermissionId {PermissionId}.",
+                request.RoleId, request.PermissionId);
+            return UniquePairConflictResult();
+        }
+
+        var now = DateTime.UtcNow;
+        var entity = new AppRolePermission
+        {
+            RoleId = request.RoleId,
+            PermissionId = request.PermissionId,
+            CreatedAt = now,
+            UpdatedAt = now,
+            DeletedAt = null
+        };
+        _db.RolePermissions.Add(entity);
+
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+        {
+            _logger.LogWarning(ex, "Conflito de unicidade ao criar vínculo RoleId {RoleId}, PermissionId {PermissionId}.",
+                request.RoleId, request.PermissionId);
+            return UniquePairConflictResult();
+        }
+        catch (DbUpdateException ex) when (IsForeignKeyViolation(ex))
+        {
+            _logger.LogWarning(ex, "Violação de FK ao criar vínculo papel-permissão.");
+            var r = await GetRoleRefStatusAsync(request.RoleId);
+            var p = await PermissionExistsAndActiveAsync(request.PermissionId);
+            return InvalidReferencesResultForCreate(r, p);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro inesperado ao persistir novo vínculo papel-permissão.");
+            throw;
+        }
+
+        _logger.LogInformation("Vínculo papel-permissão criado: {RolePermissionId}.", entity.Id);
+        return CreatedAtAction(nameof(GetById), new { id = entity.Id }, ToResponse(entity));
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll()
+    {
+        var list = await ActiveRolePermissionsWithActiveParents()
+            .OrderBy(rp => rp.CreatedAt)
+            .Select(rp => new RolePermissionResponse(
+                rp.Id,
+                rp.RoleId,
+                rp.PermissionId,
+                rp.CreatedAt,
+                rp.UpdatedAt,
+                rp.DeletedAt))
+            .ToListAsync();
+        return Ok(list);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetById(Guid id)
+    {
+        var entity = await ActiveRolePermissionsWithActiveParents().FirstOrDefaultAsync(rp => rp.Id == id);
+        if (entity is null)
+            return NotFound(new { message = "Vínculo papel-permissão não encontrado." });
+        return Ok(ToResponse(entity));
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> UpdateById(Guid id, [FromBody] UpdateRolePermissionRequest request)
+    {
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        var entity = await _db.RolePermissions.FirstOrDefaultAsync(rp => rp.Id == id);
+        if (entity is null)
+            return NotFound(new { message = "Vínculo papel-permissão não encontrado." });
+
+        var roleStatus = await GetRoleRefStatusAsync(request.RoleId);
+        var permissionOk = await PermissionExistsAndActiveAsync(request.PermissionId);
+        if (roleStatus != RoleRefStatus.Ok || !permissionOk)
+        {
+            _logger.LogWarning(
+                "Atualização de vínculo {RolePermissionId} rejeitada: Role status={RoleStatus}, Permission ok={PermOk}.",
+                id, roleStatus, permissionOk);
+            return InvalidReferencesResultForUpdate(roleStatus, permissionOk);
+        }
+
+        if (await _db.RolePermissions.IgnoreQueryFilters()
+                .AnyAsync(rp => rp.Id != id && rp.RoleId == request.RoleId && rp.PermissionId == request.PermissionId))
+        {
+            _logger.LogWarning(
+                "Conflito ao atualizar vínculo {RolePermissionId}: par RoleId/PermissionId já existe.", id);
+            return UniquePairConflictResult();
+        }
+
+        entity.RoleId = request.RoleId;
+        entity.PermissionId = request.PermissionId;
+        entity.UpdatedAt = DateTime.UtcNow;
+
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+        {
+            _logger.LogWarning(ex, "Conflito de unicidade ao atualizar vínculo {RolePermissionId}.", id);
+            return UniquePairConflictResult();
+        }
+        catch (DbUpdateException ex) when (IsForeignKeyViolation(ex))
+        {
+            _logger.LogWarning(ex, "Violação de FK ao atualizar vínculo {RolePermissionId}.", id);
+            var r = await GetRoleRefStatusAsync(request.RoleId);
+            var p = await PermissionExistsAndActiveAsync(request.PermissionId);
+            return InvalidReferencesResultForUpdate(r, p);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro inesperado ao persistir atualização do vínculo {RolePermissionId}.", id);
+            throw;
+        }
+
+        _logger.LogInformation("Vínculo papel-permissão atualizado: {RolePermissionId}.", id);
+        return Ok(ToResponse(entity));
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> DeleteById(Guid id)
+    {
+        var entity = await _db.RolePermissions.FirstOrDefaultAsync(rp => rp.Id == id);
+        if (entity is null)
+            return NotFound(new { message = "Vínculo papel-permissão não encontrado." });
+
+        entity.DeletedAt = DateTime.UtcNow;
+        entity.UpdatedAt = DateTime.UtcNow;
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro inesperado ao excluir (soft) vínculo {RolePermissionId}.", id);
+            throw;
+        }
+
+        _logger.LogInformation("Vínculo papel-permissão excluído (soft): {RolePermissionId}.", id);
+        return NoContent();
+    }
+
+    [HttpPatch("{id:guid}/restore")]
+    public async Task<IActionResult> RestoreById(Guid id)
+    {
+        var entity = await _db.RolePermissions
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(rp => rp.Id == id && rp.DeletedAt != null);
+
+        if (entity is null)
+            return NotFound(new { message = "Vínculo papel-permissão não encontrado ou não está deletado." });
+
+        if (await GetRoleRefStatusAsync(entity.RoleId) != RoleRefStatus.Ok
+            || !await PermissionExistsAndActiveAsync(entity.PermissionId))
+        {
+            return BadRequest(new
+            {
+                message = "Não é possível restaurar o vínculo: o papel ou a permissão vinculada não está mais disponível."
+            });
+        }
+
+        entity.DeletedAt = null;
+        entity.UpdatedAt = DateTime.UtcNow;
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro inesperado ao restaurar vínculo {RolePermissionId}.", id);
+            throw;
+        }
+
+        _logger.LogInformation("Vínculo papel-permissão restaurado: {RolePermissionId}.", id);
+        return Ok(ToResponse(entity));
+    }
+}

--- a/AuthService/Data/AppDbContext.cs
+++ b/AuthService/Data/AppDbContext.cs
@@ -14,6 +14,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<AppPermission> Permissions => Set<AppPermission>();
     public DbSet<AppUserRole> UserRoles => Set<AppUserRole>();
     public DbSet<AppUserPermission> UserPermissions => Set<AppUserPermission>();
+    public DbSet<AppRolePermission> RolePermissions => Set<AppRolePermission>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -56,6 +57,19 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             entity.HasOne<User>()
                 .WithMany()
                 .HasForeignKey(e => e.UserId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity.HasOne<AppPermission>()
+                .WithMany()
+                .HasForeignKey(e => e.PermissionId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<AppRolePermission>(entity =>
+        {
+            entity.HasOne<AppRole>()
+                .WithMany()
+                .HasForeignKey(e => e.RoleId)
                 .OnDelete(DeleteBehavior.Restrict);
 
             entity.HasOne<AppPermission>()

--- a/AuthService/Data/Migrations/20260329170000_CreateRolePermissionsTable.Designer.cs
+++ b/AuthService/Data/Migrations/20260329170000_CreateRolePermissionsTable.Designer.cs
@@ -4,6 +4,7 @@ using AuthService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AuthService.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260329170000_CreateRolePermissionsTable")]
+    partial class CreateRolePermissionsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AuthService/Data/Migrations/20260329170000_CreateRolePermissionsTable.cs
+++ b/AuthService/Data/Migrations/20260329170000_CreateRolePermissionsTable.cs
@@ -1,0 +1,71 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AuthService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class CreateRolePermissionsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RolePermissions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    RoleId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PermissionId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RolePermissions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RolePermissions_Permissions_PermissionId",
+                        column: x => x.PermissionId,
+                        principalTable: "Permissions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_RolePermissions_Roles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "Roles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RolePermissions_DeletedAt",
+                table: "RolePermissions",
+                column: "DeletedAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RolePermissions_PermissionId",
+                table: "RolePermissions",
+                column: "PermissionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RolePermissions_RoleId",
+                table: "RolePermissions",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_RolePermissions_RoleId_PermissionId",
+                table: "RolePermissions",
+                columns: new[] { "RoleId", "PermissionId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RolePermissions");
+        }
+    }
+}

--- a/AuthService/Models/AppRolePermission.cs
+++ b/AuthService/Models/AppRolePermission.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace AuthService.Models;
+
+[Index(nameof(DeletedAt), Name = "IX_RolePermissions_DeletedAt")]
+[Index(nameof(RoleId), Name = "IX_RolePermissions_RoleId")]
+[Index(nameof(PermissionId), Name = "IX_RolePermissions_PermissionId")]
+[Index(nameof(RoleId), nameof(PermissionId), IsUnique = true, Name = "UX_RolePermissions_RoleId_PermissionId")]
+[Table("RolePermissions")]
+public class AppRolePermission : ISoftDelete
+{
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    public Guid RoleId { get; set; }
+
+    [Required]
+    public Guid PermissionId { get; set; }
+
+    [Required]
+    public DateTime CreatedAt { get; set; }
+
+    [Required]
+    public DateTime UpdatedAt { get; set; }
+
+    public DateTime? DeletedAt { get; set; }
+}


### PR DESCRIPTION
## Resumo
Implementa o recurso **RolePermissions**: modelo, migration, persistência no `AppDbContext`, API REST em `/roles-permissions` e testes de integração no mesmo padrão de `users-permissions`.

## Alterações realizadas
- Entidade `AppRolePermission` / tabela `RolePermissions` com `Id` (Guid), `RoleId`, `PermissionId`, `CreatedAt`, `UpdatedAt`, `DeletedAt` (soft delete)
- FKs para `Roles` e `Permissions`, índice único `(RoleId, PermissionId)`, índices em `DeletedAt`, `RoleId` e `PermissionId`
- `RolePermissionsController`: POST, GET, GET por id, PUT, DELETE (soft) e PATCH restore, com logs e tratamento de conflito/ FK
- `RolePermissionsApiTests`: fluxo principal, duplicidade, referências inválidas, concorrência, listagem com filtros de pai removido, restore e update conflitante

## Riscos
- Migration nova exige `dotnet ef database update` (ou deploy com migrate) no ambiente alvo
- Comportamento alinhado a `UsersPermissions`: vínculos só aparecem se papel e permissão estiverem ativos (não soft-deleted)

## Evidências de teste
- `docker run --rm -v "<repo>:/src" -w /src mcr.microsoft.com/dotnet/sdk:10.0 dotnet build AuthService/AuthService.csproj -c Release` — sucesso (0 erros)
- `docker run ... dotnet build AuthService.Tests/AuthService.Tests.csproj -c Release` — sucesso (0 erros)
- `dotnet format` em AuthService e AuthService.Tests com `--verify-no-changes` — sucesso
- Testes de integração (`dotnet test`) dependem de `AUTH_SERVICE_TEST_SQL_BASE` apontando para SQL Server; não executados neste ambiente sem essa variável

Closes #19

Made with [Cursor](https://cursor.com)