### PR TITLE
#32 | Migrar armazenamento de senha para hash e ajustar fluxo de login

### DIFF
--- a/AuthService.Tests/AuthApiTests.cs
+++ b/AuthService.Tests/AuthApiTests.cs
@@ -53,6 +53,25 @@ public class AuthApiTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Login_AfterUserCreate_StoredPassword_IsHashedNotPlaintext()
+    {
+        const string plain = "SenhaSegura1!";
+        await _admin.PostAsJsonAsync("/v1/users",
+            new { name = "Hash Check", email = "hash.check@example.com", password = plain, identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        var login = await _anon.PostAsJsonAsync("/v1/auth/login",
+            LoginBody("hash.check@example.com", plain), TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var row = await db.Users.AsNoTracking().FirstAsync(u => u.Email == "hash.check@example.com");
+        Assert.NotEqual(plain, row.Password);
+        Assert.True(row.Password.Length > 80, "Esperado hash PBKDF2 na coluna Password.");
+    }
+
+    [Fact]
     public async Task Login_ValidCredentials_ReturnsToken()
     {
         await _admin.PostAsJsonAsync("/v1/users",

--- a/AuthService.Tests/DefaultSystemUserSeederTests.cs
+++ b/AuthService.Tests/DefaultSystemUserSeederTests.cs
@@ -26,6 +26,17 @@ public class DefaultSystemUserSeederTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task DefaultUser_StoredPassword_IsNotPlaintext()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var normalized = DefaultSystemUserSeeder.Email.Trim().ToLowerInvariant();
+        var row = await db.Users.AsNoTracking().IgnoreQueryFilters().FirstAsync(u => u.Email == normalized);
+        Assert.NotEqual(DefaultSystemUserSeeder.Password, row.Password);
+        Assert.True(row.Password.Length > 80, "Esperado hash PBKDF2 na coluna Password, não texto plano.");
+    }
+
+    [Fact]
     public async Task DefaultUser_ExistsAfterBootstrap_CanLoginWithSeededCredentials()
     {
         var response = await _client.PostAsJsonAsync("/v1/auth/login",

--- a/AuthService/Controllers/Auth/AuthController.cs
+++ b/AuthService/Controllers/Auth/AuthController.cs
@@ -2,6 +2,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;
 using AuthService.Auth;
 using AuthService.Data;
+using AuthService.Security;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -66,10 +67,24 @@ public class AuthController : ControllerBase
             return Unauthorized(new { message = "Credenciais inválidas." });
 
         var user = await _db.Users.FirstOrDefaultAsync(u => u.Email == email);
-        if (user is null || user.Password != password)
+        if (user is null)
         {
             _logger.LogWarning("Tentativa de login falhou para o email {Email}.", email);
             return Unauthorized(new { message = "Credenciais inválidas." });
+        }
+
+        var (passwordOk, newStoredPassword) = UserPasswordHasher.Verify(user, password);
+        if (!passwordOk)
+        {
+            _logger.LogWarning("Tentativa de login falhou para o email {Email}.", email);
+            return Unauthorized(new { message = "Credenciais inválidas." });
+        }
+
+        if (newStoredPassword is not null)
+        {
+            user.Password = newStoredPassword;
+            user.UpdatedAt = DateTime.UtcNow;
+            await _db.SaveChangesAsync();
         }
 
         if (!user.Active)

--- a/AuthService/Controllers/Users/UsersController.cs
+++ b/AuthService/Controllers/Users/UsersController.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using AuthService.Auth;
 using AuthService.Data;
+using AuthService.Security;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -179,7 +180,7 @@ public class UsersController : ControllerBase
         {
             Name = name,
             Email = email,
-            Password = password,
+            Password = UserPasswordHasher.HashPlainPassword(password),
             Identity = request.Identity,
             Active = request.Active,
             CreatedAt = now,
@@ -293,7 +294,7 @@ public class UsersController : ControllerBase
         if (user is null)
             return NotFound(new { message = "Usuário não encontrado." });
 
-        user.Password = password;
+        user.Password = UserPasswordHasher.HashPlainPassword(password);
         user.UpdatedAt = DateTime.UtcNow;
         await _db.SaveChangesAsync();
         return Ok(ToResponse(user));

--- a/AuthService/Data/DefaultSystemUserSeeder.cs
+++ b/AuthService/Data/DefaultSystemUserSeeder.cs
@@ -1,4 +1,5 @@
 using AuthService.Models;
+using AuthService.Security;
 using Microsoft.EntityFrameworkCore;
 
 namespace AuthService.Data;
@@ -24,7 +25,7 @@ public static class DefaultSystemUserSeeder
             {
                 Name = "Usuário padrão do sistema",
                 Email = normalizedEmail,
-                Password = Password,
+                Password = UserPasswordHasher.HashPlainPassword(Password),
                 Identity = 0,
                 Active = true,
                 TokenVersion = 0,
@@ -38,6 +39,13 @@ public static class DefaultSystemUserSeeder
         else
         {
             user = existing;
+            var (_, newHash) = UserPasswordHasher.Verify(user, Password);
+            if (newHash is not null)
+            {
+                user.Password = newHash;
+                user.UpdatedAt = utc;
+                await db.SaveChangesAsync(cancellationToken);
+            }
         }
 
         var allPermissionIds = await db.Permissions.AsNoTracking().Select(p => p.Id).ToListAsync(cancellationToken);

--- a/AuthService/Data/IntegrationBootstrapSeeder.cs
+++ b/AuthService/Data/IntegrationBootstrapSeeder.cs
@@ -1,4 +1,5 @@
 using AuthService.Models;
+using AuthService.Security;
 using Microsoft.EntityFrameworkCore;
 
 namespace AuthService.Data;
@@ -24,7 +25,7 @@ public static class IntegrationBootstrapSeeder
             {
                 Name = "Integration Bootstrap",
                 Email = normalizedEmail,
-                Password = Password,
+                Password = UserPasswordHasher.HashPlainPassword(Password),
                 Identity = 0,
                 Active = true,
                 TokenVersion = 0,
@@ -38,6 +39,13 @@ public static class IntegrationBootstrapSeeder
         else
         {
             user = existing;
+            var (_, newHash) = UserPasswordHasher.Verify(user, Password);
+            if (newHash is not null)
+            {
+                user.Password = newHash;
+                user.UpdatedAt = utc;
+                await db.SaveChangesAsync(cancellationToken);
+            }
         }
 
         var allPermissionIds = await db.Permissions.AsNoTracking().Select(p => p.Id).ToListAsync(cancellationToken);

--- a/AuthService/Data/Migrations/20260329203314_ExpandUserPasswordForHash.Designer.cs
+++ b/AuthService/Data/Migrations/20260329203314_ExpandUserPasswordForHash.Designer.cs
@@ -4,6 +4,7 @@ using AuthService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AuthService.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260329203314_ExpandUserPasswordForHash")]
+    partial class ExpandUserPasswordForHash
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AuthService/Data/Migrations/20260329203314_ExpandUserPasswordForHash.cs
+++ b/AuthService/Data/Migrations/20260329203314_ExpandUserPasswordForHash.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AuthService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ExpandUserPasswordForHash : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Password",
+                table: "Users",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(60)",
+                oldMaxLength: 60);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Password",
+                table: "Users",
+                type: "nvarchar(60)",
+                maxLength: 60,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(500)",
+                oldMaxLength: 500);
+        }
+    }
+}

--- a/AuthService/Models/User.cs
+++ b/AuthService/Models/User.cs
@@ -21,8 +21,9 @@ public class User : ISoftDelete
     [EmailAddress]
     public string Email { get; set; } = string.Empty;
 
+    /// <summary>Hash PBKDF2 (ASP.NET Identity). Não armazenar texto plano.</summary>
     [Required]
-    [StringLength(60)]
+    [StringLength(500)]
     public string Password { get; set; } = string.Empty;
 
     public int Identity { get; set; }

--- a/AuthService/Security/UserPasswordHasher.cs
+++ b/AuthService/Security/UserPasswordHasher.cs
@@ -1,0 +1,31 @@
+using AuthService.Models;
+using Microsoft.AspNetCore.Identity;
+
+namespace AuthService.Security;
+
+/// <summary>
+/// Hash e verificação de senha (PBKDF2 via <see cref="PasswordHasher{TUser}"/>).
+/// Suporta migração de valores legados em texto plano: em caso de match, devolve hash para persistir.
+/// </summary>
+public static class UserPasswordHasher
+{
+    private static readonly PasswordHasher<User> Hasher = new();
+
+    public static string HashPlainPassword(string plainPassword) =>
+        Hasher.HashPassword(new User(), plainPassword);
+
+    /// <returns>Sucesso da autenticação e, se necessário, novo valor a gravar em <see cref="User.Password"/>.</returns>
+    public static (bool Success, string? NewStoredPassword) Verify(User user, string plainPassword)
+    {
+        var result = Hasher.VerifyHashedPassword(user, user.Password, plainPassword);
+        if (result == PasswordVerificationResult.Success)
+            return (true, null);
+        if (result == PasswordVerificationResult.SuccessRehashNeeded)
+            return (true, Hasher.HashPassword(user, plainPassword));
+
+        if (user.Password == plainPassword)
+            return (true, Hasher.HashPassword(user, plainPassword));
+
+        return (false, null);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ export Auth__Jwt__Secret="sua-chave-com-pelo-menos-32-caracteres!!"
 2. **Pipeline HTTP** — em ambientes diferentes de **Testing**, `UseHttpsRedirection`. **Swagger** e **Swagger UI** são registrados **antes** de autenticação/autorização, ficando **anônimos**.
 3. **`UseAuthentication`** / **`UseAuthorization`** — JWT *handler* valida cabeçalho `Authorization: Bearer …`, *claims* e coerência com o usuário no banco (`TokenVersion`, ativo).
 4. **`MapGroup("/v1").MapControllers()`** — todas as rotas de API ficam versionadas em `/v1`.
-5. **Pós-build (Development e Production apenas)** — `OfficialCatalogSeeder.EnsureCatalogAsync` garante sistemas, tipos e permissões oficiais no banco; em seguida `DefaultSystemUserSeeder.EnsureDefaultUserAsync` garante o usuário padrão do sistema (e-mail `root@email.com.br`, senha inicial na constante `DefaultSystemUserSeeder.Password`) com vínculos às permissões do catálogo, de forma idempotente. **Em produção, troque a senha imediatamente após o primeiro acesso.**
+5. **Pós-build (Development e Production apenas)** — `OfficialCatalogSeeder.EnsureCatalogAsync` garante sistemas, tipos e permissões oficiais no banco; em seguida `DefaultSystemUserSeeder.EnsureDefaultUserAsync` garante o usuário padrão do sistema (e-mail `root@email.com.br`, senha inicial **em texto** apenas na constante `DefaultSystemUserSeeder.Password` usada na *seed*; no banco persiste-se **somente o hash** PBKDF2) com vínculos às permissões do catálogo, de forma idempotente. **Em produção, troque a senha imediatamente após o primeiro acesso.**
 
 ---
 
@@ -126,6 +126,7 @@ export Auth__Jwt__Secret="sua-chave-com-pelo-menos-32-caracteres!!"
 AuthService/
 ├── Controllers/          # Endpoints REST por agregado (Auth, Systems, Users, …)
 ├── Auth/                 # JWT, handler Bearer, políticas perm:*, permissões efetivas
+├── Security/             # Hash e verificação de senha (ASP.NET Identity PasswordHasher / PBKDF2)
 ├── Data/                 # AppDbContext, migrations, seeders (catálogo oficial, usuário padrão, bootstrap de testes)
 ├── Models/               # Entidades EF Core
 ├── OpenApi/              # Filtros Swagger (prefixo /v1 nos paths do documento)
@@ -145,6 +146,13 @@ AuthService/
 - **Login:** `POST /v1/auth/login` com `email` e `password` → resposta com `token` e `expiresAtUtc`.
 - **Cabeçalho:** `Authorization: Bearer <jwt>`.
 - O token inclui identificação do usuário (`sub`) e versão de sessão (`tv`). Alterações em `TokenVersion` (ex.: **logout**) invalidam tokens antigos.
+
+### Senhas (armazenamento e boas práticas)
+
+- A coluna `Users.Password` guarda **apenas hash** (PBKDF2 via `PasswordHasher` do ASP.NET Core Identity), nunca a senha em texto puro.
+- `POST /v1/users` e `PUT /v1/users/{id}/password` aceitam a senha em texto na requisição; a API calcula o hash antes de persistir.
+- O login compara a senha informada com o hash (`UserPasswordHasher` em `Security/`). Bases com usuários legados em texto plano: no primeiro login bem-sucedido (ou na *seed* idempotente, quando aplicável), o valor é substituído por hash.
+- Boas práticas: senhas fortes, rotação após primeiro acesso do usuário padrão, e segredo JWT forte em produção (ver [Configuração e variáveis de ambiente](#configuração-e-variáveis-de-ambiente)).
 
 ### Políticas `perm:<Chave>`
 


### PR DESCRIPTION
## Resumo
Implementa armazenamento apenas com hash (PBKDF2 via `PasswordHasher` do ASP.NET Core), ajusta login, criação/atualização de senha e seeders, com migração de coluna e testes de integração.

## Alterações realizadas
- `UserPasswordHasher` em `AuthService/Security/` — hash na persistência e verificação com suporte a legado (texto plano → rehash no login ou na seed idempotente).
- `AuthController`: login valida por hash; persiste novo hash quando há rehash ou migração de legado.
- `UsersController`: `POST /users` e `PUT .../password` gravam hash.
- `DefaultSystemUserSeeder` e `IntegrationBootstrapSeeder`: persistem hash; usuário existente com senha legada é atualizado quando a senha confere.
- Migration `ExpandUserPasswordForHash`: `Users.Password` `nvarchar(500)`.
- README: pasta `Security/`, fluxo de senhas e boas práticas.
- Testes: usuário padrão não tem senha em texto na base; após criar usuário e login, coluna não contém a senha em claro.

## Riscos
- Bases com hashes de outro algoritmo não serão aceitas (comportamento esperado).
- Down da migration falha se algum `Password` tiver mais de 60 caracteres.

## Evidências de teste
```
docker compose --profile test run --rm test
# Passed: 156, Failed: 0
```

Closes #32

Made with [Cursor](https://cursor.com)