### PR TITLE
#25 | Documentar rotas com Swagger e adicionar prefixo /v1

### DIFF
--- a/AuthService.Tests/ApiVersioningAndDocsTests.cs
+++ b/AuthService.Tests/ApiVersioningAndDocsTests.cs
@@ -1,0 +1,67 @@
+using System.Net;
+using Xunit;
+
+namespace AuthService.Tests;
+
+/// <summary>Valida prefixo global /v1 e documentação Swagger em /docs (issue #25).</summary>
+public class ApiVersioningAndDocsTests : IAsyncLifetime
+{
+    private WebAppFactory _factory = null!;
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        _factory = new WebAppFactory();
+        _client = _factory.CreateClient();
+        await Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Health_WithoutVersionPrefix_IsNotPublicApi()
+    {
+        // FallbackPolicy exige JWT; rota sem /v1 não existe como endpoint versionado → desafio 401.
+        var response = await _client.GetAsync("/health");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Health_WithV1Prefix_ReturnsOk()
+    {
+        var response = await _client.GetAsync("/v1/health");
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Users_WithoutVersionPrefix_IsNotPublicApi()
+    {
+        var response = await _client.GetAsync("/users");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SwaggerJson_ContainsVersionedPaths()
+    {
+        var response = await _client.GetAsync("/swagger/v1/swagger.json");
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync();
+        Assert.Contains("\"/v1/", json, StringComparison.Ordinal);
+        Assert.Contains("/v1/users", json, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Docs_ReturnsSwaggerUi()
+    {
+        var response = await _client.GetAsync("/docs");
+        response.EnsureSuccessStatusCode();
+        var html = await response.Content.ReadAsStringAsync();
+        Assert.Contains("swagger", html, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/AuthService.Tests/AuthApiTests.cs
+++ b/AuthService.Tests/AuthApiTests.cs
@@ -55,11 +55,11 @@ public class AuthApiTests : IAsyncLifetime
     [Fact]
     public async Task Login_ValidCredentials_ReturnsToken()
     {
-        await _admin.PostAsJsonAsync("/users",
+        await _admin.PostAsJsonAsync("/v1/users",
             new { name = "Auth User", email = "auth.user@example.com", password = "SenhaSegura1!", identity = 1, active = true },
             TestApiClient.JsonOptions);
 
-        var response = await _anon.PostAsJsonAsync("/auth/login",
+        var response = await _anon.PostAsJsonAsync("/v1/auth/login",
             LoginBody("auth.user@example.com", "SenhaSegura1!"), TestApiClient.JsonOptions);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -72,11 +72,11 @@ public class AuthApiTests : IAsyncLifetime
     [Fact]
     public async Task Login_NormalizesEmailCase()
     {
-        await _admin.PostAsJsonAsync("/users",
+        await _admin.PostAsJsonAsync("/v1/users",
             new { name = "Case User", email = "case.auth@example.com", password = "SenhaSegura1!", identity = 1, active = true },
             TestApiClient.JsonOptions);
 
-        var response = await _anon.PostAsJsonAsync("/auth/login",
+        var response = await _anon.PostAsJsonAsync("/v1/auth/login",
             LoginBody("  CASE.AUTH@EXAMPLE.COM  ", "SenhaSegura1!"), TestApiClient.JsonOptions);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -85,11 +85,11 @@ public class AuthApiTests : IAsyncLifetime
     [Fact]
     public async Task Login_WrongPassword_ReturnsUnauthorized()
     {
-        await _admin.PostAsJsonAsync("/users",
+        await _admin.PostAsJsonAsync("/v1/users",
             new { name = "U2", email = "u2@example.com", password = "SenhaSegura1!", identity = 1, active = true },
             TestApiClient.JsonOptions);
 
-        var response = await _anon.PostAsJsonAsync("/auth/login",
+        var response = await _anon.PostAsJsonAsync("/v1/auth/login",
             LoginBody("u2@example.com", "outraSenha"), TestApiClient.JsonOptions);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -98,11 +98,11 @@ public class AuthApiTests : IAsyncLifetime
     [Fact]
     public async Task Login_InactiveUser_ReturnsUnauthorized()
     {
-        await _admin.PostAsJsonAsync("/users",
+        await _admin.PostAsJsonAsync("/v1/users",
             new { name = "Inativo", email = "inativo@example.com", password = "SenhaSegura1!", identity = 1, active = false },
             TestApiClient.JsonOptions);
 
-        var response = await _anon.PostAsJsonAsync("/auth/login",
+        var response = await _anon.PostAsJsonAsync("/v1/auth/login",
             LoginBody("inativo@example.com", "SenhaSegura1!"), TestApiClient.JsonOptions);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -111,30 +111,30 @@ public class AuthApiTests : IAsyncLifetime
     [Fact]
     public async Task Login_InvalidPayload_ReturnsBadRequest()
     {
-        var response = await _anon.PostAsJsonAsync("/auth/login", new { email = "", password = "" }, TestApiClient.JsonOptions);
+        var response = await _anon.PostAsJsonAsync("/v1/auth/login", new { email = "", password = "" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]
     public async Task VerifyToken_WithoutHeader_ReturnsUnauthorized()
     {
-        var response = await _anon.GetAsync("/auth/verify-token");
+        var response = await _anon.GetAsync("/v1/auth/verify-token");
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
     [Fact]
     public async Task VerifyToken_ValidToken_ReturnsUserAndPermissions()
     {
-        await _admin.PostAsJsonAsync("/users",
+        await _admin.PostAsJsonAsync("/v1/users",
             new { name = "V User", email = "v.user@example.com", password = "SenhaSegura1!", identity = 1, active = true },
             TestApiClient.JsonOptions);
 
-        var login = await _anon.PostAsJsonAsync("/auth/login",
+        var login = await _anon.PostAsJsonAsync("/v1/auth/login",
             LoginBody("v.user@example.com", "SenhaSegura1!"), TestApiClient.JsonOptions);
         var loginDto = await login.Content.ReadFromJsonAsync<LoginResponseDto>(TestApiClient.JsonOptions);
         Assert.NotNull(loginDto);
 
-        using var req = new HttpRequestMessage(HttpMethod.Get, "/auth/verify-token");
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/v1/auth/verify-token");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
         var response = await _anon.SendAsync(req);
 
@@ -148,24 +148,24 @@ public class AuthApiTests : IAsyncLifetime
     [Fact]
     public async Task Logout_ThenVerifyToken_ReturnsUnauthorized()
     {
-        await _admin.PostAsJsonAsync("/users",
+        await _admin.PostAsJsonAsync("/v1/users",
             new { name = "L User", email = "l.user@example.com", password = "SenhaSegura1!", identity = 1, active = true },
             TestApiClient.JsonOptions);
 
-        var login = await _anon.PostAsJsonAsync("/auth/login",
+        var login = await _anon.PostAsJsonAsync("/v1/auth/login",
             LoginBody("l.user@example.com", "SenhaSegura1!"), TestApiClient.JsonOptions);
         var loginDto = await login.Content.ReadFromJsonAsync<LoginResponseDto>(TestApiClient.JsonOptions);
         Assert.NotNull(loginDto);
         var token = loginDto.Token;
 
-        using (var logoutReq = new HttpRequestMessage(HttpMethod.Get, "/auth/logout"))
+        using (var logoutReq = new HttpRequestMessage(HttpMethod.Get, "/v1/auth/logout"))
         {
             logoutReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
             var logoutRes = await _anon.SendAsync(logoutReq);
             Assert.Equal(HttpStatusCode.OK, logoutRes.StatusCode);
         }
 
-        using (var verifyReq = new HttpRequestMessage(HttpMethod.Get, "/auth/verify-token"))
+        using (var verifyReq = new HttpRequestMessage(HttpMethod.Get, "/v1/auth/verify-token"))
         {
             verifyReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
             var verifyRes = await _anon.SendAsync(verifyReq);
@@ -183,7 +183,7 @@ public class AuthApiTests : IAsyncLifetime
     [Fact]
     public async Task VerifyToken_InvalidBearerToken_ReturnsUnauthorized()
     {
-        using var req = new HttpRequestMessage(HttpMethod.Get, "/auth/verify-token");
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/v1/auth/verify-token");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "token-invalido");
         var response = await _anon.SendAsync(req);
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -193,24 +193,24 @@ public class AuthApiTests : IAsyncLifetime
     public async Task Users_WithoutToken_ReturnsUnauthorized()
     {
         using var anon = _factory.CreateClient();
-        var response = await anon.GetAsync("/users");
+        var response = await anon.GetAsync("/v1/users");
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
     [Fact]
     public async Task Users_WithValidTokenButWithoutUsersRead_ReturnsForbidden()
     {
-        await _admin.PostAsJsonAsync("/users",
+        await _admin.PostAsJsonAsync("/v1/users",
             new { name = "Sem Users.Read", email = "sem.users.read@example.com", password = "SenhaSegura1!", identity = 1, active = true },
             TestApiClient.JsonOptions);
 
-        var login = await _anon.PostAsJsonAsync("/auth/login",
+        var login = await _anon.PostAsJsonAsync("/v1/auth/login",
             LoginBody("sem.users.read@example.com", "SenhaSegura1!"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.OK, login.StatusCode);
         var loginDto = await login.Content.ReadFromJsonAsync<LoginResponseDto>(TestApiClient.JsonOptions);
         Assert.NotNull(loginDto);
 
-        using var req = new HttpRequestMessage(HttpMethod.Get, "/users");
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/v1/users");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
         var response = await _anon.SendAsync(req);
 

--- a/AuthService.Tests/PermissionTypesApiTests.cs
+++ b/AuthService.Tests/PermissionTypesApiTests.cs
@@ -29,7 +29,7 @@ public class PermissionTypesApiTests : IAsyncLifetime
     public async Task Create_Post_ReturnsCreated_WithUtcTimestamps_AndNullDeletedAt()
     {
         var body = new { name = "Tipo X", code = "PT_X", description = "Opcional" };
-        var response = await _client.PostAsJsonAsync("/permissions/types", body, TestApiClient.JsonOptions);
+        var response = await _client.PostAsJsonAsync("/v1/permissions/types", body, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
         var dto = await response.Content.ReadFromJsonAsync<PermissionTypeDto>(TestApiClient.JsonOptions);
@@ -46,18 +46,18 @@ public class PermissionTypesApiTests : IAsyncLifetime
     [Fact]
     public async Task Create_DuplicateCode_ReturnsConflict()
     {
-        await _client.PostAsJsonAsync("/permissions/types", new { name = "A", code = "PT_ABC" }, TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/permissions/types", new { name = "A", code = "PT_ABC" }, TestApiClient.JsonOptions);
 
-        var response = await _client.PostAsJsonAsync("/permissions/types", new { name = "B", code = "PT_ABC" }, TestApiClient.JsonOptions);
+        var response = await _client.PostAsJsonAsync("/v1/permissions/types", new { name = "B", code = "PT_ABC" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
 
     [Fact]
     public async Task Create_DuplicateCode_NormalizesWhitespace_ReturnsConflict()
     {
-        await _client.PostAsJsonAsync("/permissions/types", new { name = "A", code = "PT_WS" }, TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/permissions/types", new { name = "A", code = "PT_WS" }, TestApiClient.JsonOptions);
 
-        var response = await _client.PostAsJsonAsync("/permissions/types",
+        var response = await _client.PostAsJsonAsync("/v1/permissions/types",
             new { name = "B", code = "  PT_WS  " }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
@@ -65,12 +65,12 @@ public class PermissionTypesApiTests : IAsyncLifetime
     [Fact]
     public async Task Update_DuplicateCode_NormalizesWhitespace_ReturnsConflict()
     {
-        await _client.PostAsJsonAsync("/permissions/types", new { name = "A", code = "PT_CA" }, TestApiClient.JsonOptions);
-        var b = await _client.PostAsJsonAsync("/permissions/types", new { name = "B", code = "PT_CB" }, TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/permissions/types", new { name = "A", code = "PT_CA" }, TestApiClient.JsonOptions);
+        var b = await _client.PostAsJsonAsync("/v1/permissions/types", new { name = "B", code = "PT_CB" }, TestApiClient.JsonOptions);
         var dtoB = await b.Content.ReadFromJsonAsync<PermissionTypeDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dtoB);
 
-        var put = await _client.PutAsJsonAsync($"/permissions/types/{dtoB.Id}",
+        var put = await _client.PutAsJsonAsync($"/v1/permissions/types/{dtoB.Id}",
             new { name = "B2", code = "  PT_CA  " }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, put.StatusCode);
     }
@@ -81,8 +81,8 @@ public class PermissionTypesApiTests : IAsyncLifetime
         const string code = "PT_CONCURRENT";
         var bodyA = new { name = "A", code };
         var bodyB = new { name = "B", code };
-        var t1 = _client.PostAsJsonAsync("/permissions/types", bodyA, TestApiClient.JsonOptions);
-        var t2 = _client.PostAsJsonAsync("/permissions/types", bodyB, TestApiClient.JsonOptions);
+        var t1 = _client.PostAsJsonAsync("/v1/permissions/types", bodyA, TestApiClient.JsonOptions);
+        var t2 = _client.PostAsJsonAsync("/v1/permissions/types", bodyB, TestApiClient.JsonOptions);
         await Task.WhenAll(t1, t2);
 
         var r1 = await t1;
@@ -95,25 +95,25 @@ public class PermissionTypesApiTests : IAsyncLifetime
     [Fact]
     public async Task Create_WhitespaceOnlyName_ReturnsBadRequest()
     {
-        var response = await _client.PostAsJsonAsync("/permissions/types", new { name = "   ", code = "PT_X1" }, TestApiClient.JsonOptions);
+        var response = await _client.PostAsJsonAsync("/v1/permissions/types", new { name = "   ", code = "PT_X1" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]
     public async Task Create_WhitespaceOnlyCode_ReturnsBadRequest()
     {
-        var response = await _client.PostAsJsonAsync("/permissions/types", new { name = "N1", code = "\t  " }, TestApiClient.JsonOptions);
+        var response = await _client.PostAsJsonAsync("/v1/permissions/types", new { name = "N1", code = "\t  " }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]
     public async Task Put_WhitespaceOnlyName_ReturnsBadRequest()
     {
-        var create = await _client.PostAsJsonAsync("/permissions/types", new { name = "S", code = "PT_W1" }, TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/permissions/types", new { name = "S", code = "PT_W1" }, TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<PermissionTypeDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var put = await _client.PutAsJsonAsync($"/permissions/types/{dto.Id}",
+        var put = await _client.PutAsJsonAsync($"/v1/permissions/types/{dto.Id}",
             new { name = "   ", code = "PT_W1" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
     }
@@ -121,14 +121,14 @@ public class PermissionTypesApiTests : IAsyncLifetime
     [Fact]
     public async Task GetAll_ReturnsOnlyActivePermissionTypes()
     {
-        await _client.PostAsJsonAsync("/permissions/types", new { name = "Ativo", code = "PT_ATIVO" }, TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/permissions/types", new { name = "Ativo", code = "PT_ATIVO" }, TestApiClient.JsonOptions);
 
-        var other = await _client.PostAsJsonAsync("/permissions/types", new { name = "Outro", code = "PT_OUTRO" }, TestApiClient.JsonOptions);
+        var other = await _client.PostAsJsonAsync("/v1/permissions/types", new { name = "Outro", code = "PT_OUTRO" }, TestApiClient.JsonOptions);
         var toDelete = await other.Content.ReadFromJsonAsync<PermissionTypeDto>(TestApiClient.JsonOptions);
         Assert.NotNull(toDelete);
-        await _client.DeleteAsync($"/permissions/types/{toDelete.Id}");
+        await _client.DeleteAsync($"/v1/permissions/types/{toDelete.Id}");
 
-        var listResp = await _client.GetAsync("/permissions/types");
+        var listResp = await _client.GetAsync("/v1/permissions/types");
         listResp.EnsureSuccessStatusCode();
         var list = await listResp.Content.ReadFromJsonAsync<List<PermissionTypeDto>>(TestApiClient.JsonOptions);
         Assert.NotNull(list);
@@ -140,31 +140,31 @@ public class PermissionTypesApiTests : IAsyncLifetime
     [Fact]
     public async Task GetById_Active_ReturnsOk_Deleted_Returns404()
     {
-        var create = await _client.PostAsJsonAsync("/permissions/types", new { name = "S", code = "PT_S1" }, TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/permissions/types", new { name = "S", code = "PT_S1" }, TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<PermissionTypeDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var getOk = await _client.GetAsync($"/permissions/types/{dto.Id}");
+        var getOk = await _client.GetAsync($"/v1/permissions/types/{dto.Id}");
         Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
 
-        await _client.DeleteAsync($"/permissions/types/{dto.Id}");
-        var get404 = await _client.GetAsync($"/permissions/types/{dto.Id}");
+        await _client.DeleteAsync($"/v1/permissions/types/{dto.Id}");
+        var get404 = await _client.GetAsync($"/v1/permissions/types/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
     }
 
     [Fact]
     public async Task Update_Active_ReturnsOk_Deleted_Returns404()
     {
-        var create = await _client.PostAsJsonAsync("/permissions/types", new { name = "S", code = "PT_U1" }, TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/permissions/types", new { name = "S", code = "PT_U1" }, TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<PermissionTypeDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var putOk = await _client.PutAsJsonAsync($"/permissions/types/{dto.Id}",
+        var putOk = await _client.PutAsJsonAsync($"/v1/permissions/types/{dto.Id}",
             new { name = "S2", code = "PT_U1", description = (string?)null }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.OK, putOk.StatusCode);
 
-        await _client.DeleteAsync($"/permissions/types/{dto.Id}");
-        var put404 = await _client.PutAsJsonAsync($"/permissions/types/{dto.Id}",
+        await _client.DeleteAsync($"/v1/permissions/types/{dto.Id}");
+        var put404 = await _client.PutAsJsonAsync($"/v1/permissions/types/{dto.Id}",
             new { name = "S3", code = "PT_U1" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.NotFound, put404.StatusCode);
     }
@@ -172,11 +172,11 @@ public class PermissionTypesApiTests : IAsyncLifetime
     [Fact]
     public async Task Delete_SoftDelete_ThenDeleteAgain_Returns404()
     {
-        var create = await _client.PostAsJsonAsync("/permissions/types", new { name = "S", code = "PT_D1" }, TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/permissions/types", new { name = "S", code = "PT_D1" }, TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<PermissionTypeDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var del1 = await _client.DeleteAsync($"/permissions/types/{dto.Id}");
+        var del1 = await _client.DeleteAsync($"/v1/permissions/types/{dto.Id}");
         Assert.Equal(HttpStatusCode.NoContent, del1.StatusCode);
 
         using (var scope = _factory.Services.CreateScope())
@@ -186,26 +186,26 @@ public class PermissionTypesApiTests : IAsyncLifetime
             Assert.NotNull(row.DeletedAt);
         }
 
-        var del2 = await _client.DeleteAsync($"/permissions/types/{dto.Id}");
+        var del2 = await _client.DeleteAsync($"/v1/permissions/types/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, del2.StatusCode);
     }
 
     [Fact]
     public async Task Restore_Deleted_ThenOperationsWorkAgain()
     {
-        var create = await _client.PostAsJsonAsync("/permissions/types", new { name = "S", code = "PT_R1" }, TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/permissions/types", new { name = "S", code = "PT_R1" }, TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<PermissionTypeDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        await _client.DeleteAsync($"/permissions/types/{dto.Id}");
+        await _client.DeleteAsync($"/v1/permissions/types/{dto.Id}");
 
-        var get404 = await _client.GetAsync($"/permissions/types/{dto.Id}");
+        var get404 = await _client.GetAsync($"/v1/permissions/types/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
 
-        var restore = await _client.PostAsync($"/permissions/types/{dto.Id}/restore", null);
+        var restore = await _client.PostAsync($"/v1/permissions/types/{dto.Id}/restore", null);
         Assert.Equal(HttpStatusCode.OK, restore.StatusCode);
 
-        var getOk = await _client.GetAsync($"/permissions/types/{dto.Id}");
+        var getOk = await _client.GetAsync($"/v1/permissions/types/{dto.Id}");
         Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
         var restored = await getOk.Content.ReadFromJsonAsync<PermissionTypeDto>(TestApiClient.JsonOptions);
         Assert.NotNull(restored);

--- a/AuthService.Tests/PermissionsApiTests.cs
+++ b/AuthService.Tests/PermissionsApiTests.cs
@@ -27,7 +27,7 @@ public class PermissionsApiTests : IAsyncLifetime
 
     private async Task<Guid> CreateSystemAsync(string code, string name = "Sistema")
     {
-        var r = await _client.PostAsJsonAsync("/systems", new { name, code, description = (string?)null }, TestApiClient.JsonOptions);
+        var r = await _client.PostAsJsonAsync("/v1/systems", new { name, code, description = (string?)null }, TestApiClient.JsonOptions);
         r.EnsureSuccessStatusCode();
         var dto = await r.Content.ReadFromJsonAsync<RefDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
@@ -36,7 +36,7 @@ public class PermissionsApiTests : IAsyncLifetime
 
     private async Task<Guid> CreatePermissionTypeAsync(string code, string name = "Tipo")
     {
-        var r = await _client.PostAsJsonAsync("/permissions/types", new { name, code, description = (string?)null }, TestApiClient.JsonOptions);
+        var r = await _client.PostAsJsonAsync("/v1/permissions/types", new { name, code, description = (string?)null }, TestApiClient.JsonOptions);
         r.EnsureSuccessStatusCode();
         var dto = await r.Content.ReadFromJsonAsync<RefDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
@@ -55,7 +55,7 @@ public class PermissionsApiTests : IAsyncLifetime
         var sysId = await CreateSystemAsync("PERM_SYS_1");
         var typeId = await CreatePermissionTypeAsync("PERM_TYPE_1");
 
-        var response = await _client.PostAsJsonAsync("/permissions",
+        var response = await _client.PostAsJsonAsync("/v1/permissions",
             PermCreateBody(sysId, typeId, "Opcional"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
@@ -75,7 +75,7 @@ public class PermissionsApiTests : IAsyncLifetime
         var sysId = await CreateSystemAsync("PERM_SYS_ND");
         var typeId = await CreatePermissionTypeAsync("PERM_TYPE_ND");
 
-        var response = await _client.PostAsJsonAsync("/permissions",
+        var response = await _client.PostAsJsonAsync("/v1/permissions",
             PermCreateBody(sysId, typeId, "   "), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
@@ -89,7 +89,7 @@ public class PermissionsApiTests : IAsyncLifetime
     {
         var typeId = await CreatePermissionTypeAsync("PERM_TYPE_INV_S");
 
-        var response = await _client.PostAsJsonAsync("/permissions",
+        var response = await _client.PostAsJsonAsync("/v1/permissions",
             PermCreateBody(Guid.NewGuid(), typeId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -99,7 +99,7 @@ public class PermissionsApiTests : IAsyncLifetime
     {
         var sysId = await CreateSystemAsync("PERM_SYS_INV_T");
 
-        var response = await _client.PostAsJsonAsync("/permissions",
+        var response = await _client.PostAsJsonAsync("/v1/permissions",
             PermCreateBody(sysId, Guid.NewGuid()), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -111,7 +111,7 @@ public class PermissionsApiTests : IAsyncLifetime
         var typeId = await CreatePermissionTypeAsync("PERM_TYPE_LEN");
         var longDesc = new string('d', 501);
 
-        var response = await _client.PostAsJsonAsync("/permissions",
+        var response = await _client.PostAsJsonAsync("/v1/permissions",
             PermCreateBody(sysId, typeId, longDesc), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -121,11 +121,11 @@ public class PermissionsApiTests : IAsyncLifetime
     {
         var sysId = await CreateSystemAsync("PERM_SYS_AR");
         var typeId = await CreatePermissionTypeAsync("PERM_TYPE_AR");
-        var create = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/permissions", PermCreateBody(sysId, typeId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Post, $"/permissions/{dto.Id}/restore"));
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Post, $"/v1/permissions/{dto.Id}/restore"));
         Assert.Equal(HttpStatusCode.NotFound, patch.StatusCode);
     }
 
@@ -134,16 +134,16 @@ public class PermissionsApiTests : IAsyncLifetime
     {
         var sysId = await CreateSystemAsync("PERM_SYS_GA");
         var typeId = await CreatePermissionTypeAsync("PERM_TYPE_GA");
-        var firstRes = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId, null), TestApiClient.JsonOptions);
+        var firstRes = await _client.PostAsJsonAsync("/v1/permissions", PermCreateBody(sysId, typeId, null), TestApiClient.JsonOptions);
         var firstDto = await firstRes.Content.ReadFromJsonAsync<PermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(firstDto);
 
-        var other = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId, "b"), TestApiClient.JsonOptions);
+        var other = await _client.PostAsJsonAsync("/v1/permissions", PermCreateBody(sysId, typeId, "b"), TestApiClient.JsonOptions);
         var toDelete = await other.Content.ReadFromJsonAsync<PermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(toDelete);
-        await _client.DeleteAsync($"/permissions/{toDelete.Id}");
+        await _client.DeleteAsync($"/v1/permissions/{toDelete.Id}");
 
-        var listResp = await _client.GetAsync("/permissions");
+        var listResp = await _client.GetAsync("/v1/permissions");
         listResp.EnsureSuccessStatusCode();
         var list = await listResp.Content.ReadFromJsonAsync<List<PermissionDto>>(TestApiClient.JsonOptions);
         Assert.NotNull(list);
@@ -157,14 +157,14 @@ public class PermissionsApiTests : IAsyncLifetime
     {
         var sysId = await CreateSystemAsync("PERM_SYS_G1");
         var typeId = await CreatePermissionTypeAsync("PERM_TYPE_G1");
-        var create = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/permissions", PermCreateBody(sysId, typeId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        Assert.Equal(HttpStatusCode.OK, (await _client.GetAsync($"/permissions/{dto.Id}")).StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await _client.GetAsync($"/v1/permissions/{dto.Id}")).StatusCode);
 
-        await _client.DeleteAsync($"/permissions/{dto.Id}");
-        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/permissions/{dto.Id}")).StatusCode);
+        await _client.DeleteAsync($"/v1/permissions/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/v1/permissions/{dto.Id}")).StatusCode);
     }
 
     [Fact]
@@ -172,16 +172,16 @@ public class PermissionsApiTests : IAsyncLifetime
     {
         var sysId = await CreateSystemAsync("PERM_SYS_U1");
         var typeId = await CreatePermissionTypeAsync("PERM_TYPE_U1");
-        var create = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId, "a"), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/permissions", PermCreateBody(sysId, typeId, "a"), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var putOk = await _client.PutAsJsonAsync($"/permissions/{dto.Id}",
+        var putOk = await _client.PutAsJsonAsync($"/v1/permissions/{dto.Id}",
             PermUpdateBody(sysId, typeId, "b"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.OK, putOk.StatusCode);
 
-        await _client.DeleteAsync($"/permissions/{dto.Id}");
-        var put404 = await _client.PutAsJsonAsync($"/permissions/{dto.Id}",
+        await _client.DeleteAsync($"/v1/permissions/{dto.Id}");
+        var put404 = await _client.PutAsJsonAsync($"/v1/permissions/{dto.Id}",
             PermUpdateBody(sysId, typeId, "c"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.NotFound, put404.StatusCode);
     }
@@ -191,11 +191,11 @@ public class PermissionsApiTests : IAsyncLifetime
     {
         var sysId = await CreateSystemAsync("PERM_SYS_UINV");
         var typeId = await CreatePermissionTypeAsync("PERM_TYPE_UINV");
-        var create = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/permissions", PermCreateBody(sysId, typeId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var put = await _client.PutAsJsonAsync($"/permissions/{dto.Id}",
+        var put = await _client.PutAsJsonAsync($"/v1/permissions/{dto.Id}",
             PermUpdateBody(Guid.NewGuid(), typeId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
     }
@@ -205,11 +205,11 @@ public class PermissionsApiTests : IAsyncLifetime
     {
         var sysId = await CreateSystemAsync("PERM_SYS_D1");
         var typeId = await CreatePermissionTypeAsync("PERM_TYPE_D1");
-        var create = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/permissions", PermCreateBody(sysId, typeId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        Assert.Equal(HttpStatusCode.NoContent, (await _client.DeleteAsync($"/permissions/{dto.Id}")).StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent, (await _client.DeleteAsync($"/v1/permissions/{dto.Id}")).StatusCode);
 
         using (var scope = _factory.Services.CreateScope())
         {
@@ -218,7 +218,7 @@ public class PermissionsApiTests : IAsyncLifetime
             Assert.NotNull(row.DeletedAt);
         }
 
-        Assert.Equal(HttpStatusCode.NotFound, (await _client.DeleteAsync($"/permissions/{dto.Id}")).StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, (await _client.DeleteAsync($"/v1/permissions/{dto.Id}")).StatusCode);
     }
 
     [Fact]
@@ -226,17 +226,17 @@ public class PermissionsApiTests : IAsyncLifetime
     {
         var sysId = await CreateSystemAsync("PERM_SYS_R1");
         var typeId = await CreatePermissionTypeAsync("PERM_TYPE_R1");
-        var create = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/permissions", PermCreateBody(sysId, typeId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        await _client.DeleteAsync($"/permissions/{dto.Id}");
-        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/permissions/{dto.Id}")).StatusCode);
+        await _client.DeleteAsync($"/v1/permissions/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/v1/permissions/{dto.Id}")).StatusCode);
 
-        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Post, $"/permissions/{dto.Id}/restore"));
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Post, $"/v1/permissions/{dto.Id}/restore"));
         Assert.Equal(HttpStatusCode.OK, patch.StatusCode);
 
-        var getOk = await _client.GetAsync($"/permissions/{dto.Id}");
+        var getOk = await _client.GetAsync($"/v1/permissions/{dto.Id}");
         Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
         var restored = await getOk.Content.ReadFromJsonAsync<PermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(restored);
@@ -248,9 +248,9 @@ public class PermissionsApiTests : IAsyncLifetime
     {
         var sysId = await CreateSystemAsync("PERM_SYS_DELSYS");
         var typeId = await CreatePermissionTypeAsync("PERM_TYPE_DELSYS");
-        await _client.DeleteAsync($"/systems/{sysId}");
+        await _client.DeleteAsync($"/v1/systems/{sysId}");
 
-        var response = await _client.PostAsJsonAsync("/permissions",
+        var response = await _client.PostAsJsonAsync("/v1/permissions",
             PermCreateBody(sysId, typeId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -260,15 +260,15 @@ public class PermissionsApiTests : IAsyncLifetime
     {
         var sysId = await CreateSystemAsync("PERM_SYS_ORPH");
         var typeId = await CreatePermissionTypeAsync("PERM_TYPE_ORPH");
-        var create = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/permissions", PermCreateBody(sysId, typeId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        await _client.DeleteAsync($"/systems/{sysId}");
+        await _client.DeleteAsync($"/v1/systems/{sysId}");
 
-        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/permissions/{dto.Id}")).StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/v1/permissions/{dto.Id}")).StatusCode);
 
-        var listResp = await _client.GetAsync("/permissions");
+        var listResp = await _client.GetAsync("/v1/permissions");
         listResp.EnsureSuccessStatusCode();
         var list = await listResp.Content.ReadFromJsonAsync<List<PermissionDto>>(TestApiClient.JsonOptions);
         Assert.NotNull(list);
@@ -280,15 +280,15 @@ public class PermissionsApiTests : IAsyncLifetime
     {
         var sysId = await CreateSystemAsync("PERM_SYS_PT");
         var typeId = await CreatePermissionTypeAsync("PERM_TYPE_PT");
-        var create = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/permissions", PermCreateBody(sysId, typeId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        await _client.DeleteAsync($"/permissions/types/{typeId}");
+        await _client.DeleteAsync($"/v1/permissions/types/{typeId}");
 
-        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/permissions/{dto.Id}")).StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/v1/permissions/{dto.Id}")).StatusCode);
 
-        var listResp = await _client.GetAsync("/permissions");
+        var listResp = await _client.GetAsync("/v1/permissions");
         listResp.EnsureSuccessStatusCode();
         var list = await listResp.Content.ReadFromJsonAsync<List<PermissionDto>>(TestApiClient.JsonOptions);
         Assert.NotNull(list);
@@ -300,14 +300,14 @@ public class PermissionsApiTests : IAsyncLifetime
     {
         var sysId = await CreateSystemAsync("PERM_SYS_RSYS");
         var typeId = await CreatePermissionTypeAsync("PERM_TYPE_RSYS");
-        var create = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/permissions", PermCreateBody(sysId, typeId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        await _client.DeleteAsync($"/permissions/{dto.Id}");
-        await _client.DeleteAsync($"/systems/{sysId}");
+        await _client.DeleteAsync($"/v1/permissions/{dto.Id}");
+        await _client.DeleteAsync($"/v1/systems/{sysId}");
 
-        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Post, $"/permissions/{dto.Id}/restore"));
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Post, $"/v1/permissions/{dto.Id}/restore"));
         Assert.Equal(HttpStatusCode.BadRequest, patch.StatusCode);
     }
 
@@ -316,9 +316,9 @@ public class PermissionsApiTests : IAsyncLifetime
     {
         var sysId = await CreateSystemAsync("PERM_SYS_DELPT");
         var typeId = await CreatePermissionTypeAsync("PERM_TYPE_DELPT");
-        await _client.DeleteAsync($"/permissions/types/{typeId}");
+        await _client.DeleteAsync($"/v1/permissions/types/{typeId}");
 
-        var response = await _client.PostAsJsonAsync("/permissions",
+        var response = await _client.PostAsJsonAsync("/v1/permissions",
             PermCreateBody(sysId, typeId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -328,14 +328,14 @@ public class PermissionsApiTests : IAsyncLifetime
     {
         var sysId = await CreateSystemAsync("PERM_SYS_RPT");
         var typeId = await CreatePermissionTypeAsync("PERM_TYPE_RPT");
-        var create = await _client.PostAsJsonAsync("/permissions", PermCreateBody(sysId, typeId), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/permissions", PermCreateBody(sysId, typeId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        await _client.DeleteAsync($"/permissions/{dto.Id}");
-        await _client.DeleteAsync($"/permissions/types/{typeId}");
+        await _client.DeleteAsync($"/v1/permissions/{dto.Id}");
+        await _client.DeleteAsync($"/v1/permissions/types/{typeId}");
 
-        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Post, $"/permissions/{dto.Id}/restore"));
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Post, $"/v1/permissions/{dto.Id}/restore"));
         Assert.Equal(HttpStatusCode.BadRequest, patch.StatusCode);
     }
 

--- a/AuthService.Tests/RolePermissionsApiTests.cs
+++ b/AuthService.Tests/RolePermissionsApiTests.cs
@@ -27,7 +27,7 @@ public class RolePermissionsApiTests : IAsyncLifetime
 
     private async Task<Guid> CreateRoleAsync(string code)
     {
-        var r = await _client.PostAsJsonAsync("/roles",
+        var r = await _client.PostAsJsonAsync("/v1/roles",
             new { name = "R", code, }, TestApiClient.JsonOptions);
         r.EnsureSuccessStatusCode();
         var dto = await r.Content.ReadFromJsonAsync<RefGuidDto>(TestApiClient.JsonOptions);
@@ -37,7 +37,7 @@ public class RolePermissionsApiTests : IAsyncLifetime
 
     private async Task<Guid> CreateSystemAsync(string code)
     {
-        var r = await _client.PostAsJsonAsync("/systems",
+        var r = await _client.PostAsJsonAsync("/v1/systems",
             new { name = "S", code, description = (string?)null }, TestApiClient.JsonOptions);
         r.EnsureSuccessStatusCode();
         var dto = await r.Content.ReadFromJsonAsync<RefGuidDto>(TestApiClient.JsonOptions);
@@ -47,7 +47,7 @@ public class RolePermissionsApiTests : IAsyncLifetime
 
     private async Task<Guid> CreatePermissionTypeAsync(string code)
     {
-        var r = await _client.PostAsJsonAsync("/permissions/types",
+        var r = await _client.PostAsJsonAsync("/v1/permissions/types",
             new { name = "T", code, description = (string?)null }, TestApiClient.JsonOptions);
         r.EnsureSuccessStatusCode();
         var dto = await r.Content.ReadFromJsonAsync<RefGuidDto>(TestApiClient.JsonOptions);
@@ -57,7 +57,7 @@ public class RolePermissionsApiTests : IAsyncLifetime
 
     private async Task<Guid> CreatePermissionAsync(Guid systemId, Guid permissionTypeId)
     {
-        var r = await _client.PostAsJsonAsync("/permissions",
+        var r = await _client.PostAsJsonAsync("/v1/permissions",
             new { systemId, permissionTypeId, description = (string?)null }, TestApiClient.JsonOptions);
         r.EnsureSuccessStatusCode();
         var dto = await r.Content.ReadFromJsonAsync<RefGuidDto>(TestApiClient.JsonOptions);
@@ -75,7 +75,7 @@ public class RolePermissionsApiTests : IAsyncLifetime
         var typeId = await CreatePermissionTypeAsync("PT_RP_CREATE");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
 
-        var response = await _client.PostAsJsonAsync("/roles-permissions",
+        var response = await _client.PostAsJsonAsync("/v1/roles-permissions",
             RolePermissionBody(roleId, permissionId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
@@ -97,9 +97,9 @@ public class RolePermissionsApiTests : IAsyncLifetime
         var typeId = await CreatePermissionTypeAsync("PT_RP_DUP");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
 
-        await _client.PostAsJsonAsync("/roles-permissions", RolePermissionBody(roleId, permissionId), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/roles-permissions", RolePermissionBody(roleId, permissionId), TestApiClient.JsonOptions);
 
-        var response = await _client.PostAsJsonAsync("/roles-permissions",
+        var response = await _client.PostAsJsonAsync("/v1/roles-permissions",
             RolePermissionBody(roleId, permissionId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
@@ -111,7 +111,7 @@ public class RolePermissionsApiTests : IAsyncLifetime
         var typeId = await CreatePermissionTypeAsync("PT_RP_INV_R");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
 
-        var response = await _client.PostAsJsonAsync("/roles-permissions",
+        var response = await _client.PostAsJsonAsync("/v1/roles-permissions",
             RolePermissionBody(Guid.NewGuid(), permissionId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -121,7 +121,7 @@ public class RolePermissionsApiTests : IAsyncLifetime
     {
         var roleId = await CreateRoleAsync("RP_INV_P");
 
-        var response = await _client.PostAsJsonAsync("/roles-permissions",
+        var response = await _client.PostAsJsonAsync("/v1/roles-permissions",
             RolePermissionBody(roleId, Guid.NewGuid()), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -134,8 +134,8 @@ public class RolePermissionsApiTests : IAsyncLifetime
         var typeId = await CreatePermissionTypeAsync("PT_RP_CONC");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
         var body = RolePermissionBody(roleId, permissionId);
-        var t1 = _client.PostAsJsonAsync("/roles-permissions", body, TestApiClient.JsonOptions);
-        var t2 = _client.PostAsJsonAsync("/roles-permissions", body, TestApiClient.JsonOptions);
+        var t1 = _client.PostAsJsonAsync("/v1/roles-permissions", body, TestApiClient.JsonOptions);
+        var t2 = _client.PostAsJsonAsync("/v1/roles-permissions", body, TestApiClient.JsonOptions);
         await Task.WhenAll(t1, t2);
 
         var r1 = await t1;
@@ -154,13 +154,13 @@ public class RolePermissionsApiTests : IAsyncLifetime
         var permA = await CreatePermissionAsync(sysId, typeId);
         var permB = await CreatePermissionAsync(sysId, typeId);
 
-        await _client.PostAsJsonAsync("/roles-permissions", RolePermissionBody(roleId, permA), TestApiClient.JsonOptions);
-        var second = await _client.PostAsJsonAsync("/roles-permissions", RolePermissionBody(roleId, permB), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/roles-permissions", RolePermissionBody(roleId, permA), TestApiClient.JsonOptions);
+        var second = await _client.PostAsJsonAsync("/v1/roles-permissions", RolePermissionBody(roleId, permB), TestApiClient.JsonOptions);
         var secondDto = await second.Content.ReadFromJsonAsync<RolePermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(secondDto);
-        await _client.DeleteAsync($"/roles-permissions/{secondDto.Id}");
+        await _client.DeleteAsync($"/v1/roles-permissions/{secondDto.Id}");
 
-        var listResp = await _client.GetAsync("/roles-permissions");
+        var listResp = await _client.GetAsync("/v1/roles-permissions");
         listResp.EnsureSuccessStatusCode();
         var list = await listResp.Content.ReadFromJsonAsync<List<RolePermissionDto>>(TestApiClient.JsonOptions);
         Assert.NotNull(list);
@@ -176,16 +176,16 @@ public class RolePermissionsApiTests : IAsyncLifetime
         var sysId = await CreateSystemAsync("SYS_RP_GET");
         var typeId = await CreatePermissionTypeAsync("PT_RP_GET");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
-        var create = await _client.PostAsJsonAsync("/roles-permissions",
+        var create = await _client.PostAsJsonAsync("/v1/roles-permissions",
             RolePermissionBody(roleId, permissionId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RolePermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var getOk = await _client.GetAsync($"/roles-permissions/{dto.Id}");
+        var getOk = await _client.GetAsync($"/v1/roles-permissions/{dto.Id}");
         Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
 
-        await _client.DeleteAsync($"/roles-permissions/{dto.Id}");
-        var get404 = await _client.GetAsync($"/roles-permissions/{dto.Id}");
+        await _client.DeleteAsync($"/v1/roles-permissions/{dto.Id}");
+        var get404 = await _client.GetAsync($"/v1/roles-permissions/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
     }
 
@@ -196,13 +196,13 @@ public class RolePermissionsApiTests : IAsyncLifetime
         var sysId = await CreateSystemAsync("SYS_RP_RS_ACT");
         var typeId = await CreatePermissionTypeAsync("PT_RP_RS_ACT");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
-        var create = await _client.PostAsJsonAsync("/roles-permissions",
+        var create = await _client.PostAsJsonAsync("/v1/roles-permissions",
             RolePermissionBody(roleId, permissionId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RolePermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
         var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch,
-            $"/roles-permissions/{dto.Id}/restore"));
+            $"/v1/roles-permissions/{dto.Id}/restore"));
         Assert.Equal(HttpStatusCode.NotFound, patch.StatusCode);
     }
 
@@ -213,21 +213,21 @@ public class RolePermissionsApiTests : IAsyncLifetime
         var sysId = await CreateSystemAsync("SYS_RP_RS_OK");
         var typeId = await CreatePermissionTypeAsync("PT_RP_RS_OK");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
-        var create = await _client.PostAsJsonAsync("/roles-permissions",
+        var create = await _client.PostAsJsonAsync("/v1/roles-permissions",
             RolePermissionBody(roleId, permissionId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RolePermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        await _client.DeleteAsync($"/roles-permissions/{dto.Id}");
+        await _client.DeleteAsync($"/v1/roles-permissions/{dto.Id}");
 
-        var get404 = await _client.GetAsync($"/roles-permissions/{dto.Id}");
+        var get404 = await _client.GetAsync($"/v1/roles-permissions/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
 
         var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch,
-            $"/roles-permissions/{dto.Id}/restore"));
+            $"/v1/roles-permissions/{dto.Id}/restore"));
         Assert.Equal(HttpStatusCode.OK, patch.StatusCode);
 
-        var getOk = await _client.GetAsync($"/roles-permissions/{dto.Id}");
+        var getOk = await _client.GetAsync($"/v1/roles-permissions/{dto.Id}");
         Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
         var restored = await getOk.Content.ReadFromJsonAsync<RolePermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(restored);
@@ -241,16 +241,16 @@ public class RolePermissionsApiTests : IAsyncLifetime
         var sysId = await CreateSystemAsync("SYS_RP_RS_BAD_R");
         var typeId = await CreatePermissionTypeAsync("PT_RP_RS_BAD_R");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
-        var create = await _client.PostAsJsonAsync("/roles-permissions",
+        var create = await _client.PostAsJsonAsync("/v1/roles-permissions",
             RolePermissionBody(roleId, permissionId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RolePermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        await _client.DeleteAsync($"/roles-permissions/{dto.Id}");
-        await _client.DeleteAsync($"/roles/{roleId}");
+        await _client.DeleteAsync($"/v1/roles-permissions/{dto.Id}");
+        await _client.DeleteAsync($"/v1/roles/{roleId}");
 
         var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch,
-            $"/roles-permissions/{dto.Id}/restore"));
+            $"/v1/roles-permissions/{dto.Id}/restore"));
         Assert.Equal(HttpStatusCode.BadRequest, patch.StatusCode);
     }
 
@@ -263,12 +263,12 @@ public class RolePermissionsApiTests : IAsyncLifetime
         var permA = await CreatePermissionAsync(sysId, typeId);
         var permB = await CreatePermissionAsync(sysId, typeId);
 
-        await _client.PostAsJsonAsync("/roles-permissions", RolePermissionBody(roleId, permA), TestApiClient.JsonOptions);
-        var b = await _client.PostAsJsonAsync("/roles-permissions", RolePermissionBody(roleId, permB), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/roles-permissions", RolePermissionBody(roleId, permA), TestApiClient.JsonOptions);
+        var b = await _client.PostAsJsonAsync("/v1/roles-permissions", RolePermissionBody(roleId, permB), TestApiClient.JsonOptions);
         var dtoB = await b.Content.ReadFromJsonAsync<RolePermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dtoB);
 
-        var put = await _client.PutAsJsonAsync($"/roles-permissions/{dtoB.Id}",
+        var put = await _client.PutAsJsonAsync($"/v1/roles-permissions/{dtoB.Id}",
             RolePermissionBody(roleId, permA), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, put.StatusCode);
     }
@@ -280,12 +280,12 @@ public class RolePermissionsApiTests : IAsyncLifetime
         var sysId = await CreateSystemAsync("SYS_RP_DEL");
         var typeId = await CreatePermissionTypeAsync("PT_RP_DEL");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
-        var create = await _client.PostAsJsonAsync("/roles-permissions",
+        var create = await _client.PostAsJsonAsync("/v1/roles-permissions",
             RolePermissionBody(roleId, permissionId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RolePermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var del1 = await _client.DeleteAsync($"/roles-permissions/{dto.Id}");
+        var del1 = await _client.DeleteAsync($"/v1/roles-permissions/{dto.Id}");
         Assert.Equal(HttpStatusCode.NoContent, del1.StatusCode);
 
         using (var scope = _factory.Services.CreateScope())
@@ -295,7 +295,7 @@ public class RolePermissionsApiTests : IAsyncLifetime
             Assert.NotNull(row.DeletedAt);
         }
 
-        var del2 = await _client.DeleteAsync($"/roles-permissions/{dto.Id}");
+        var del2 = await _client.DeleteAsync($"/v1/roles-permissions/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, del2.StatusCode);
     }
 
@@ -306,11 +306,11 @@ public class RolePermissionsApiTests : IAsyncLifetime
         var sysId = await CreateSystemAsync("SYS_RP_HIDE");
         var typeId = await CreatePermissionTypeAsync("PT_RP_HIDE");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
-        await _client.PostAsJsonAsync("/roles-permissions", RolePermissionBody(roleId, permissionId), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/roles-permissions", RolePermissionBody(roleId, permissionId), TestApiClient.JsonOptions);
 
-        await _client.DeleteAsync($"/permissions/{permissionId}");
+        await _client.DeleteAsync($"/v1/permissions/{permissionId}");
 
-        var listResp = await _client.GetAsync("/roles-permissions");
+        var listResp = await _client.GetAsync("/v1/roles-permissions");
         listResp.EnsureSuccessStatusCode();
         var list = await listResp.Content.ReadFromJsonAsync<List<RolePermissionDto>>(TestApiClient.JsonOptions);
         Assert.NotNull(list);
@@ -324,11 +324,11 @@ public class RolePermissionsApiTests : IAsyncLifetime
         var sysId = await CreateSystemAsync("SYS_RP_HIDE_R");
         var typeId = await CreatePermissionTypeAsync("PT_RP_HIDE_R");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
-        await _client.PostAsJsonAsync("/roles-permissions", RolePermissionBody(roleId, permissionId), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/roles-permissions", RolePermissionBody(roleId, permissionId), TestApiClient.JsonOptions);
 
-        await _client.DeleteAsync($"/roles/{roleId}");
+        await _client.DeleteAsync($"/v1/roles/{roleId}");
 
-        var listResp = await _client.GetAsync("/roles-permissions");
+        var listResp = await _client.GetAsync("/v1/roles-permissions");
         listResp.EnsureSuccessStatusCode();
         var list = await listResp.Content.ReadFromJsonAsync<List<RolePermissionDto>>(TestApiClient.JsonOptions);
         Assert.NotNull(list);

--- a/AuthService.Tests/RolesApiTests.cs
+++ b/AuthService.Tests/RolesApiTests.cs
@@ -29,7 +29,7 @@ public class RolesApiTests : IAsyncLifetime
     public async Task Create_Post_ReturnsCreated_WithUtcTimestamps_AndNullDeletedAt()
     {
         var body = new { name = "Administrador", code = "ROLE_ADMIN" };
-        var response = await _client.PostAsJsonAsync("/roles", body, TestApiClient.JsonOptions);
+        var response = await _client.PostAsJsonAsync("/v1/roles", body, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
         var dto = await response.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
@@ -45,18 +45,18 @@ public class RolesApiTests : IAsyncLifetime
     [Fact]
     public async Task Create_DuplicateCode_ReturnsConflict()
     {
-        await _client.PostAsJsonAsync("/roles", new { name = "A", code = "ROLE_ABC" }, TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/roles", new { name = "A", code = "ROLE_ABC" }, TestApiClient.JsonOptions);
 
-        var response = await _client.PostAsJsonAsync("/roles", new { name = "B", code = "ROLE_ABC" }, TestApiClient.JsonOptions);
+        var response = await _client.PostAsJsonAsync("/v1/roles", new { name = "B", code = "ROLE_ABC" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
 
     [Fact]
     public async Task Create_DuplicateCode_NormalizesWhitespace_ReturnsConflict()
     {
-        await _client.PostAsJsonAsync("/roles", new { name = "A", code = "ROLE_WS" }, TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/roles", new { name = "A", code = "ROLE_WS" }, TestApiClient.JsonOptions);
 
-        var response = await _client.PostAsJsonAsync("/roles",
+        var response = await _client.PostAsJsonAsync("/v1/roles",
             new { name = "B", code = "  ROLE_WS  " }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
@@ -64,12 +64,12 @@ public class RolesApiTests : IAsyncLifetime
     [Fact]
     public async Task Update_DuplicateCode_NormalizesWhitespace_ReturnsConflict()
     {
-        await _client.PostAsJsonAsync("/roles", new { name = "A", code = "ROLE_CA" }, TestApiClient.JsonOptions);
-        var b = await _client.PostAsJsonAsync("/roles", new { name = "B", code = "ROLE_CB" }, TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/roles", new { name = "A", code = "ROLE_CA" }, TestApiClient.JsonOptions);
+        var b = await _client.PostAsJsonAsync("/v1/roles", new { name = "B", code = "ROLE_CB" }, TestApiClient.JsonOptions);
         var dtoB = await b.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dtoB);
 
-        var put = await _client.PutAsJsonAsync($"/roles/{dtoB.Id}",
+        var put = await _client.PutAsJsonAsync($"/v1/roles/{dtoB.Id}",
             new { name = "B2", code = "  ROLE_CA  " }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, put.StatusCode);
     }
@@ -80,8 +80,8 @@ public class RolesApiTests : IAsyncLifetime
         const string code = "ROLE_CONCURRENT";
         var bodyA = new { name = "A", code };
         var bodyB = new { name = "B", code };
-        var t1 = _client.PostAsJsonAsync("/roles", bodyA, TestApiClient.JsonOptions);
-        var t2 = _client.PostAsJsonAsync("/roles", bodyB, TestApiClient.JsonOptions);
+        var t1 = _client.PostAsJsonAsync("/v1/roles", bodyA, TestApiClient.JsonOptions);
+        var t2 = _client.PostAsJsonAsync("/v1/roles", bodyB, TestApiClient.JsonOptions);
         await Task.WhenAll(t1, t2);
 
         var r1 = await t1;
@@ -94,14 +94,14 @@ public class RolesApiTests : IAsyncLifetime
     [Fact]
     public async Task Create_WhitespaceOnlyName_ReturnsBadRequest()
     {
-        var response = await _client.PostAsJsonAsync("/roles", new { name = "   ", code = "ROLE_X1" }, TestApiClient.JsonOptions);
+        var response = await _client.PostAsJsonAsync("/v1/roles", new { name = "   ", code = "ROLE_X1" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]
     public async Task Create_WhitespaceOnlyCode_ReturnsBadRequest()
     {
-        var response = await _client.PostAsJsonAsync("/roles", new { name = "N1", code = "\t  " }, TestApiClient.JsonOptions);
+        var response = await _client.PostAsJsonAsync("/v1/roles", new { name = "N1", code = "\t  " }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
@@ -109,7 +109,7 @@ public class RolesApiTests : IAsyncLifetime
     public async Task Create_NameExceedsMaxLength_ReturnsBadRequest()
     {
         var name81 = new string('n', 81);
-        var response = await _client.PostAsJsonAsync("/roles",
+        var response = await _client.PostAsJsonAsync("/v1/roles",
             new { name = name81, code = "ROLE_LEN_NAME" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -118,7 +118,7 @@ public class RolesApiTests : IAsyncLifetime
     public async Task Create_CodeExceedsMaxLength_ReturnsBadRequest()
     {
         var code51 = new string('c', 51);
-        var response = await _client.PostAsJsonAsync("/roles",
+        var response = await _client.PostAsJsonAsync("/v1/roles",
             new { name = "Nome válido", code = code51 }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -129,22 +129,22 @@ public class RolesApiTests : IAsyncLifetime
     [Fact]
     public async Task Restore_ActiveRole_ReturnsNotFound()
     {
-        var create = await _client.PostAsJsonAsync("/roles", new { name = "Ativo", code = "ROLE_ACTIVE_R" }, TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/roles", new { name = "Ativo", code = "ROLE_ACTIVE_R" }, TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var restore = await _client.PostAsync($"/roles/{dto.Id}/restore", null);
+        var restore = await _client.PostAsync($"/v1/roles/{dto.Id}/restore", null);
         Assert.Equal(HttpStatusCode.NotFound, restore.StatusCode);
     }
 
     [Fact]
     public async Task Put_WhitespaceOnlyName_ReturnsBadRequest()
     {
-        var create = await _client.PostAsJsonAsync("/roles", new { name = "S", code = "ROLE_W1" }, TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/roles", new { name = "S", code = "ROLE_W1" }, TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var put = await _client.PutAsJsonAsync($"/roles/{dto.Id}",
+        var put = await _client.PutAsJsonAsync($"/v1/roles/{dto.Id}",
             new { name = "   ", code = "ROLE_W1" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
     }
@@ -152,14 +152,14 @@ public class RolesApiTests : IAsyncLifetime
     [Fact]
     public async Task GetAll_ReturnsOnlyActiveRoles()
     {
-        await _client.PostAsJsonAsync("/roles", new { name = "Ativo", code = "ROLE_ATIVO" }, TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/roles", new { name = "Ativo", code = "ROLE_ATIVO" }, TestApiClient.JsonOptions);
 
-        var other = await _client.PostAsJsonAsync("/roles", new { name = "Outro", code = "ROLE_OUTRO" }, TestApiClient.JsonOptions);
+        var other = await _client.PostAsJsonAsync("/v1/roles", new { name = "Outro", code = "ROLE_OUTRO" }, TestApiClient.JsonOptions);
         var toDelete = await other.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(toDelete);
-        await _client.DeleteAsync($"/roles/{toDelete.Id}");
+        await _client.DeleteAsync($"/v1/roles/{toDelete.Id}");
 
-        var listResp = await _client.GetAsync("/roles");
+        var listResp = await _client.GetAsync("/v1/roles");
         listResp.EnsureSuccessStatusCode();
         var list = await listResp.Content.ReadFromJsonAsync<List<RoleDto>>(TestApiClient.JsonOptions);
         Assert.NotNull(list);
@@ -171,31 +171,31 @@ public class RolesApiTests : IAsyncLifetime
     [Fact]
     public async Task GetById_Active_ReturnsOk_Deleted_Returns404()
     {
-        var create = await _client.PostAsJsonAsync("/roles", new { name = "S", code = "ROLE_S1" }, TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/roles", new { name = "S", code = "ROLE_S1" }, TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var getOk = await _client.GetAsync($"/roles/{dto.Id}");
+        var getOk = await _client.GetAsync($"/v1/roles/{dto.Id}");
         Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
 
-        await _client.DeleteAsync($"/roles/{dto.Id}");
-        var get404 = await _client.GetAsync($"/roles/{dto.Id}");
+        await _client.DeleteAsync($"/v1/roles/{dto.Id}");
+        var get404 = await _client.GetAsync($"/v1/roles/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
     }
 
     [Fact]
     public async Task Update_Active_ReturnsOk_Deleted_Returns404()
     {
-        var create = await _client.PostAsJsonAsync("/roles", new { name = "S", code = "ROLE_U1" }, TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/roles", new { name = "S", code = "ROLE_U1" }, TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var putOk = await _client.PutAsJsonAsync($"/roles/{dto.Id}",
+        var putOk = await _client.PutAsJsonAsync($"/v1/roles/{dto.Id}",
             new { name = "S2", code = "ROLE_U1" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.OK, putOk.StatusCode);
 
-        await _client.DeleteAsync($"/roles/{dto.Id}");
-        var put404 = await _client.PutAsJsonAsync($"/roles/{dto.Id}",
+        await _client.DeleteAsync($"/v1/roles/{dto.Id}");
+        var put404 = await _client.PutAsJsonAsync($"/v1/roles/{dto.Id}",
             new { name = "S3", code = "ROLE_U1" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.NotFound, put404.StatusCode);
     }
@@ -203,11 +203,11 @@ public class RolesApiTests : IAsyncLifetime
     [Fact]
     public async Task Delete_SoftDelete_ThenDeleteAgain_Returns404()
     {
-        var create = await _client.PostAsJsonAsync("/roles", new { name = "S", code = "ROLE_D1" }, TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/roles", new { name = "S", code = "ROLE_D1" }, TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var del1 = await _client.DeleteAsync($"/roles/{dto.Id}");
+        var del1 = await _client.DeleteAsync($"/v1/roles/{dto.Id}");
         Assert.Equal(HttpStatusCode.NoContent, del1.StatusCode);
 
         using (var scope = _factory.Services.CreateScope())
@@ -217,26 +217,26 @@ public class RolesApiTests : IAsyncLifetime
             Assert.NotNull(row.DeletedAt);
         }
 
-        var del2 = await _client.DeleteAsync($"/roles/{dto.Id}");
+        var del2 = await _client.DeleteAsync($"/v1/roles/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, del2.StatusCode);
     }
 
     [Fact]
     public async Task Restore_Deleted_ThenOperationsWorkAgain()
     {
-        var create = await _client.PostAsJsonAsync("/roles", new { name = "S", code = "ROLE_R1" }, TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/roles", new { name = "S", code = "ROLE_R1" }, TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        await _client.DeleteAsync($"/roles/{dto.Id}");
+        await _client.DeleteAsync($"/v1/roles/{dto.Id}");
 
-        var get404 = await _client.GetAsync($"/roles/{dto.Id}");
+        var get404 = await _client.GetAsync($"/v1/roles/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
 
-        var restore = await _client.PostAsync($"/roles/{dto.Id}/restore", null);
+        var restore = await _client.PostAsync($"/v1/roles/{dto.Id}/restore", null);
         Assert.Equal(HttpStatusCode.OK, restore.StatusCode);
 
-        var getOk = await _client.GetAsync($"/roles/{dto.Id}");
+        var getOk = await _client.GetAsync($"/v1/roles/{dto.Id}");
         Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
         var restored = await getOk.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(restored);

--- a/AuthService.Tests/RoutesApiTests.cs
+++ b/AuthService.Tests/RoutesApiTests.cs
@@ -27,7 +27,7 @@ public class RoutesApiTests : IAsyncLifetime
 
     private async Task<Guid> CreateSystemAsync(string code, string name = "Sistema")
     {
-        var r = await _client.PostAsJsonAsync("/systems", new { name, code, description = (string?)null }, TestApiClient.JsonOptions);
+        var r = await _client.PostAsJsonAsync("/v1/systems", new { name, code, description = (string?)null }, TestApiClient.JsonOptions);
         r.EnsureSuccessStatusCode();
         var dto = await r.Content.ReadFromJsonAsync<SystemRefDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
@@ -45,7 +45,7 @@ public class RoutesApiTests : IAsyncLifetime
     {
         var sysId = await CreateSystemAsync("RT_SYS_1");
 
-        var response = await _client.PostAsJsonAsync("/systems/routes",
+        var response = await _client.PostAsJsonAsync("/v1/systems/routes",
             RouteCreateBody(sysId, "Rota A", "ROUTE_A", "Opcional"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
@@ -62,7 +62,7 @@ public class RoutesApiTests : IAsyncLifetime
     [Fact]
     public async Task Create_WithInvalidSystemId_ReturnsBadRequest()
     {
-        var response = await _client.PostAsJsonAsync("/systems/routes",
+        var response = await _client.PostAsJsonAsync("/v1/systems/routes",
             RouteCreateBody(Guid.NewGuid(), "X", "CODE_X"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -71,9 +71,9 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task Create_DuplicateCode_ReturnsConflict()
     {
         var sysId = await CreateSystemAsync("RT_SYS_DUP");
-        await _client.PostAsJsonAsync("/systems/routes", RouteCreateBody(sysId, "A", "DUP_CODE"), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/systems/routes", RouteCreateBody(sysId, "A", "DUP_CODE"), TestApiClient.JsonOptions);
 
-        var response = await _client.PostAsJsonAsync("/systems/routes", RouteCreateBody(sysId, "B", "DUP_CODE"), TestApiClient.JsonOptions);
+        var response = await _client.PostAsJsonAsync("/v1/systems/routes", RouteCreateBody(sysId, "B", "DUP_CODE"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
 
@@ -81,9 +81,9 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task Create_DuplicateCode_NormalizesWhitespace_ReturnsConflict()
     {
         var sysId = await CreateSystemAsync("RT_SYS_WS");
-        await _client.PostAsJsonAsync("/systems/routes", RouteCreateBody(sysId, "A", "ABC_RT"), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/systems/routes", RouteCreateBody(sysId, "A", "ABC_RT"), TestApiClient.JsonOptions);
 
-        var response = await _client.PostAsJsonAsync("/systems/routes",
+        var response = await _client.PostAsJsonAsync("/v1/systems/routes",
             RouteCreateBody(sysId, "B", "  ABC_RT  "), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
@@ -93,8 +93,8 @@ public class RoutesApiTests : IAsyncLifetime
     {
         var sysId = await CreateSystemAsync("RT_SYS_CONC");
         const string code = "CONC_RT";
-        var t1 = _client.PostAsJsonAsync("/systems/routes", RouteCreateBody(sysId, "A", code), TestApiClient.JsonOptions);
-        var t2 = _client.PostAsJsonAsync("/systems/routes", RouteCreateBody(sysId, "B", code), TestApiClient.JsonOptions);
+        var t1 = _client.PostAsJsonAsync("/v1/systems/routes", RouteCreateBody(sysId, "A", code), TestApiClient.JsonOptions);
+        var t2 = _client.PostAsJsonAsync("/v1/systems/routes", RouteCreateBody(sysId, "B", code), TestApiClient.JsonOptions);
         await Task.WhenAll(t1, t2);
         var statuses = new[] { (await t1).StatusCode, (await t2).StatusCode };
         Assert.Contains(HttpStatusCode.Created, statuses);
@@ -105,7 +105,7 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task Create_WhitespaceOnlyName_ReturnsBadRequest()
     {
         var sysId = await CreateSystemAsync("RT_SYS_WN");
-        var response = await _client.PostAsJsonAsync("/systems/routes",
+        var response = await _client.PostAsJsonAsync("/v1/systems/routes",
             RouteCreateBody(sysId, "   ", "C1"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -114,14 +114,14 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task GetAll_ReturnsOnlyActiveRoutes()
     {
         var sysId = await CreateSystemAsync("RT_SYS_GA");
-        await _client.PostAsJsonAsync("/systems/routes", RouteCreateBody(sysId, "Ativa", "RT_ATIVA"), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/systems/routes", RouteCreateBody(sysId, "Ativa", "RT_ATIVA"), TestApiClient.JsonOptions);
 
-        var other = await _client.PostAsJsonAsync("/systems/routes", RouteCreateBody(sysId, "Outra", "RT_OUTRA"), TestApiClient.JsonOptions);
+        var other = await _client.PostAsJsonAsync("/v1/systems/routes", RouteCreateBody(sysId, "Outra", "RT_OUTRA"), TestApiClient.JsonOptions);
         var otherDto = await other.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
         Assert.NotNull(otherDto);
-        await _client.DeleteAsync($"/systems/routes/{otherDto.Id}");
+        await _client.DeleteAsync($"/v1/systems/routes/{otherDto.Id}");
 
-        var listResp = await _client.GetAsync("/systems/routes");
+        var listResp = await _client.GetAsync("/v1/systems/routes");
         listResp.EnsureSuccessStatusCode();
         var list = await listResp.Content.ReadFromJsonAsync<List<RouteDto>>(TestApiClient.JsonOptions);
         Assert.NotNull(list);
@@ -134,30 +134,30 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task GetById_Active_ReturnsOk_Deleted_Returns404()
     {
         var sysId = await CreateSystemAsync("RT_SYS_G1");
-        var create = await _client.PostAsJsonAsync("/systems/routes", RouteCreateBody(sysId, "S", "RT_G1"), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/systems/routes", RouteCreateBody(sysId, "S", "RT_G1"), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        Assert.Equal(HttpStatusCode.OK, (await _client.GetAsync($"/systems/routes/{dto.Id}")).StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await _client.GetAsync($"/v1/systems/routes/{dto.Id}")).StatusCode);
 
-        await _client.DeleteAsync($"/systems/routes/{dto.Id}");
-        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/systems/routes/{dto.Id}")).StatusCode);
+        await _client.DeleteAsync($"/v1/systems/routes/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/v1/systems/routes/{dto.Id}")).StatusCode);
     }
 
     [Fact]
     public async Task Update_Active_ReturnsOk_Deleted_Returns404()
     {
         var sysId = await CreateSystemAsync("RT_SYS_U1");
-        var create = await _client.PostAsJsonAsync("/systems/routes", RouteCreateBody(sysId, "S", "RT_U1"), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/systems/routes", RouteCreateBody(sysId, "S", "RT_U1"), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var putOk = await _client.PutAsJsonAsync($"/systems/routes/{dto.Id}",
+        var putOk = await _client.PutAsJsonAsync($"/v1/systems/routes/{dto.Id}",
             RouteUpdateBody(sysId, "S2", "RT_U1", null), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.OK, putOk.StatusCode);
 
-        await _client.DeleteAsync($"/systems/routes/{dto.Id}");
-        var put404 = await _client.PutAsJsonAsync($"/systems/routes/{dto.Id}",
+        await _client.DeleteAsync($"/v1/systems/routes/{dto.Id}");
+        var put404 = await _client.PutAsJsonAsync($"/v1/systems/routes/{dto.Id}",
             RouteUpdateBody(sysId, "S3", "RT_U1"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.NotFound, put404.StatusCode);
     }
@@ -166,11 +166,11 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task Update_WithInvalidSystemId_ReturnsBadRequest()
     {
         var sysId = await CreateSystemAsync("RT_SYS_UINV");
-        var create = await _client.PostAsJsonAsync("/systems/routes", RouteCreateBody(sysId, "S", "RT_INV"), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/systems/routes", RouteCreateBody(sysId, "S", "RT_INV"), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var put = await _client.PutAsJsonAsync($"/systems/routes/{dto.Id}",
+        var put = await _client.PutAsJsonAsync($"/v1/systems/routes/{dto.Id}",
             RouteUpdateBody(Guid.NewGuid(), "S", "RT_INV"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
     }
@@ -179,7 +179,7 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task Update_NonExistentId_WithInvalidSystemId_Returns404()
     {
         var missingId = Guid.NewGuid();
-        var put = await _client.PutAsJsonAsync($"/systems/routes/{missingId}",
+        var put = await _client.PutAsJsonAsync($"/v1/systems/routes/{missingId}",
             RouteUpdateBody(Guid.NewGuid(), "S", "RT_NO404"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.NotFound, put.StatusCode);
     }
@@ -188,11 +188,11 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task Delete_SoftDelete_ThenDeleteAgain_Returns404()
     {
         var sysId = await CreateSystemAsync("RT_SYS_D1");
-        var create = await _client.PostAsJsonAsync("/systems/routes", RouteCreateBody(sysId, "S", "RT_D1"), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/systems/routes", RouteCreateBody(sysId, "S", "RT_D1"), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        Assert.Equal(HttpStatusCode.NoContent, (await _client.DeleteAsync($"/systems/routes/{dto.Id}")).StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent, (await _client.DeleteAsync($"/v1/systems/routes/{dto.Id}")).StatusCode);
 
         using (var scope = _factory.Services.CreateScope())
         {
@@ -201,30 +201,30 @@ public class RoutesApiTests : IAsyncLifetime
             Assert.NotNull(row.DeletedAt);
         }
 
-        Assert.Equal(HttpStatusCode.NotFound, (await _client.DeleteAsync($"/systems/routes/{dto.Id}")).StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, (await _client.DeleteAsync($"/v1/systems/routes/{dto.Id}")).StatusCode);
     }
 
     [Fact]
     public async Task Restore_Deleted_ThenAppearsInGetAll_AndGetByIdWorks()
     {
         var sysId = await CreateSystemAsync("RT_SYS_R1");
-        var create = await _client.PostAsJsonAsync("/systems/routes", RouteCreateBody(sysId, "S", "RT_R1"), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/systems/routes", RouteCreateBody(sysId, "S", "RT_R1"), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        await _client.DeleteAsync($"/systems/routes/{dto.Id}");
-        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/systems/routes/{dto.Id}")).StatusCode);
+        await _client.DeleteAsync($"/v1/systems/routes/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/v1/systems/routes/{dto.Id}")).StatusCode);
 
-        var restore = await _client.PostAsync($"/systems/routes/{dto.Id}/restore", null);
+        var restore = await _client.PostAsync($"/v1/systems/routes/{dto.Id}/restore", null);
         Assert.Equal(HttpStatusCode.OK, restore.StatusCode);
 
-        var getOk = await _client.GetAsync($"/systems/routes/{dto.Id}");
+        var getOk = await _client.GetAsync($"/v1/systems/routes/{dto.Id}");
         Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
         var restored = await getOk.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
         Assert.NotNull(restored);
         Assert.Null(restored.DeletedAt);
 
-        var listResp = await _client.GetAsync("/systems/routes");
+        var listResp = await _client.GetAsync("/v1/systems/routes");
         listResp.EnsureSuccessStatusCode();
         var list = await listResp.Content.ReadFromJsonAsync<List<RouteDto>>(TestApiClient.JsonOptions);
         Assert.NotNull(list);
@@ -235,9 +235,9 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task Create_WithDeletedSystem_ReturnsBadRequest()
     {
         var sysId = await CreateSystemAsync("RT_SYS_DELSYS");
-        await _client.DeleteAsync($"/systems/{sysId}");
+        await _client.DeleteAsync($"/v1/systems/{sysId}");
 
-        var response = await _client.PostAsJsonAsync("/systems/routes",
+        var response = await _client.PostAsJsonAsync("/v1/systems/routes",
             RouteCreateBody(sysId, "R", "RT_DELSYS"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -246,16 +246,16 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task GetAll_AndGetById_ExcludeRoutesWhenSystemSoftDeleted()
     {
         var sysId = await CreateSystemAsync("RT_SYS_ORPH");
-        var create = await _client.PostAsJsonAsync("/systems/routes",
+        var create = await _client.PostAsJsonAsync("/v1/systems/routes",
             RouteCreateBody(sysId, "R", "RT_ORPH"), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        await _client.DeleteAsync($"/systems/{sysId}");
+        await _client.DeleteAsync($"/v1/systems/{sysId}");
 
-        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/systems/routes/{dto.Id}")).StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/v1/systems/routes/{dto.Id}")).StatusCode);
 
-        var listResp = await _client.GetAsync("/systems/routes");
+        var listResp = await _client.GetAsync("/v1/systems/routes");
         listResp.EnsureSuccessStatusCode();
         var list = await listResp.Content.ReadFromJsonAsync<List<RouteDto>>(TestApiClient.JsonOptions);
         Assert.NotNull(list);
@@ -266,15 +266,15 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task Restore_WhenSystemSoftDeleted_ReturnsBadRequest()
     {
         var sysId = await CreateSystemAsync("RT_SYS_RSYS");
-        var create = await _client.PostAsJsonAsync("/systems/routes",
+        var create = await _client.PostAsJsonAsync("/v1/systems/routes",
             RouteCreateBody(sysId, "S", "RT_RSYS"), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        await _client.DeleteAsync($"/systems/routes/{dto.Id}");
-        await _client.DeleteAsync($"/systems/{sysId}");
+        await _client.DeleteAsync($"/v1/systems/routes/{dto.Id}");
+        await _client.DeleteAsync($"/v1/systems/{sysId}");
 
-        var restore = await _client.PostAsync($"/systems/routes/{dto.Id}/restore", null);
+        var restore = await _client.PostAsync($"/v1/systems/routes/{dto.Id}/restore", null);
         Assert.Equal(HttpStatusCode.BadRequest, restore.StatusCode);
     }
 

--- a/AuthService.Tests/SystemsApiTests.cs
+++ b/AuthService.Tests/SystemsApiTests.cs
@@ -32,7 +32,7 @@ public class SystemsApiTests : IAsyncLifetime
     public async Task Create_Post_ReturnsCreated_WithUtcTimestamps_AndNullDeletedAt()
     {
         var body = new { name = "Sistema X", code = "SISTEMA_X", description = "Opcional" };
-        var response = await _client.PostAsJsonAsync("/systems", body, TestApiClient.JsonOptions);
+        var response = await _client.PostAsJsonAsync("/v1/systems", body, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
         var dto = await response.Content.ReadFromJsonAsync<SystemDto>(TestApiClient.JsonOptions);
@@ -49,30 +49,30 @@ public class SystemsApiTests : IAsyncLifetime
     [Fact]
     public async Task Create_DuplicateCode_ReturnsConflict()
     {
-        await _client.PostAsJsonAsync("/systems", new { name = "A", code = "ABC" }, TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/systems", new { name = "A", code = "ABC" }, TestApiClient.JsonOptions);
 
-        var response = await _client.PostAsJsonAsync("/systems", new { name = "B", code = "ABC" }, TestApiClient.JsonOptions);
+        var response = await _client.PostAsJsonAsync("/v1/systems", new { name = "B", code = "ABC" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
 
     [Fact]
     public async Task Create_DuplicateCode_NormalizesWhitespace_ReturnsConflict()
     {
-        await _client.PostAsJsonAsync("/systems", new { name = "A", code = "ABC" }, TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/systems", new { name = "A", code = "ABC" }, TestApiClient.JsonOptions);
 
-        var response = await _client.PostAsJsonAsync("/systems", new { name = "B", code = "  ABC  " }, TestApiClient.JsonOptions);
+        var response = await _client.PostAsJsonAsync("/v1/systems", new { name = "B", code = "  ABC  " }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
 
     [Fact]
     public async Task Update_DuplicateCode_NormalizesWhitespace_ReturnsConflict()
     {
-        await _client.PostAsJsonAsync("/systems", new { name = "A", code = "CODE_A" }, TestApiClient.JsonOptions);
-        var b = await _client.PostAsJsonAsync("/systems", new { name = "B", code = "CODE_B" }, TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/systems", new { name = "A", code = "CODE_A" }, TestApiClient.JsonOptions);
+        var b = await _client.PostAsJsonAsync("/v1/systems", new { name = "B", code = "CODE_B" }, TestApiClient.JsonOptions);
         var dtoB = await b.Content.ReadFromJsonAsync<SystemDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dtoB);
 
-        var put = await _client.PutAsJsonAsync($"/systems/{dtoB.Id}",
+        var put = await _client.PutAsJsonAsync($"/v1/systems/{dtoB.Id}",
             new { name = "B2", code = "  CODE_A  " }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, put.StatusCode);
     }
@@ -83,8 +83,8 @@ public class SystemsApiTests : IAsyncLifetime
         const string code = "CONCURRENT_X";
         var bodyA = new { name = "A", code };
         var bodyB = new { name = "B", code };
-        var t1 = _client.PostAsJsonAsync("/systems", bodyA, TestApiClient.JsonOptions);
-        var t2 = _client.PostAsJsonAsync("/systems", bodyB, TestApiClient.JsonOptions);
+        var t1 = _client.PostAsJsonAsync("/v1/systems", bodyA, TestApiClient.JsonOptions);
+        var t2 = _client.PostAsJsonAsync("/v1/systems", bodyB, TestApiClient.JsonOptions);
         await Task.WhenAll(t1, t2);
 
         var r1 = await t1;
@@ -97,25 +97,25 @@ public class SystemsApiTests : IAsyncLifetime
     [Fact]
     public async Task Create_WhitespaceOnlyName_ReturnsBadRequest()
     {
-        var response = await _client.PostAsJsonAsync("/systems", new { name = "   ", code = "X1" }, TestApiClient.JsonOptions);
+        var response = await _client.PostAsJsonAsync("/v1/systems", new { name = "   ", code = "X1" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]
     public async Task Create_WhitespaceOnlyCode_ReturnsBadRequest()
     {
-        var response = await _client.PostAsJsonAsync("/systems", new { name = "N1", code = "\t  " }, TestApiClient.JsonOptions);
+        var response = await _client.PostAsJsonAsync("/v1/systems", new { name = "N1", code = "\t  " }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]
     public async Task Put_WhitespaceOnlyName_ReturnsBadRequest()
     {
-        var create = await _client.PostAsJsonAsync("/systems", new { name = "S", code = "W1" }, TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/systems", new { name = "S", code = "W1" }, TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<SystemDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var put = await _client.PutAsJsonAsync($"/systems/{dto.Id}",
+        var put = await _client.PutAsJsonAsync($"/v1/systems/{dto.Id}",
             new { name = "   ", code = "W1" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
     }
@@ -123,14 +123,14 @@ public class SystemsApiTests : IAsyncLifetime
     [Fact]
     public async Task GetAll_ReturnsOnlyActiveSystems()
     {
-        await _client.PostAsJsonAsync("/systems", new { name = "Ativo", code = "ATIVO" }, TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/systems", new { name = "Ativo", code = "ATIVO" }, TestApiClient.JsonOptions);
 
-        var other = await _client.PostAsJsonAsync("/systems", new { name = "Outro", code = "OUTRO" }, TestApiClient.JsonOptions);
+        var other = await _client.PostAsJsonAsync("/v1/systems", new { name = "Outro", code = "OUTRO" }, TestApiClient.JsonOptions);
         var toDelete = await other.Content.ReadFromJsonAsync<SystemDto>(TestApiClient.JsonOptions);
         Assert.NotNull(toDelete);
-        await _client.DeleteAsync($"/systems/{toDelete.Id}");
+        await _client.DeleteAsync($"/v1/systems/{toDelete.Id}");
 
-        var listResp = await _client.GetAsync("/systems");
+        var listResp = await _client.GetAsync("/v1/systems");
         listResp.EnsureSuccessStatusCode();
         var list = await listResp.Content.ReadFromJsonAsync<List<SystemDto>>(TestApiClient.JsonOptions);
         Assert.NotNull(list);
@@ -142,31 +142,31 @@ public class SystemsApiTests : IAsyncLifetime
     [Fact]
     public async Task GetById_Active_ReturnsOk_Deleted_Returns404()
     {
-        var create = await _client.PostAsJsonAsync("/systems", new { name = "S", code = "S1" }, TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/systems", new { name = "S", code = "S1" }, TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<SystemDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var getOk = await _client.GetAsync($"/systems/{dto.Id}");
+        var getOk = await _client.GetAsync($"/v1/systems/{dto.Id}");
         Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
 
-        await _client.DeleteAsync($"/systems/{dto.Id}");
-        var get404 = await _client.GetAsync($"/systems/{dto.Id}");
+        await _client.DeleteAsync($"/v1/systems/{dto.Id}");
+        var get404 = await _client.GetAsync($"/v1/systems/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
     }
 
     [Fact]
     public async Task Update_Active_ReturnsOk_Deleted_Returns404()
     {
-        var create = await _client.PostAsJsonAsync("/systems", new { name = "S", code = "U1" }, TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/systems", new { name = "S", code = "U1" }, TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<SystemDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var putOk = await _client.PutAsJsonAsync($"/systems/{dto.Id}",
+        var putOk = await _client.PutAsJsonAsync($"/v1/systems/{dto.Id}",
             new { name = "S2", code = "U1", description = (string?)null }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.OK, putOk.StatusCode);
 
-        await _client.DeleteAsync($"/systems/{dto.Id}");
-        var put404 = await _client.PutAsJsonAsync($"/systems/{dto.Id}",
+        await _client.DeleteAsync($"/v1/systems/{dto.Id}");
+        var put404 = await _client.PutAsJsonAsync($"/v1/systems/{dto.Id}",
             new { name = "S3", code = "U1" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.NotFound, put404.StatusCode);
     }
@@ -174,11 +174,11 @@ public class SystemsApiTests : IAsyncLifetime
     [Fact]
     public async Task Delete_SoftDelete_ThenDeleteAgain_Returns404()
     {
-        var create = await _client.PostAsJsonAsync("/systems", new { name = "S", code = "D1" }, TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/systems", new { name = "S", code = "D1" }, TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<SystemDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var del1 = await _client.DeleteAsync($"/systems/{dto.Id}");
+        var del1 = await _client.DeleteAsync($"/v1/systems/{dto.Id}");
         Assert.Equal(HttpStatusCode.NoContent, del1.StatusCode);
 
         using (var scope = _factory.Services.CreateScope())
@@ -188,26 +188,26 @@ public class SystemsApiTests : IAsyncLifetime
             Assert.NotNull(row.DeletedAt);
         }
 
-        var del2 = await _client.DeleteAsync($"/systems/{dto.Id}");
+        var del2 = await _client.DeleteAsync($"/v1/systems/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, del2.StatusCode);
     }
 
     [Fact]
     public async Task Restore_Deleted_ThenOperationsWorkAgain()
     {
-        var create = await _client.PostAsJsonAsync("/systems", new { name = "S", code = "R1" }, TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/systems", new { name = "S", code = "R1" }, TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<SystemDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        await _client.DeleteAsync($"/systems/{dto.Id}");
+        await _client.DeleteAsync($"/v1/systems/{dto.Id}");
 
-        var get404 = await _client.GetAsync($"/systems/{dto.Id}");
+        var get404 = await _client.GetAsync($"/v1/systems/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
 
-        var restore = await _client.PostAsync($"/systems/{dto.Id}/restore", null);
+        var restore = await _client.PostAsync($"/v1/systems/{dto.Id}/restore", null);
         Assert.Equal(HttpStatusCode.OK, restore.StatusCode);
 
-        var getOk = await _client.GetAsync($"/systems/{dto.Id}");
+        var getOk = await _client.GetAsync($"/v1/systems/{dto.Id}");
         Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
         var restored = await getOk.Content.ReadFromJsonAsync<SystemDto>(TestApiClient.JsonOptions);
         Assert.NotNull(restored);

--- a/AuthService.Tests/TestApiClient.cs
+++ b/AuthService.Tests/TestApiClient.cs
@@ -23,7 +23,7 @@ internal static class TestApiClient
     internal static async Task<HttpClient> CreateAuthenticatedAsync(WebAppFactory factory)
     {
         var client = factory.CreateClient();
-        var login = await client.PostAsJsonAsync("/auth/login",
+        var login = await client.PostAsJsonAsync("/v1/auth/login",
             new { email = IntegrationBootstrapSeeder.Email, password = IntegrationBootstrapSeeder.Password },
             JsonOptions);
         login.EnsureSuccessStatusCode();

--- a/AuthService.Tests/TokenTypesApiTests.cs
+++ b/AuthService.Tests/TokenTypesApiTests.cs
@@ -29,7 +29,7 @@ public class TokenTypesApiTests : IAsyncLifetime
     public async Task Create_Post_ReturnsCreated_WithUtcTimestamps_AndNullDeletedAt()
     {
         var body = new { name = "Tipo token", code = "TT_X", description = "Opcional" };
-        var response = await _client.PostAsJsonAsync("/tokens/types", body, TestApiClient.JsonOptions);
+        var response = await _client.PostAsJsonAsync("/v1/tokens/types", body, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
         var dto = await response.Content.ReadFromJsonAsync<TokenTypeDto>(TestApiClient.JsonOptions);
@@ -44,9 +44,9 @@ public class TokenTypesApiTests : IAsyncLifetime
     [Fact]
     public async Task Create_DuplicateCode_ReturnsConflict()
     {
-        await _client.PostAsJsonAsync("/tokens/types", new { name = "A", code = "TT_DUP" }, TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/tokens/types", new { name = "A", code = "TT_DUP" }, TestApiClient.JsonOptions);
 
-        var response = await _client.PostAsJsonAsync("/tokens/types", new { name = "B", code = "TT_DUP" }, TestApiClient.JsonOptions);
+        var response = await _client.PostAsJsonAsync("/v1/tokens/types", new { name = "B", code = "TT_DUP" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
 
@@ -54,23 +54,23 @@ public class TokenTypesApiTests : IAsyncLifetime
     public async Task Get_WithoutToken_ReturnsUnauthorized()
     {
         using var anon = _factory.CreateClient();
-        var response = await anon.GetAsync("/tokens/types");
+        var response = await anon.GetAsync("/v1/tokens/types");
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
     [Fact]
     public async Task Restore_Deleted_ThenGetReturnsOk()
     {
-        var create = await _client.PostAsJsonAsync("/tokens/types", new { name = "S", code = "TT_R1" }, TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/tokens/types", new { name = "S", code = "TT_R1" }, TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<TokenTypeDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        await _client.DeleteAsync($"/tokens/types/{dto.Id}");
+        await _client.DeleteAsync($"/v1/tokens/types/{dto.Id}");
 
-        var restore = await _client.PostAsync($"/tokens/types/{dto.Id}/restore", null);
+        var restore = await _client.PostAsync($"/v1/tokens/types/{dto.Id}/restore", null);
         Assert.Equal(HttpStatusCode.OK, restore.StatusCode);
 
-        var getOk = await _client.GetAsync($"/tokens/types/{dto.Id}");
+        var getOk = await _client.GetAsync($"/v1/tokens/types/{dto.Id}");
         Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
 
         using (var scope = _factory.Services.CreateScope())

--- a/AuthService.Tests/UserPermissionsApiTests.cs
+++ b/AuthService.Tests/UserPermissionsApiTests.cs
@@ -32,7 +32,7 @@ public class UserPermissionsApiTests : IAsyncLifetime
     private async Task<Guid> CreateUserAsync(string emailLocal, bool active = true)
     {
         var email = $"{emailLocal}@up.test";
-        var r = await _client.PostAsJsonAsync("/users", UserCreateBody("U", email, active: active), TestApiClient.JsonOptions);
+        var r = await _client.PostAsJsonAsync("/v1/users", UserCreateBody("U", email, active: active), TestApiClient.JsonOptions);
         r.EnsureSuccessStatusCode();
         var dto = await r.Content.ReadFromJsonAsync<RefGuidDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
@@ -41,7 +41,7 @@ public class UserPermissionsApiTests : IAsyncLifetime
 
     private async Task<Guid> CreateSystemAsync(string code)
     {
-        var r = await _client.PostAsJsonAsync("/systems",
+        var r = await _client.PostAsJsonAsync("/v1/systems",
             new { name = "S", code, description = (string?)null }, TestApiClient.JsonOptions);
         r.EnsureSuccessStatusCode();
         var dto = await r.Content.ReadFromJsonAsync<RefGuidDto>(TestApiClient.JsonOptions);
@@ -51,7 +51,7 @@ public class UserPermissionsApiTests : IAsyncLifetime
 
     private async Task<Guid> CreatePermissionTypeAsync(string code)
     {
-        var r = await _client.PostAsJsonAsync("/permissions/types",
+        var r = await _client.PostAsJsonAsync("/v1/permissions/types",
             new { name = "T", code, description = (string?)null }, TestApiClient.JsonOptions);
         r.EnsureSuccessStatusCode();
         var dto = await r.Content.ReadFromJsonAsync<RefGuidDto>(TestApiClient.JsonOptions);
@@ -61,7 +61,7 @@ public class UserPermissionsApiTests : IAsyncLifetime
 
     private async Task<Guid> CreatePermissionAsync(Guid systemId, Guid permissionTypeId)
     {
-        var r = await _client.PostAsJsonAsync("/permissions",
+        var r = await _client.PostAsJsonAsync("/v1/permissions",
             new { systemId, permissionTypeId, description = (string?)null }, TestApiClient.JsonOptions);
         r.EnsureSuccessStatusCode();
         var dto = await r.Content.ReadFromJsonAsync<RefGuidDto>(TestApiClient.JsonOptions);
@@ -79,7 +79,7 @@ public class UserPermissionsApiTests : IAsyncLifetime
         var typeId = await CreatePermissionTypeAsync("PT_UP_CREATE");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
 
-        var response = await _client.PostAsJsonAsync("/users-permissions",
+        var response = await _client.PostAsJsonAsync("/v1/users-permissions",
             UserPermissionBody(userId, permissionId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
@@ -101,9 +101,9 @@ public class UserPermissionsApiTests : IAsyncLifetime
         var typeId = await CreatePermissionTypeAsync("PT_UP_DUP");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
 
-        await _client.PostAsJsonAsync("/users-permissions", UserPermissionBody(userId, permissionId), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/users-permissions", UserPermissionBody(userId, permissionId), TestApiClient.JsonOptions);
 
-        var response = await _client.PostAsJsonAsync("/users-permissions",
+        var response = await _client.PostAsJsonAsync("/v1/users-permissions",
             UserPermissionBody(userId, permissionId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
@@ -115,7 +115,7 @@ public class UserPermissionsApiTests : IAsyncLifetime
         var typeId = await CreatePermissionTypeAsync("PT_UP_INV_U");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
 
-        var response = await _client.PostAsJsonAsync("/users-permissions",
+        var response = await _client.PostAsJsonAsync("/v1/users-permissions",
             UserPermissionBody(Guid.NewGuid(), permissionId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -125,7 +125,7 @@ public class UserPermissionsApiTests : IAsyncLifetime
     {
         var userId = await CreateUserAsync("up_inv_p");
 
-        var response = await _client.PostAsJsonAsync("/users-permissions",
+        var response = await _client.PostAsJsonAsync("/v1/users-permissions",
             UserPermissionBody(userId, Guid.NewGuid()), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -138,7 +138,7 @@ public class UserPermissionsApiTests : IAsyncLifetime
         var typeId = await CreatePermissionTypeAsync("PT_UP_INACT");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
 
-        var response = await _client.PostAsJsonAsync("/users-permissions",
+        var response = await _client.PostAsJsonAsync("/v1/users-permissions",
             UserPermissionBody(userId, permissionId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
@@ -154,8 +154,8 @@ public class UserPermissionsApiTests : IAsyncLifetime
         var typeId = await CreatePermissionTypeAsync("PT_UP_CONC");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
         var body = UserPermissionBody(userId, permissionId);
-        var t1 = _client.PostAsJsonAsync("/users-permissions", body, TestApiClient.JsonOptions);
-        var t2 = _client.PostAsJsonAsync("/users-permissions", body, TestApiClient.JsonOptions);
+        var t1 = _client.PostAsJsonAsync("/v1/users-permissions", body, TestApiClient.JsonOptions);
+        var t2 = _client.PostAsJsonAsync("/v1/users-permissions", body, TestApiClient.JsonOptions);
         await Task.WhenAll(t1, t2);
 
         var r1 = await t1;
@@ -174,13 +174,13 @@ public class UserPermissionsApiTests : IAsyncLifetime
         var permA = await CreatePermissionAsync(sysId, typeId);
         var permB = await CreatePermissionAsync(sysId, typeId);
 
-        await _client.PostAsJsonAsync("/users-permissions", UserPermissionBody(userId, permA), TestApiClient.JsonOptions);
-        var second = await _client.PostAsJsonAsync("/users-permissions", UserPermissionBody(userId, permB), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/users-permissions", UserPermissionBody(userId, permA), TestApiClient.JsonOptions);
+        var second = await _client.PostAsJsonAsync("/v1/users-permissions", UserPermissionBody(userId, permB), TestApiClient.JsonOptions);
         var secondDto = await second.Content.ReadFromJsonAsync<UserPermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(secondDto);
-        await _client.DeleteAsync($"/users-permissions/{secondDto.Id}");
+        await _client.DeleteAsync($"/v1/users-permissions/{secondDto.Id}");
 
-        var listResp = await _client.GetAsync("/users-permissions");
+        var listResp = await _client.GetAsync("/v1/users-permissions");
         listResp.EnsureSuccessStatusCode();
         var list = await listResp.Content.ReadFromJsonAsync<List<UserPermissionDto>>(TestApiClient.JsonOptions);
         Assert.NotNull(list);
@@ -196,16 +196,16 @@ public class UserPermissionsApiTests : IAsyncLifetime
         var sysId = await CreateSystemAsync("SYS_UP_GET");
         var typeId = await CreatePermissionTypeAsync("PT_UP_GET");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
-        var create = await _client.PostAsJsonAsync("/users-permissions",
+        var create = await _client.PostAsJsonAsync("/v1/users-permissions",
             UserPermissionBody(userId, permissionId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<UserPermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var getOk = await _client.GetAsync($"/users-permissions/{dto.Id}");
+        var getOk = await _client.GetAsync($"/v1/users-permissions/{dto.Id}");
         Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
 
-        await _client.DeleteAsync($"/users-permissions/{dto.Id}");
-        var get404 = await _client.GetAsync($"/users-permissions/{dto.Id}");
+        await _client.DeleteAsync($"/v1/users-permissions/{dto.Id}");
+        var get404 = await _client.GetAsync($"/v1/users-permissions/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
     }
 
@@ -216,13 +216,13 @@ public class UserPermissionsApiTests : IAsyncLifetime
         var sysId = await CreateSystemAsync("SYS_UP_RS_ACT");
         var typeId = await CreatePermissionTypeAsync("PT_UP_RS_ACT");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
-        var create = await _client.PostAsJsonAsync("/users-permissions",
+        var create = await _client.PostAsJsonAsync("/v1/users-permissions",
             UserPermissionBody(userId, permissionId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<UserPermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
         var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch,
-            $"/users-permissions/{dto.Id}/restore"));
+            $"/v1/users-permissions/{dto.Id}/restore"));
         Assert.Equal(HttpStatusCode.NotFound, patch.StatusCode);
     }
 
@@ -233,21 +233,21 @@ public class UserPermissionsApiTests : IAsyncLifetime
         var sysId = await CreateSystemAsync("SYS_UP_RS_OK");
         var typeId = await CreatePermissionTypeAsync("PT_UP_RS_OK");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
-        var create = await _client.PostAsJsonAsync("/users-permissions",
+        var create = await _client.PostAsJsonAsync("/v1/users-permissions",
             UserPermissionBody(userId, permissionId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<UserPermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        await _client.DeleteAsync($"/users-permissions/{dto.Id}");
+        await _client.DeleteAsync($"/v1/users-permissions/{dto.Id}");
 
-        var get404 = await _client.GetAsync($"/users-permissions/{dto.Id}");
+        var get404 = await _client.GetAsync($"/v1/users-permissions/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
 
         var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch,
-            $"/users-permissions/{dto.Id}/restore"));
+            $"/v1/users-permissions/{dto.Id}/restore"));
         Assert.Equal(HttpStatusCode.OK, patch.StatusCode);
 
-        var getOk = await _client.GetAsync($"/users-permissions/{dto.Id}");
+        var getOk = await _client.GetAsync($"/v1/users-permissions/{dto.Id}");
         Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
         var restored = await getOk.Content.ReadFromJsonAsync<UserPermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(restored);
@@ -261,16 +261,16 @@ public class UserPermissionsApiTests : IAsyncLifetime
         var sysId = await CreateSystemAsync("SYS_UP_RS_BAD_U");
         var typeId = await CreatePermissionTypeAsync("PT_UP_RS_BAD_U");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
-        var create = await _client.PostAsJsonAsync("/users-permissions",
+        var create = await _client.PostAsJsonAsync("/v1/users-permissions",
             UserPermissionBody(userId, permissionId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<UserPermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        await _client.DeleteAsync($"/users-permissions/{dto.Id}");
-        await _client.DeleteAsync($"/users/{userId}");
+        await _client.DeleteAsync($"/v1/users-permissions/{dto.Id}");
+        await _client.DeleteAsync($"/v1/users/{userId}");
 
         var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch,
-            $"/users-permissions/{dto.Id}/restore"));
+            $"/v1/users-permissions/{dto.Id}/restore"));
         Assert.Equal(HttpStatusCode.BadRequest, patch.StatusCode);
     }
 
@@ -283,12 +283,12 @@ public class UserPermissionsApiTests : IAsyncLifetime
         var permA = await CreatePermissionAsync(sysId, typeId);
         var permB = await CreatePermissionAsync(sysId, typeId);
 
-        await _client.PostAsJsonAsync("/users-permissions", UserPermissionBody(userId, permA), TestApiClient.JsonOptions);
-        var b = await _client.PostAsJsonAsync("/users-permissions", UserPermissionBody(userId, permB), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/users-permissions", UserPermissionBody(userId, permA), TestApiClient.JsonOptions);
+        var b = await _client.PostAsJsonAsync("/v1/users-permissions", UserPermissionBody(userId, permB), TestApiClient.JsonOptions);
         var dtoB = await b.Content.ReadFromJsonAsync<UserPermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dtoB);
 
-        var put = await _client.PutAsJsonAsync($"/users-permissions/{dtoB.Id}",
+        var put = await _client.PutAsJsonAsync($"/v1/users-permissions/{dtoB.Id}",
             UserPermissionBody(userId, permA), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, put.StatusCode);
     }
@@ -300,12 +300,12 @@ public class UserPermissionsApiTests : IAsyncLifetime
         var sysId = await CreateSystemAsync("SYS_UP_DEL");
         var typeId = await CreatePermissionTypeAsync("PT_UP_DEL");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
-        var create = await _client.PostAsJsonAsync("/users-permissions",
+        var create = await _client.PostAsJsonAsync("/v1/users-permissions",
             UserPermissionBody(userId, permissionId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<UserPermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var del1 = await _client.DeleteAsync($"/users-permissions/{dto.Id}");
+        var del1 = await _client.DeleteAsync($"/v1/users-permissions/{dto.Id}");
         Assert.Equal(HttpStatusCode.NoContent, del1.StatusCode);
 
         using (var scope = _factory.Services.CreateScope())
@@ -315,7 +315,7 @@ public class UserPermissionsApiTests : IAsyncLifetime
             Assert.NotNull(row.DeletedAt);
         }
 
-        var del2 = await _client.DeleteAsync($"/users-permissions/{dto.Id}");
+        var del2 = await _client.DeleteAsync($"/v1/users-permissions/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, del2.StatusCode);
     }
 
@@ -326,11 +326,11 @@ public class UserPermissionsApiTests : IAsyncLifetime
         var sysId = await CreateSystemAsync("SYS_UP_HIDE");
         var typeId = await CreatePermissionTypeAsync("PT_UP_HIDE");
         var permissionId = await CreatePermissionAsync(sysId, typeId);
-        await _client.PostAsJsonAsync("/users-permissions", UserPermissionBody(userId, permissionId), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/users-permissions", UserPermissionBody(userId, permissionId), TestApiClient.JsonOptions);
 
-        await _client.DeleteAsync($"/permissions/{permissionId}");
+        await _client.DeleteAsync($"/v1/permissions/{permissionId}");
 
-        var listResp = await _client.GetAsync("/users-permissions");
+        var listResp = await _client.GetAsync("/v1/users-permissions");
         listResp.EnsureSuccessStatusCode();
         var list = await listResp.Content.ReadFromJsonAsync<List<UserPermissionDto>>(TestApiClient.JsonOptions);
         Assert.NotNull(list);

--- a/AuthService.Tests/UsersApiTests.cs
+++ b/AuthService.Tests/UsersApiTests.cs
@@ -38,7 +38,7 @@ public class UsersApiTests : IAsyncLifetime
     [Fact]
     public async Task Create_Post_ReturnsCreated_WithUtcTimestamps_AndNullDeletedAt()
     {
-        var response = await _client.PostAsJsonAsync("/users",
+        var response = await _client.PostAsJsonAsync("/v1/users",
             UserCreateBody("Usuário X", "usuario.x@example.com"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
@@ -56,18 +56,18 @@ public class UsersApiTests : IAsyncLifetime
     [Fact]
     public async Task Create_DuplicateEmail_ReturnsConflict()
     {
-        await _client.PostAsJsonAsync("/users", UserCreateBody("A", "dup@example.com"), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/users", UserCreateBody("A", "dup@example.com"), TestApiClient.JsonOptions);
 
-        var response = await _client.PostAsJsonAsync("/users", UserCreateBody("B", "dup@example.com"), TestApiClient.JsonOptions);
+        var response = await _client.PostAsJsonAsync("/v1/users", UserCreateBody("B", "dup@example.com"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
 
     [Fact]
     public async Task Create_DuplicateEmail_NormalizesWhitespaceAndCase_ReturnsConflict()
     {
-        await _client.PostAsJsonAsync("/users", UserCreateBody("A", "same@example.com"), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/users", UserCreateBody("A", "same@example.com"), TestApiClient.JsonOptions);
 
-        var response = await _client.PostAsJsonAsync("/users",
+        var response = await _client.PostAsJsonAsync("/v1/users",
             UserCreateBody("B", "  SAME@EXAMPLE.COM  "), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
@@ -75,12 +75,12 @@ public class UsersApiTests : IAsyncLifetime
     [Fact]
     public async Task Update_DuplicateEmail_NormalizesCase_ReturnsConflict()
     {
-        await _client.PostAsJsonAsync("/users", UserCreateBody("A", "a_mail@example.com"), TestApiClient.JsonOptions);
-        var b = await _client.PostAsJsonAsync("/users", UserCreateBody("B", "b_mail@example.com"), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/users", UserCreateBody("A", "a_mail@example.com"), TestApiClient.JsonOptions);
+        var b = await _client.PostAsJsonAsync("/v1/users", UserCreateBody("B", "b_mail@example.com"), TestApiClient.JsonOptions);
         var dtoB = await b.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dtoB);
 
-        var put = await _client.PutAsJsonAsync($"/users/{dtoB.Id}",
+        var put = await _client.PutAsJsonAsync($"/v1/users/{dtoB.Id}",
             UserUpdateBody("B2", "A_MAIL@EXAMPLE.COM"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, put.StatusCode);
     }
@@ -91,8 +91,8 @@ public class UsersApiTests : IAsyncLifetime
         const string email = "concurrent@example.com";
         var bodyA = UserCreateBody("A", email);
         var bodyB = UserCreateBody("B", email);
-        var t1 = _client.PostAsJsonAsync("/users", bodyA, TestApiClient.JsonOptions);
-        var t2 = _client.PostAsJsonAsync("/users", bodyB, TestApiClient.JsonOptions);
+        var t1 = _client.PostAsJsonAsync("/v1/users", bodyA, TestApiClient.JsonOptions);
+        var t2 = _client.PostAsJsonAsync("/v1/users", bodyB, TestApiClient.JsonOptions);
         await Task.WhenAll(t1, t2);
 
         var r1 = await t1;
@@ -105,7 +105,7 @@ public class UsersApiTests : IAsyncLifetime
     [Fact]
     public async Task Create_WhitespaceOnlyName_ReturnsBadRequest()
     {
-        var response = await _client.PostAsJsonAsync("/users",
+        var response = await _client.PostAsJsonAsync("/v1/users",
             UserCreateBody("   ", "n1@example.com"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -113,7 +113,7 @@ public class UsersApiTests : IAsyncLifetime
     [Fact]
     public async Task Create_WhitespaceOnlyEmail_ReturnsBadRequest()
     {
-        var response = await _client.PostAsJsonAsync("/users",
+        var response = await _client.PostAsJsonAsync("/v1/users",
             UserCreateBody("Nome", "\t  "), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -121,7 +121,7 @@ public class UsersApiTests : IAsyncLifetime
     [Fact]
     public async Task Create_WhitespaceOnlyPassword_ReturnsBadRequest()
     {
-        var response = await _client.PostAsJsonAsync("/users",
+        var response = await _client.PostAsJsonAsync("/v1/users",
             new { name = "N", email = "p1@example.com", password = "   ", identity = 1, active = true }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -129,11 +129,11 @@ public class UsersApiTests : IAsyncLifetime
     [Fact]
     public async Task Put_WhitespaceOnlyName_ReturnsBadRequest()
     {
-        var create = await _client.PostAsJsonAsync("/users", UserCreateBody("S", "w1@example.com"), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/users", UserCreateBody("S", "w1@example.com"), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var put = await _client.PutAsJsonAsync($"/users/{dto.Id}",
+        var put = await _client.PutAsJsonAsync($"/v1/users/{dto.Id}",
             UserUpdateBody("   ", "w1@example.com"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
     }
@@ -141,14 +141,14 @@ public class UsersApiTests : IAsyncLifetime
     [Fact]
     public async Task GetAll_ReturnsOnlyActiveUsers()
     {
-        await _client.PostAsJsonAsync("/users", UserCreateBody("Ativo", "ativo@example.com"), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/users", UserCreateBody("Ativo", "ativo@example.com"), TestApiClient.JsonOptions);
 
-        var other = await _client.PostAsJsonAsync("/users", UserCreateBody("Outro", "outro@example.com"), TestApiClient.JsonOptions);
+        var other = await _client.PostAsJsonAsync("/v1/users", UserCreateBody("Outro", "outro@example.com"), TestApiClient.JsonOptions);
         var toDelete = await other.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
         Assert.NotNull(toDelete);
-        await _client.DeleteAsync($"/users/{toDelete.Id}");
+        await _client.DeleteAsync($"/v1/users/{toDelete.Id}");
 
-        var listResp = await _client.GetAsync("/users");
+        var listResp = await _client.GetAsync("/v1/users");
         listResp.EnsureSuccessStatusCode();
         var list = await listResp.Content.ReadFromJsonAsync<List<UserDto>>(TestApiClient.JsonOptions);
         Assert.NotNull(list);
@@ -160,31 +160,31 @@ public class UsersApiTests : IAsyncLifetime
     [Fact]
     public async Task GetById_Active_ReturnsOk_Deleted_Returns404()
     {
-        var create = await _client.PostAsJsonAsync("/users", UserCreateBody("S", "g1@example.com"), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/users", UserCreateBody("S", "g1@example.com"), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var getOk = await _client.GetAsync($"/users/{dto.Id}");
+        var getOk = await _client.GetAsync($"/v1/users/{dto.Id}");
         Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
 
-        await _client.DeleteAsync($"/users/{dto.Id}");
-        var get404 = await _client.GetAsync($"/users/{dto.Id}");
+        await _client.DeleteAsync($"/v1/users/{dto.Id}");
+        var get404 = await _client.GetAsync($"/v1/users/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
     }
 
     [Fact]
     public async Task Update_Active_ReturnsOk_Deleted_Returns404()
     {
-        var create = await _client.PostAsJsonAsync("/users", UserCreateBody("S", "u1@example.com"), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/users", UserCreateBody("S", "u1@example.com"), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var putOk = await _client.PutAsJsonAsync($"/users/{dto.Id}",
+        var putOk = await _client.PutAsJsonAsync($"/v1/users/{dto.Id}",
             UserUpdateBody("S2", "u1@example.com", identity: 2, active: false), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.OK, putOk.StatusCode);
 
-        await _client.DeleteAsync($"/users/{dto.Id}");
-        var put404 = await _client.PutAsJsonAsync($"/users/{dto.Id}",
+        await _client.DeleteAsync($"/v1/users/{dto.Id}");
+        var put404 = await _client.PutAsJsonAsync($"/v1/users/{dto.Id}",
             UserUpdateBody("S3", "u1@example.com"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.NotFound, put404.StatusCode);
     }
@@ -192,11 +192,11 @@ public class UsersApiTests : IAsyncLifetime
     [Fact]
     public async Task Delete_SoftDelete_ThenDeleteAgain_Returns404()
     {
-        var create = await _client.PostAsJsonAsync("/users", UserCreateBody("S", "d1@example.com"), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/users", UserCreateBody("S", "d1@example.com"), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var del1 = await _client.DeleteAsync($"/users/{dto.Id}");
+        var del1 = await _client.DeleteAsync($"/v1/users/{dto.Id}");
         Assert.Equal(HttpStatusCode.NoContent, del1.StatusCode);
 
         using (var scope = _factory.Services.CreateScope())
@@ -206,27 +206,27 @@ public class UsersApiTests : IAsyncLifetime
             Assert.NotNull(row.DeletedAt);
         }
 
-        var del2 = await _client.DeleteAsync($"/users/{dto.Id}");
+        var del2 = await _client.DeleteAsync($"/v1/users/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, del2.StatusCode);
     }
 
     [Fact]
     public async Task UpdatePassword_Put_ThenLoginWithNewPassword_ReturnsOk()
     {
-        var create = await _client.PostAsJsonAsync("/users", UserCreateBody("P", "pwd.change@example.com"), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/users", UserCreateBody("P", "pwd.change@example.com"), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var putPwd = await _client.PutAsJsonAsync($"/users/{dto.Id}/password",
+        var putPwd = await _client.PutAsJsonAsync($"/v1/users/{dto.Id}/password",
             new { password = "NovaSenhaSegura2!" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.OK, putPwd.StatusCode);
 
         var anon = _factory.CreateClient();
-        var oldLogin = await anon.PostAsJsonAsync("/auth/login",
+        var oldLogin = await anon.PostAsJsonAsync("/v1/auth/login",
             new { email = "pwd.change@example.com", password = "SenhaSegura1!" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Unauthorized, oldLogin.StatusCode);
 
-        var newLogin = await anon.PostAsJsonAsync("/auth/login",
+        var newLogin = await anon.PostAsJsonAsync("/v1/auth/login",
             new { email = "pwd.change@example.com", password = "NovaSenhaSegura2!" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.OK, newLogin.StatusCode);
     }
@@ -234,25 +234,25 @@ public class UsersApiTests : IAsyncLifetime
     [Fact]
     public async Task Restore_Deleted_ThenOperationsWorkAgain()
     {
-        var create = await _client.PostAsJsonAsync("/users", UserCreateBody("S", "r1@example.com"), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/users", UserCreateBody("S", "r1@example.com"), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        await _client.DeleteAsync($"/users/{dto.Id}");
+        await _client.DeleteAsync($"/v1/users/{dto.Id}");
 
-        var get404 = await _client.GetAsync($"/users/{dto.Id}");
+        var get404 = await _client.GetAsync($"/v1/users/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
 
-        var restore = await _client.PostAsync($"/users/{dto.Id}/restore", null);
+        var restore = await _client.PostAsync($"/v1/users/{dto.Id}/restore", null);
         Assert.Equal(HttpStatusCode.OK, restore.StatusCode);
 
-        var getOk = await _client.GetAsync($"/users/{dto.Id}");
+        var getOk = await _client.GetAsync($"/v1/users/{dto.Id}");
         Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
         var restored = await getOk.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
         Assert.NotNull(restored);
         Assert.Null(restored.DeletedAt);
 
-        var listResp = await _client.GetAsync("/users");
+        var listResp = await _client.GetAsync("/v1/users");
         listResp.EnsureSuccessStatusCode();
         var list = await listResp.Content.ReadFromJsonAsync<List<UserDto>>(TestApiClient.JsonOptions);
         Assert.NotNull(list);

--- a/AuthService.Tests/UsersRolesApiTests.cs
+++ b/AuthService.Tests/UsersRolesApiTests.cs
@@ -32,7 +32,7 @@ public class UsersRolesApiTests : IAsyncLifetime
     private async Task<Guid> CreateUserAsync(string emailLocal)
     {
         var email = $"{emailLocal}@ur.test";
-        var r = await _client.PostAsJsonAsync("/users", UserCreateBody("U", email), TestApiClient.JsonOptions);
+        var r = await _client.PostAsJsonAsync("/v1/users", UserCreateBody("U", email), TestApiClient.JsonOptions);
         r.EnsureSuccessStatusCode();
         var dto = await r.Content.ReadFromJsonAsync<RefGuidDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
@@ -41,7 +41,7 @@ public class UsersRolesApiTests : IAsyncLifetime
 
     private async Task<Guid> CreateRoleAsync(string code)
     {
-        var r = await _client.PostAsJsonAsync("/roles",
+        var r = await _client.PostAsJsonAsync("/v1/roles",
             new { name = "R", code }, TestApiClient.JsonOptions);
         r.EnsureSuccessStatusCode();
         var dto = await r.Content.ReadFromJsonAsync<RefGuidDto>(TestApiClient.JsonOptions);
@@ -57,7 +57,7 @@ public class UsersRolesApiTests : IAsyncLifetime
         var userId = await CreateUserAsync("ur_create");
         var roleId = await CreateRoleAsync("ROLE_UR_CREATE");
 
-        var response = await _client.PostAsJsonAsync("/users-roles", UserRoleBody(userId, roleId), TestApiClient.JsonOptions);
+        var response = await _client.PostAsJsonAsync("/v1/users-roles", UserRoleBody(userId, roleId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
         var dto = await response.Content.ReadFromJsonAsync<UserRoleDto>(TestApiClient.JsonOptions);
@@ -76,9 +76,9 @@ public class UsersRolesApiTests : IAsyncLifetime
         var userId = await CreateUserAsync("ur_dup");
         var roleId = await CreateRoleAsync("ROLE_UR_DUP");
 
-        await _client.PostAsJsonAsync("/users-roles", UserRoleBody(userId, roleId), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/users-roles", UserRoleBody(userId, roleId), TestApiClient.JsonOptions);
 
-        var response = await _client.PostAsJsonAsync("/users-roles", UserRoleBody(userId, roleId), TestApiClient.JsonOptions);
+        var response = await _client.PostAsJsonAsync("/v1/users-roles", UserRoleBody(userId, roleId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
 
@@ -87,7 +87,7 @@ public class UsersRolesApiTests : IAsyncLifetime
     {
         var roleId = await CreateRoleAsync("ROLE_UR_INV_U");
 
-        var response = await _client.PostAsJsonAsync("/users-roles",
+        var response = await _client.PostAsJsonAsync("/v1/users-roles",
             UserRoleBody(Guid.NewGuid(), roleId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -97,7 +97,7 @@ public class UsersRolesApiTests : IAsyncLifetime
     {
         var userId = await CreateUserAsync("ur_inv_r");
 
-        var response = await _client.PostAsJsonAsync("/users-roles",
+        var response = await _client.PostAsJsonAsync("/v1/users-roles",
             UserRoleBody(userId, Guid.NewGuid()), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -108,8 +108,8 @@ public class UsersRolesApiTests : IAsyncLifetime
         var userId = await CreateUserAsync("ur_conc");
         var roleId = await CreateRoleAsync("ROLE_UR_CONC");
         var body = UserRoleBody(userId, roleId);
-        var t1 = _client.PostAsJsonAsync("/users-roles", body, TestApiClient.JsonOptions);
-        var t2 = _client.PostAsJsonAsync("/users-roles", body, TestApiClient.JsonOptions);
+        var t1 = _client.PostAsJsonAsync("/v1/users-roles", body, TestApiClient.JsonOptions);
+        var t2 = _client.PostAsJsonAsync("/v1/users-roles", body, TestApiClient.JsonOptions);
         await Task.WhenAll(t1, t2);
 
         var r1 = await t1;
@@ -126,13 +126,13 @@ public class UsersRolesApiTests : IAsyncLifetime
         var roleA = await CreateRoleAsync("ROLE_UR_LIST_A");
         var roleB = await CreateRoleAsync("ROLE_UR_LIST_B");
 
-        await _client.PostAsJsonAsync("/users-roles", UserRoleBody(userId, roleA), TestApiClient.JsonOptions);
-        var second = await _client.PostAsJsonAsync("/users-roles", UserRoleBody(userId, roleB), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/users-roles", UserRoleBody(userId, roleA), TestApiClient.JsonOptions);
+        var second = await _client.PostAsJsonAsync("/v1/users-roles", UserRoleBody(userId, roleB), TestApiClient.JsonOptions);
         var secondDto = await second.Content.ReadFromJsonAsync<UserRoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(secondDto);
-        await _client.DeleteAsync($"/users-roles/{secondDto.Id}");
+        await _client.DeleteAsync($"/v1/users-roles/{secondDto.Id}");
 
-        var listResp = await _client.GetAsync("/users-roles");
+        var listResp = await _client.GetAsync("/v1/users-roles");
         listResp.EnsureSuccessStatusCode();
         var list = await listResp.Content.ReadFromJsonAsync<List<UserRoleDto>>(TestApiClient.JsonOptions);
         Assert.NotNull(list);
@@ -146,15 +146,15 @@ public class UsersRolesApiTests : IAsyncLifetime
     {
         var userId = await CreateUserAsync("ur_get");
         var roleId = await CreateRoleAsync("ROLE_UR_GET");
-        var create = await _client.PostAsJsonAsync("/users-roles", UserRoleBody(userId, roleId), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/users-roles", UserRoleBody(userId, roleId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<UserRoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var getOk = await _client.GetAsync($"/users-roles/{dto.Id}");
+        var getOk = await _client.GetAsync($"/v1/users-roles/{dto.Id}");
         Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
 
-        await _client.DeleteAsync($"/users-roles/{dto.Id}");
-        var get404 = await _client.GetAsync($"/users-roles/{dto.Id}");
+        await _client.DeleteAsync($"/v1/users-roles/{dto.Id}");
+        var get404 = await _client.GetAsync($"/v1/users-roles/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
     }
 
@@ -163,11 +163,11 @@ public class UsersRolesApiTests : IAsyncLifetime
     {
         var userId = await CreateUserAsync("ur_rs_act");
         var roleId = await CreateRoleAsync("ROLE_UR_RS_ACT");
-        var create = await _client.PostAsJsonAsync("/users-roles", UserRoleBody(userId, roleId), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/users-roles", UserRoleBody(userId, roleId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<UserRoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch, $"/users-roles/{dto.Id}/restore"));
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch, $"/v1/users-roles/{dto.Id}/restore"));
         Assert.Equal(HttpStatusCode.NotFound, patch.StatusCode);
     }
 
@@ -176,19 +176,19 @@ public class UsersRolesApiTests : IAsyncLifetime
     {
         var userId = await CreateUserAsync("ur_rs_ok");
         var roleId = await CreateRoleAsync("ROLE_UR_RS_OK");
-        var create = await _client.PostAsJsonAsync("/users-roles", UserRoleBody(userId, roleId), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/users-roles", UserRoleBody(userId, roleId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<UserRoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        await _client.DeleteAsync($"/users-roles/{dto.Id}");
+        await _client.DeleteAsync($"/v1/users-roles/{dto.Id}");
 
-        var get404 = await _client.GetAsync($"/users-roles/{dto.Id}");
+        var get404 = await _client.GetAsync($"/v1/users-roles/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
 
-        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch, $"/users-roles/{dto.Id}/restore"));
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch, $"/v1/users-roles/{dto.Id}/restore"));
         Assert.Equal(HttpStatusCode.OK, patch.StatusCode);
 
-        var getOk = await _client.GetAsync($"/users-roles/{dto.Id}");
+        var getOk = await _client.GetAsync($"/v1/users-roles/{dto.Id}");
         Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
         var restored = await getOk.Content.ReadFromJsonAsync<UserRoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(restored);
@@ -200,14 +200,14 @@ public class UsersRolesApiTests : IAsyncLifetime
     {
         var userId = await CreateUserAsync("ur_rs_bad_u");
         var roleId = await CreateRoleAsync("ROLE_UR_RS_BAD_U");
-        var create = await _client.PostAsJsonAsync("/users-roles", UserRoleBody(userId, roleId), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/users-roles", UserRoleBody(userId, roleId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<UserRoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        await _client.DeleteAsync($"/users-roles/{dto.Id}");
-        await _client.DeleteAsync($"/users/{userId}");
+        await _client.DeleteAsync($"/v1/users-roles/{dto.Id}");
+        await _client.DeleteAsync($"/v1/users/{userId}");
 
-        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch, $"/users-roles/{dto.Id}/restore"));
+        var patch = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Patch, $"/v1/users-roles/{dto.Id}/restore"));
         Assert.Equal(HttpStatusCode.BadRequest, patch.StatusCode);
     }
 
@@ -218,12 +218,12 @@ public class UsersRolesApiTests : IAsyncLifetime
         var roleA = await CreateRoleAsync("ROLE_UR_PUT_A");
         var roleB = await CreateRoleAsync("ROLE_UR_PUT_B");
 
-        await _client.PostAsJsonAsync("/users-roles", UserRoleBody(userId, roleA), TestApiClient.JsonOptions);
-        var b = await _client.PostAsJsonAsync("/users-roles", UserRoleBody(userId, roleB), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/users-roles", UserRoleBody(userId, roleA), TestApiClient.JsonOptions);
+        var b = await _client.PostAsJsonAsync("/v1/users-roles", UserRoleBody(userId, roleB), TestApiClient.JsonOptions);
         var dtoB = await b.Content.ReadFromJsonAsync<UserRoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dtoB);
 
-        var put = await _client.PutAsJsonAsync($"/users-roles/{dtoB.Id}", UserRoleBody(userId, roleA), TestApiClient.JsonOptions);
+        var put = await _client.PutAsJsonAsync($"/v1/users-roles/{dtoB.Id}", UserRoleBody(userId, roleA), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, put.StatusCode);
     }
 
@@ -232,11 +232,11 @@ public class UsersRolesApiTests : IAsyncLifetime
     {
         var userId = await CreateUserAsync("ur_del");
         var roleId = await CreateRoleAsync("ROLE_UR_DEL");
-        var create = await _client.PostAsJsonAsync("/users-roles", UserRoleBody(userId, roleId), TestApiClient.JsonOptions);
+        var create = await _client.PostAsJsonAsync("/v1/users-roles", UserRoleBody(userId, roleId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<UserRoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        var del1 = await _client.DeleteAsync($"/users-roles/{dto.Id}");
+        var del1 = await _client.DeleteAsync($"/v1/users-roles/{dto.Id}");
         Assert.Equal(HttpStatusCode.NoContent, del1.StatusCode);
 
         using (var scope = _factory.Services.CreateScope())
@@ -246,7 +246,7 @@ public class UsersRolesApiTests : IAsyncLifetime
             Assert.NotNull(row.DeletedAt);
         }
 
-        var del2 = await _client.DeleteAsync($"/users-roles/{dto.Id}");
+        var del2 = await _client.DeleteAsync($"/v1/users-roles/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, del2.StatusCode);
     }
 
@@ -255,11 +255,11 @@ public class UsersRolesApiTests : IAsyncLifetime
     {
         var userId = await CreateUserAsync("ur_hide_r");
         var roleId = await CreateRoleAsync("ROLE_UR_HIDE_R");
-        await _client.PostAsJsonAsync("/users-roles", UserRoleBody(userId, roleId), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/v1/users-roles", UserRoleBody(userId, roleId), TestApiClient.JsonOptions);
 
-        await _client.DeleteAsync($"/roles/{roleId}");
+        await _client.DeleteAsync($"/v1/roles/{roleId}");
 
-        var listResp = await _client.GetAsync("/users-roles");
+        var listResp = await _client.GetAsync("/v1/users-roles");
         listResp.EnsureSuccessStatusCode();
         var list = await listResp.Content.ReadFromJsonAsync<List<UserRoleDto>>(TestApiClient.JsonOptions);
         Assert.NotNull(list);

--- a/AuthService/AuthService.csproj
+++ b/AuthService/AuthService.csproj
@@ -10,12 +10,12 @@
 
   <ItemGroup>
     <PackageReference Include="JWT" Version="11.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
   </ItemGroup>
 
 </Project>

--- a/AuthService/OpenApi/V1PathPrefixDocumentFilter.cs
+++ b/AuthService/OpenApi/V1PathPrefixDocumentFilter.cs
@@ -1,0 +1,24 @@
+using Microsoft.OpenApi;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace AuthService.OpenApi;
+
+/// <summary>
+/// Prefixa paths no OpenAPI com /v1, alinhando ao <c>MapGroup("/v1")</c> (ApiExplorer não inclui o grupo).
+/// </summary>
+public sealed class V1PathPrefixDocumentFilter : IDocumentFilter
+{
+    public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+    {
+        var keys = swaggerDoc.Paths.Keys.ToList();
+        foreach (var path in keys)
+        {
+            if (path.StartsWith("/v1", StringComparison.Ordinal))
+                continue;
+            if (!swaggerDoc.Paths.TryGetValue(path, out var item) || item is null)
+                continue;
+            swaggerDoc.Paths.Remove(path);
+            swaggerDoc.Paths.Add("/v1" + path, item);
+        }
+    }
+}

--- a/AuthService/Program.cs
+++ b/AuthService/Program.cs
@@ -1,8 +1,10 @@
 using AuthService.Auth;
 using AuthService.Data;
+using AuthService.OpenApi;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.OpenApi;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -34,27 +36,47 @@ builder.Services.AddAuthorization(options =>
 });
 
 builder.Services.AddControllers();
-
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
-builder.Services.AddOpenApi();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new OpenApiInfo
+    {
+        Title = "Auth Service API",
+        Version = "v1",
+        Description = "Autenticação, autorização e cadastros correlatos. Rotas versionadas sob o prefixo /v1."
+    });
+    options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Name = "Authorization",
+        Type = SecuritySchemeType.Http,
+        Scheme = "bearer",
+        BearerFormat = "JWT",
+        In = ParameterLocation.Header,
+        Description = "JWT no header Authorization (Bearer {token})."
+    });
+    options.DocumentFilter<V1PathPrefixDocumentFilter>();
+});
 
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
-{
-    app.MapOpenApi();
-}
-
 if (!app.Environment.IsEnvironment("Testing"))
 {
     app.UseHttpsRedirection();
 }
 
+// Swagger antes de autenticação/autorização: documentação e OpenAPI JSON são anônimos.
+app.UseSwagger();
+app.UseSwaggerUI(options =>
+{
+    options.RoutePrefix = "docs";
+    options.SwaggerEndpoint("/swagger/v1/swagger.json", "Auth Service API v1");
+});
+
 app.UseAuthentication();
 app.UseAuthorization();
 
-app.MapControllers();
+app.MapGroup("/v1").MapControllers();
 
 if (!app.Environment.IsEnvironment("Testing"))
 {


### PR DESCRIPTION
## Resumo
Implementa versionamento global com prefixo `/v1`, documentação OpenAPI/Swagger alinhada às rotas reais e UI de documentação em `/docs`, conforme escopo da issue.

## Alterações realizadas
- Configuração em `Program.cs` e pacotes em `AuthService.csproj` para API versioning e Swagger.
- Filtro `V1PathPrefixDocumentFilter` em `AuthService/OpenApi/` para consistência do contrato documentado.
- Ajuste do `TestApiClient` e dos testes de API existentes para usar o prefixo `/v1`.
- Novos testes de integração em `ApiVersioningAndDocsTests.cs` (rotas versionadas e disponibilidade de `/docs`).

## Riscos
- Consumidores que chamem URLs sem `/v1` precisarão migrar (já mapeado na issue).
- Divergência documentação vs. implementação mitigada pelo filtro e pelos testes.

## Evidências de teste
- **Local:** `dotnet test` não foi executado neste ambiente (SDK .NET indisponível no host).
- **Recomendado na revisão:** `dotnet test` no CI ou máquina com SDK instalado; validar também `GET /docs` e exemplos de rotas `/v1/...` manualmente se necessário.

Closes #25

Made with [Cursor](https://cursor.com)