### PR TITLE
#21 | Implementar rotas de autenticação do recurso Auth

### DIFF
--- a/AuthService.Tests/AuthApiTests.cs
+++ b/AuthService.Tests/AuthApiTests.cs
@@ -1,0 +1,196 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AuthService.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AuthService.Tests;
+
+public class AuthApiTests : IAsyncLifetime
+{
+    private WebAppFactory _factory = null!;
+    private HttpClient _client = null!;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    public Task InitializeAsync()
+    {
+        _factory = new WebAppFactory();
+        _client = _factory.CreateClient();
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private static object LoginBody(string email, string password) => new { email, password };
+
+    private sealed class LoginDto
+    {
+        public string Token { get; set; } = string.Empty;
+        public DateTime ExpiresAtUtc { get; set; }
+    }
+
+    private sealed class VerifyDto
+    {
+        public AuthUserDto? User { get; set; }
+        public List<Guid>? PermissionIds { get; set; }
+    }
+
+    private sealed class AuthUserDto
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public int Identity { get; set; }
+        public bool Active { get; set; }
+    }
+
+    [Fact]
+    public async Task Login_ValidCredentials_ReturnsToken()
+    {
+        await _client.PostAsJsonAsync("/users",
+            new { name = "Auth User", email = "auth.user@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            JsonOptions);
+
+        var response = await _client.PostAsJsonAsync("/auth/login",
+            LoginBody("auth.user@example.com", "SenhaSegura1!"), JsonOptions);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var dto = await response.Content.ReadFromJsonAsync<LoginDto>(JsonOptions);
+        Assert.NotNull(dto);
+        Assert.False(string.IsNullOrWhiteSpace(dto.Token));
+        Assert.True(dto.ExpiresAtUtc > DateTime.UtcNow);
+    }
+
+    [Fact]
+    public async Task Login_NormalizesEmailCase()
+    {
+        await _client.PostAsJsonAsync("/users",
+            new { name = "Case User", email = "case.auth@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            JsonOptions);
+
+        var response = await _client.PostAsJsonAsync("/auth/login",
+            LoginBody("  CASE.AUTH@EXAMPLE.COM  ", "SenhaSegura1!"), JsonOptions);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WrongPassword_ReturnsUnauthorized()
+    {
+        await _client.PostAsJsonAsync("/users",
+            new { name = "U2", email = "u2@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            JsonOptions);
+
+        var response = await _client.PostAsJsonAsync("/auth/login",
+            LoginBody("u2@example.com", "outraSenha"), JsonOptions);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_InactiveUser_ReturnsUnauthorized()
+    {
+        await _client.PostAsJsonAsync("/users",
+            new { name = "Inativo", email = "inativo@example.com", password = "SenhaSegura1!", identity = 1, active = false },
+            JsonOptions);
+
+        var response = await _client.PostAsJsonAsync("/auth/login",
+            LoginBody("inativo@example.com", "SenhaSegura1!"), JsonOptions);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_InvalidPayload_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsJsonAsync("/auth/login", new { email = "", password = "" }, JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task VerifyToken_WithoutHeader_ReturnsUnauthorized()
+    {
+        var response = await _client.GetAsync("/auth/verify-token");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task VerifyToken_ValidToken_ReturnsUserAndPermissions()
+    {
+        await _client.PostAsJsonAsync("/users",
+            new { name = "V User", email = "v.user@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            JsonOptions);
+
+        var login = await _client.PostAsJsonAsync("/auth/login",
+            LoginBody("v.user@example.com", "SenhaSegura1!"), JsonOptions);
+        var loginDto = await login.Content.ReadFromJsonAsync<LoginDto>(JsonOptions);
+        Assert.NotNull(loginDto);
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        var response = await _client.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<VerifyDto>(JsonOptions);
+        Assert.NotNull(body?.User);
+        Assert.Equal("v.user@example.com", body.User.Email);
+        Assert.NotNull(body.PermissionIds);
+    }
+
+    [Fact]
+    public async Task Logout_ThenVerifyToken_ReturnsUnauthorized()
+    {
+        await _client.PostAsJsonAsync("/users",
+            new { name = "L User", email = "l.user@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            JsonOptions);
+
+        var login = await _client.PostAsJsonAsync("/auth/login",
+            LoginBody("l.user@example.com", "SenhaSegura1!"), JsonOptions);
+        var loginDto = await login.Content.ReadFromJsonAsync<LoginDto>(JsonOptions);
+        Assert.NotNull(loginDto);
+        var token = loginDto.Token;
+
+        using (var logoutReq = new HttpRequestMessage(HttpMethod.Get, "/auth/logout"))
+        {
+            logoutReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            var logoutRes = await _client.SendAsync(logoutReq);
+            Assert.Equal(HttpStatusCode.OK, logoutRes.StatusCode);
+        }
+
+        using (var verifyReq = new HttpRequestMessage(HttpMethod.Get, "/auth/verify-token"))
+        {
+            verifyReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            var verifyRes = await _client.SendAsync(verifyReq);
+            Assert.Equal(HttpStatusCode.Unauthorized, verifyRes.StatusCode);
+        }
+
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var row = await db.Users.AsNoTracking().FirstAsync(u => u.Email == "l.user@example.com");
+            Assert.True(row.TokenVersion >= 1);
+        }
+    }
+
+    [Fact]
+    public async Task VerifyToken_InvalidBearerToken_ReturnsUnauthorized()
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "token-invalido");
+        var response = await _client.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+}

--- a/AuthService.Tests/WebAppFactory.cs
+++ b/AuthService.Tests/WebAppFactory.cs
@@ -47,7 +47,9 @@ public class WebAppFactory : WebApplicationFactory<Program>
         {
             config.AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["ConnectionStrings:DefaultConnection"] = _appConnectionString
+                ["ConnectionStrings:DefaultConnection"] = _appConnectionString,
+                ["Auth:Jwt:Secret"] = "integration-tests-jwt-secret-key-32chars!!",
+                ["Auth:Jwt:ExpirationMinutes"] = "60"
             });
         });
     }

--- a/AuthService/Auth/BearerAuthenticationDefaults.cs
+++ b/AuthService/Auth/BearerAuthenticationDefaults.cs
@@ -1,0 +1,6 @@
+namespace AuthService.Auth;
+
+public static class BearerAuthenticationDefaults
+{
+    public const string AuthenticationScheme = "Bearer";
+}

--- a/AuthService/Auth/IJwtTokenService.cs
+++ b/AuthService/Auth/IJwtTokenService.cs
@@ -1,0 +1,7 @@
+namespace AuthService.Auth;
+
+public interface IJwtTokenService
+{
+    /// <summary>Emite JWT com claims <c>sub</c> (user id) e <c>tv</c> (token version).</summary>
+    string CreateAccessToken(Guid userId, int tokenVersion, out DateTimeOffset expiresAt);
+}

--- a/AuthService/Auth/JwtBearerAuthenticationHandler.cs
+++ b/AuthService/Auth/JwtBearerAuthenticationHandler.cs
@@ -1,0 +1,117 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using AuthService.Data;
+using JWT.Algorithms;
+using JWT.Builder;
+using JWT.Exceptions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+namespace AuthService.Auth;
+
+public sealed class JwtBearerAuthenticationHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder,
+    IOptions<JwtOptions> jwtOptions,
+    IServiceProvider services)
+    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    private readonly JwtOptions _jwt = jwtOptions.Value;
+    private readonly IServiceProvider _services = services;
+
+    protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue("Authorization", out var values))
+            return AuthenticateResult.NoResult();
+
+        var auth = values.ToString();
+        if (string.IsNullOrWhiteSpace(auth) || !auth.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            return AuthenticateResult.Fail("Cabeçalho Authorization inválido.");
+
+        var token = auth["Bearer ".Length..].Trim();
+        if (string.IsNullOrEmpty(token))
+            return AuthenticateResult.Fail("Token ausente.");
+
+        if (string.IsNullOrWhiteSpace(_jwt.Secret) || _jwt.Secret.Length < 32)
+        {
+            Logger.LogError("Auth:Jwt:Secret inválido ou ausente.");
+            return AuthenticateResult.Fail("Configuração de autenticação inválida.");
+        }
+
+        IDictionary<string, object> payload;
+        try
+        {
+            payload = JwtBuilder.Create()
+                .WithAlgorithm(new HMACSHA256Algorithm())
+                .WithSecret(_jwt.Secret)
+                .MustVerifySignature()
+                .Decode<IDictionary<string, object>>(token);
+        }
+        catch (TokenExpiredException)
+        {
+            return AuthenticateResult.Fail("Token expirado.");
+        }
+        catch (SignatureVerificationException)
+        {
+            return AuthenticateResult.Fail("Assinatura do token inválida.");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Falha ao validar JWT.");
+            return AuthenticateResult.Fail("Token inválido.");
+        }
+
+        if (!payload.TryGetValue("sub", out var subObj) || subObj?.ToString() is not { } subStr
+            || !Guid.TryParse(subStr, out var userId))
+            return AuthenticateResult.Fail("Token sem identificador de usuário válido.");
+
+        if (!payload.TryGetValue("tv", out var tvObj) || !TryGetInt32(tvObj, out var tokenVersionClaim))
+            return AuthenticateResult.Fail("Token sem versão de sessão válida.");
+
+        await using var scope = _services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var user = await db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == userId);
+        if (user is null)
+            return AuthenticateResult.Fail("Usuário não encontrado.");
+
+        if (!user.Active)
+            return AuthenticateResult.Fail("Usuário inativo.");
+
+        if (user.TokenVersion != tokenVersionClaim)
+            return AuthenticateResult.Fail("Token revogado.");
+
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, userId.ToString("D")),
+            new(ClaimTypes.Email, user.Email),
+            new(ClaimTypes.Name, user.Name)
+        };
+        var identity = new ClaimsIdentity(claims, Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        return AuthenticateResult.Success(new AuthenticationTicket(principal, Scheme.Name));
+    }
+
+    private static bool TryGetInt32(object? value, out int n)
+    {
+        n = 0;
+        switch (value)
+        {
+            case int i:
+                n = i;
+                return true;
+            case long l when l is >= int.MinValue and <= int.MaxValue:
+                n = (int)l;
+                return true;
+            case double d when d is >= int.MinValue and <= int.MaxValue:
+                n = (int)d;
+                return true;
+            default:
+                return int.TryParse(
+                    value?.ToString(),
+                    System.Globalization.NumberStyles.Integer,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out n);
+        }
+    }
+}

--- a/AuthService/Auth/JwtOptions.cs
+++ b/AuthService/Auth/JwtOptions.cs
@@ -1,0 +1,12 @@
+namespace AuthService.Auth;
+
+public sealed class JwtOptions
+{
+    public const string SectionName = "Auth:Jwt";
+
+    /// <summary>Segredo HMAC (mínimo recomendado: 32 caracteres).</summary>
+    public string Secret { get; set; } = string.Empty;
+
+    /// <summary>Validade do access token em minutos.</summary>
+    public int ExpirationMinutes { get; set; } = 60;
+}

--- a/AuthService/Auth/JwtTokenService.cs
+++ b/AuthService/Auth/JwtTokenService.cs
@@ -1,0 +1,29 @@
+using JWT.Algorithms;
+using JWT.Builder;
+using Microsoft.Extensions.Options;
+
+namespace AuthService.Auth;
+
+public sealed class JwtTokenService(IOptions<JwtOptions> options) : IJwtTokenService
+{
+    private readonly JwtOptions _options = options.Value;
+
+    public string CreateAccessToken(Guid userId, int tokenVersion, out DateTimeOffset expiresAt)
+    {
+        if (string.IsNullOrWhiteSpace(_options.Secret) || _options.Secret.Length < 32)
+            throw new InvalidOperationException("Auth:Jwt:Secret deve ter pelo menos 32 caracteres.");
+
+        var minutes = _options.ExpirationMinutes <= 0 ? 60 : _options.ExpirationMinutes;
+        expiresAt = DateTimeOffset.UtcNow.AddMinutes(minutes);
+        var exp = expiresAt.ToUnixTimeSeconds();
+
+        return JwtBuilder.Create()
+            .WithAlgorithm(new HMACSHA256Algorithm())
+            .WithSecret(_options.Secret)
+            .AddClaim("sub", userId.ToString("D"))
+            .AddClaim("tv", tokenVersion)
+            .AddClaim("exp", exp)
+            .AddClaim("iat", DateTimeOffset.UtcNow.ToUnixTimeSeconds())
+            .Encode();
+    }
+}

--- a/AuthService/AuthService.csproj
+++ b/AuthService/AuthService.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="JWT" Version="11.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/AuthService/Controllers/Auth/AuthController.cs
+++ b/AuthService/Controllers/Auth/AuthController.cs
@@ -1,0 +1,141 @@
+using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+using AuthService.Auth;
+using AuthService.Data;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using UserEntity = AuthService.Models.User;
+
+namespace AuthService.Controllers.Auth;
+
+[ApiController]
+[Route("auth")]
+public class AuthController : ControllerBase
+{
+    private readonly AppDbContext _db;
+    private readonly IJwtTokenService _jwt;
+    private readonly ILogger<AuthController> _logger;
+
+    public AuthController(AppDbContext db, IJwtTokenService jwt, ILogger<AuthController> logger)
+    {
+        _db = db;
+        _jwt = jwt;
+        _logger = logger;
+    }
+
+    public class LoginRequest
+    {
+        [Required(ErrorMessage = "Email é obrigatório.")]
+        [EmailAddress(ErrorMessage = "Email inválido.")]
+        [MaxLength(320)]
+        public string Email { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Password é obrigatório.")]
+        [MaxLength(60)]
+        public string Password { get; set; } = string.Empty;
+    }
+
+    public record LoginResponse(string Token, DateTime ExpiresAtUtc);
+
+    public record AuthUserResponse(
+        Guid Id,
+        string Name,
+        string Email,
+        int Identity,
+        bool Active,
+        DateTime CreatedAt,
+        DateTime UpdatedAt);
+
+    public record VerifyTokenResponse(AuthUserResponse User, IReadOnlyList<Guid> PermissionIds);
+
+    private static AuthUserResponse ToAuthUser(UserEntity u) =>
+        new(u.Id, u.Name, u.Email, u.Identity, u.Active, u.CreatedAt, u.UpdatedAt);
+
+    private async Task<IReadOnlyList<Guid>> GetEffectivePermissionIdsAsync(Guid userId)
+    {
+        var direct = await _db.UserPermissions
+            .AsNoTracking()
+            .Where(up => up.UserId == userId)
+            .Select(up => up.PermissionId)
+            .ToListAsync();
+
+        var viaRoles = await _db.UserRoles
+            .AsNoTracking()
+            .Where(ur => ur.UserId == userId)
+            .Join(
+                _db.RolePermissions.AsNoTracking(),
+                ur => ur.RoleId,
+                rp => rp.RoleId,
+                (_, rp) => rp.PermissionId)
+            .ToListAsync();
+
+        return direct.Concat(viaRoles).Distinct().OrderBy(x => x).ToList();
+    }
+
+    [HttpPost("login")]
+    [AllowAnonymous]
+    public async Task<IActionResult> Login([FromBody] LoginRequest request)
+    {
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        var email = request.Email.Trim().ToLowerInvariant();
+        var password = request.Password.Trim();
+
+        if (string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(password))
+            return Unauthorized(new { message = "Credenciais inválidas." });
+
+        var user = await _db.Users.FirstOrDefaultAsync(u => u.Email == email);
+        if (user is null || user.Password != password)
+        {
+            _logger.LogWarning("Tentativa de login falhou para o email {Email}.", email);
+            return Unauthorized(new { message = "Credenciais inválidas." });
+        }
+
+        if (!user.Active)
+        {
+            _logger.LogWarning("Tentativa de login para usuário inativo {UserId}.", user.Id);
+            return Unauthorized(new { message = "Credenciais inválidas." });
+        }
+
+        var token = _jwt.CreateAccessToken(user.Id, user.TokenVersion, out var expiresAt);
+        return Ok(new LoginResponse(token, expiresAt.UtcDateTime));
+    }
+
+    [HttpGet("verify-token")]
+    [Authorize(AuthenticationSchemes = BearerAuthenticationDefaults.AuthenticationScheme)]
+    public async Task<IActionResult> VerifyToken()
+    {
+        var sub = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrEmpty(sub) || !Guid.TryParse(sub, out var userId))
+            return Unauthorized(new { message = "Token inválido." });
+
+        var user = await _db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == userId);
+        if (user is null)
+            return Unauthorized(new { message = "Usuário não encontrado." });
+
+        var permissionIds = await GetEffectivePermissionIdsAsync(userId);
+        return Ok(new VerifyTokenResponse(ToAuthUser(user), permissionIds));
+    }
+
+    [HttpGet("logout")]
+    [Authorize(AuthenticationSchemes = BearerAuthenticationDefaults.AuthenticationScheme)]
+    public async Task<IActionResult> Logout()
+    {
+        var sub = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrEmpty(sub) || !Guid.TryParse(sub, out var userId))
+            return Unauthorized(new { message = "Token inválido." });
+
+        var user = await _db.Users.FirstOrDefaultAsync(u => u.Id == userId);
+        if (user is null)
+            return Unauthorized(new { message = "Usuário não encontrado." });
+
+        user.TokenVersion++;
+        user.UpdatedAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+
+        _logger.LogInformation("Logout concluído para o usuário {UserId}.", userId);
+        return Ok(new { message = "Sessão encerrada." });
+    }
+}

--- a/AuthService/Data/Migrations/20260329174310_AddUserTokenVersionForAuth.Designer.cs
+++ b/AuthService/Data/Migrations/20260329174310_AddUserTokenVersionForAuth.Designer.cs
@@ -4,6 +4,7 @@ using AuthService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AuthService.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260329174310_AddUserTokenVersionForAuth")]
+    partial class AddUserTokenVersionForAuth
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AuthService/Data/Migrations/20260329174310_AddUserTokenVersionForAuth.cs
+++ b/AuthService/Data/Migrations/20260329174310_AddUserTokenVersionForAuth.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AuthService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserTokenVersionForAuth : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "TokenVersion",
+                table: "Users",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TokenVersion",
+                table: "Users");
+        }
+    }
+}

--- a/AuthService/Models/User.cs
+++ b/AuthService/Models/User.cs
@@ -30,6 +30,12 @@ public class User : ISoftDelete
     [Required]
     public bool Active { get; set; } = true;
 
+    /// <summary>
+    /// Incrementado no logout para invalidar JWTs emitidos anteriormente (claim <c>tv</c>).
+    /// </summary>
+    [Required]
+    public int TokenVersion { get; set; }
+
     [Required]
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 

--- a/AuthService/Program.cs
+++ b/AuthService/Program.cs
@@ -1,4 +1,6 @@
+using AuthService.Auth;
 using AuthService.Data;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -7,6 +9,18 @@ var builder = WebApplication.CreateBuilder(args);
 // Em "Testing", a connection string vem do WebApplicationFactory (banco dedicado por execução de teste).
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+builder.Services.Configure<JwtOptions>(builder.Configuration.GetSection(JwtOptions.SectionName));
+builder.Services.AddSingleton<IJwtTokenService, JwtTokenService>();
+builder.Services.AddAuthentication(options =>
+    {
+        options.DefaultAuthenticateScheme = BearerAuthenticationDefaults.AuthenticationScheme;
+        options.DefaultChallengeScheme = BearerAuthenticationDefaults.AuthenticationScheme;
+    })
+    .AddScheme<AuthenticationSchemeOptions, JwtBearerAuthenticationHandler>(
+        BearerAuthenticationDefaults.AuthenticationScheme,
+        _ => { });
+builder.Services.AddAuthorization();
 
 builder.Services.AddControllers();
 
@@ -26,6 +40,7 @@ if (!app.Environment.IsEnvironment("Testing"))
     app.UseHttpsRedirection();
 }
 
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();

--- a/AuthService/appsettings.Development.json
+++ b/AuthService/appsettings.Development.json
@@ -7,5 +7,11 @@
   },
   "ConnectionStrings": {
     "DefaultConnection": "Server=localhost,1433;Database=AuthServiceDb;User Id=sa;Password=DevPassword123!;TrustServerCertificate=True"
+  },
+  "Auth": {
+    "Jwt": {
+      "Secret": "dev-only-change-in-production-min-32-chars!!",
+      "ExpirationMinutes": 60
+    }
   }
 }

--- a/AuthService/appsettings.json
+++ b/AuthService/appsettings.json
@@ -5,5 +5,11 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Auth": {
+    "Jwt": {
+      "Secret": "dev-only-change-in-production-min-32-chars!!",
+      "ExpirationMinutes": 60
+    }
+  }
 }


### PR DESCRIPTION
## Resumo
Implementa o fluxo de autenticação com JWT (biblioteca [jwt-dotnet/jwt](https://github.com/jwt-dotnet/jwt)): login por email/senha, validação de token com retorno do usuário e permissões efetivas, e logout com invalidação de tokens emitidos anteriormente.

## Alterações realizadas
- Pacote `JWT` (11.0.0); emissão e validação de JWT com HMAC-SHA256 via `JwtBuilder`.
- `POST /auth/login` (anônimo): normalização de email; `401` com mensagem genérica em falha; resposta `{ token, expiresAtUtc }`.
- `GET /auth/verify-token` (Bearer): retorno `{ user, permissionIds }` (união de permissões diretas e via papéis).
- `GET /auth/logout` (Bearer): incrementa `Users.TokenVersion`; tokens com claim `tv` desatualizada passam a ser rejeitados.
- Migration `AddUserTokenVersionForAuth`; configuração `Auth:Jwt:Secret` (mín. 32 caracteres) e `Auth:Jwt:ExpirationMinutes`.
- `WebAppFactory`: segredo JWT fixo para testes; testes de integração em `AuthApiTests`.

## Riscos
- **Segredo JWT**: valor padrão em `appsettings*` é apenas para desenvolvimento; produção deve usar segredo forte via variável de ambiente/config segura.
- **Senhas**: o projeto já persiste senha em texto plano no CRUD de usuários; o login apenas replica a mesma comparação (sem hash). Melhoria de hashing fica fora desta entrega.
- **Logout global por usuário**: incrementar `TokenVersion` invalida **todos** os JWTs daquele usuário (comportamento usual para "sair em todos os dispositivos").

## Evidências de teste
```bash
export AUTH_SERVICE_TEST_SQL_BASE="Server=127.0.0.1,1433;User Id=sa;Password=...;TrustServerCertificate=True"
docker run --rm --network host -e AUTH_SERVICE_TEST_SQL_BASE -v "$PWD:/src" -w /src mcr.microsoft.com/dotnet/sdk:10.0 \
  dotnet test AuthService.Tests/AuthService.Tests.csproj --verbosity minimal
```
Resultado local: **140 testes passando** (inclui `AuthApiTests`).

Closes #21

Made with [Cursor](https://cursor.com)