### PR TITLE
#30 | Adicionar seed de usuário padrão do sistema

### DIFF
--- a/AuthService.Tests/DefaultSystemUserSeederTests.cs
+++ b/AuthService.Tests/DefaultSystemUserSeederTests.cs
@@ -1,0 +1,64 @@
+using System.Net;
+using System.Net.Http.Json;
+using AuthService.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AuthService.Tests;
+
+public class DefaultSystemUserSeederTests : IAsyncLifetime
+{
+    private WebAppFactory _factory = null!;
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        _factory = new WebAppFactory();
+        _client = _factory.CreateClient();
+    }
+
+    public Task DisposeAsync()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task DefaultUser_ExistsAfterBootstrap_CanLoginWithSeededCredentials()
+    {
+        var response = await _client.PostAsJsonAsync("/v1/auth/login",
+            new { email = DefaultSystemUserSeeder.Email, password = DefaultSystemUserSeeder.Password },
+            TestApiClient.JsonOptions);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<LoginTokenDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(body);
+        Assert.False(string.IsNullOrWhiteSpace(body.Token));
+    }
+
+    [Fact]
+    public async Task EnsureDefaultUserAsync_Idempotent_DoesNotDuplicateUser()
+    {
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            await DefaultSystemUserSeeder.EnsureDefaultUserAsync(db);
+            await DefaultSystemUserSeeder.EnsureDefaultUserAsync(db);
+        }
+
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var normalized = DefaultSystemUserSeeder.Email.Trim().ToLowerInvariant();
+            var count = await db.Users.IgnoreQueryFilters().CountAsync(u => u.Email == normalized);
+            Assert.Equal(1, count);
+        }
+    }
+
+    private sealed class LoginTokenDto
+    {
+        public string Token { get; set; } = string.Empty;
+    }
+}

--- a/AuthService.Tests/WebAppFactory.cs
+++ b/AuthService.Tests/WebAppFactory.cs
@@ -61,6 +61,7 @@ public class WebAppFactory : WebApplicationFactory<Program>
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
         db.Database.Migrate();
         OfficialCatalogSeeder.EnsureCatalogAsync(db).GetAwaiter().GetResult();
+        DefaultSystemUserSeeder.EnsureDefaultUserAsync(db).GetAwaiter().GetResult();
         IntegrationBootstrapSeeder.EnsureBootstrapUserAsync(db).GetAwaiter().GetResult();
         return host;
     }

--- a/AuthService/Data/DefaultSystemUserSeeder.cs
+++ b/AuthService/Data/DefaultSystemUserSeeder.cs
@@ -1,0 +1,67 @@
+using AuthService.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace AuthService.Data;
+
+/// <summary>Garante o usuário padrão do sistema (idempotente). Executar após <see cref="OfficialCatalogSeeder"/>.</summary>
+public static class DefaultSystemUserSeeder
+{
+    public const string Email = "root@email.com.br";
+    public const string Password = "toor";
+
+    public static async Task EnsureDefaultUserAsync(AppDbContext db, CancellationToken cancellationToken = default)
+    {
+        var normalizedEmail = Email.Trim().ToLowerInvariant();
+        var existing = await db.Users.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(u => u.Email == normalizedEmail, cancellationToken);
+
+        var utc = DateTime.UtcNow;
+        User user;
+
+        if (existing is null)
+        {
+            user = new User
+            {
+                Name = "Usuário padrão do sistema",
+                Email = normalizedEmail,
+                Password = Password,
+                Identity = 0,
+                Active = true,
+                TokenVersion = 0,
+                CreatedAt = utc,
+                UpdatedAt = utc,
+                DeletedAt = null
+            };
+            db.Users.Add(user);
+            await db.SaveChangesAsync(cancellationToken);
+        }
+        else
+        {
+            user = existing;
+        }
+
+        var allPermissionIds = await db.Permissions.AsNoTracking().Select(p => p.Id).ToListAsync(cancellationToken);
+
+        var existingLinks = (await db.UserPermissions.AsNoTracking()
+            .Where(up => up.UserId == user.Id)
+            .Select(up => up.PermissionId)
+            .ToListAsync(cancellationToken)).ToHashSet();
+
+        foreach (var pid in allPermissionIds)
+        {
+            if (existingLinks.Contains(pid))
+                continue;
+
+            db.UserPermissions.Add(new AppUserPermission
+            {
+                UserId = user.Id,
+                PermissionId = pid,
+                CreatedAt = utc,
+                UpdatedAt = utc,
+                DeletedAt = null
+            });
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/AuthService/Program.cs
+++ b/AuthService/Program.cs
@@ -85,6 +85,7 @@ if (!app.Environment.IsEnvironment("Testing"))
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
         await db.Database.MigrateAsync();
         await OfficialCatalogSeeder.EnsureCatalogAsync(db);
+        await DefaultSystemUserSeeder.EnsureDefaultUserAsync(db);
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ export Auth__Jwt__Secret="sua-chave-com-pelo-menos-32-caracteres!!"
 2. **Pipeline HTTP** — em ambientes diferentes de **Testing**, `UseHttpsRedirection`. **Swagger** e **Swagger UI** são registrados **antes** de autenticação/autorização, ficando **anônimos**.
 3. **`UseAuthentication`** / **`UseAuthorization`** — JWT *handler* valida cabeçalho `Authorization: Bearer …`, *claims* e coerência com o usuário no banco (`TokenVersion`, ativo).
 4. **`MapGroup("/v1").MapControllers()`** — todas as rotas de API ficam versionadas em `/v1`.
-5. **Pós-build (Development e Production apenas)** — `OfficialCatalogSeeder.EnsureCatalogAsync` garante sistemas, tipos e permissões oficiais no banco.
+5. **Pós-build (Development e Production apenas)** — `OfficialCatalogSeeder.EnsureCatalogAsync` garante sistemas, tipos e permissões oficiais no banco; em seguida `DefaultSystemUserSeeder.EnsureDefaultUserAsync` garante o usuário padrão do sistema (e-mail `root@email.com.br`, senha inicial na constante `DefaultSystemUserSeeder.Password`) com vínculos às permissões do catálogo, de forma idempotente. **Em produção, troque a senha imediatamente após o primeiro acesso.**
 
 ---
 
@@ -126,7 +126,7 @@ export Auth__Jwt__Secret="sua-chave-com-pelo-menos-32-caracteres!!"
 AuthService/
 ├── Controllers/          # Endpoints REST por agregado (Auth, Systems, Users, …)
 ├── Auth/                 # JWT, handler Bearer, políticas perm:*, permissões efetivas
-├── Data/                 # AppDbContext, migrations, seeders (catálogo oficial, bootstrap de testes)
+├── Data/                 # AppDbContext, migrations, seeders (catálogo oficial, usuário padrão, bootstrap de testes)
 ├── Models/               # Entidades EF Core
 ├── OpenApi/              # Filtros Swagger (prefixo /v1 nos paths do documento)
 └── Program.cs            # Composição, pipeline, mapa de rotas


### PR DESCRIPTION
## Resumo
Implementa seed idempotente para o usuário padrão `root@email.com.br` com senha inicial `toor`, alinhada ao armazenamento atual de senha (igual `UsersController` / `IntegrationBootstrapSeeder`). Garante permissões do catálogo após `OfficialCatalogSeeder`.

Closes #30

## Alterações realizadas
- Novo `DefaultSystemUserSeeder` em `AuthService/Data/`
- Chamada no startup (não-Testing) após migrações e catálogo oficial
- `WebAppFactory`: mesma ordem para testes de integração
- Testes: login com credenciais da seed e idempotência de `EnsureDefaultUserAsync`
- README: fluxo de inicialização e aviso de troca de senha em produção

## Riscos
- Credencial padrão conhecida: mitigado com documentação para troca imediata em produção e uso consciente em ambientes compartilhados.

## Evidências de teste
- `docker compose --profile test run --rm test`: **154 testes passando** (incluindo os novos).
- `dotnet format` (`--verify-no-changes`) em `AuthService` e `AuthService.Tests` (via imagem `mcr.microsoft.com/dotnet/sdk:10.0`).
- Build: `dotnet build` nos projetos (Docker SDK 10.0).

Made with [Cursor](https://cursor.com)