### PR TITLE
#39 | Adicionar testes unitários e fortalecer qualidade do código

### DIFF
--- a/AuthService.Tests/JwtTokenServiceUnitTests.cs
+++ b/AuthService.Tests/JwtTokenServiceUnitTests.cs
@@ -1,0 +1,82 @@
+using System.Text.Json;
+using AuthService.Auth;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace AuthService.Tests;
+
+public class JwtTokenServiceUnitTests
+{
+    [Fact]
+    public void CreateAccessToken_WithShortSecret_ThrowsInvalidOperationException()
+    {
+        var options = Options.Create(new JwtOptions
+        {
+            Secret = "short-secret",
+            ExpirationMinutes = 30
+        });
+        var service = new JwtTokenService(options);
+
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            service.CreateAccessToken(Guid.NewGuid(), 1, out _);
+        });
+    }
+
+    [Fact]
+    public void CreateAccessToken_WithNonPositiveExpiration_UsesDefault60Minutes()
+    {
+        var options = Options.Create(new JwtOptions
+        {
+            Secret = "12345678901234567890123456789012",
+            ExpirationMinutes = 0
+        });
+        var service = new JwtTokenService(options);
+        var now = DateTimeOffset.UtcNow;
+
+        _ = service.CreateAccessToken(Guid.NewGuid(), 3, out var expiresAt);
+
+        var minutes = (expiresAt - now).TotalMinutes;
+        Assert.InRange(minutes, 59, 61);
+    }
+
+    [Fact]
+    public void CreateAccessToken_EmbedsExpectedClaims()
+    {
+        var userId = Guid.NewGuid();
+        const int tokenVersion = 7;
+        var options = Options.Create(new JwtOptions
+        {
+            Secret = "abcdefghijklmnopqrstuvwxyz123456",
+            ExpirationMinutes = 15
+        });
+        var service = new JwtTokenService(options);
+
+        var token = service.CreateAccessToken(userId, tokenVersion, out _);
+        var payload = ReadJwtPayload(token);
+
+        Assert.Equal(userId.ToString("D"), payload.GetProperty("sub").GetString());
+        Assert.Equal(tokenVersion, payload.GetProperty("tv").GetInt32());
+        Assert.True(payload.GetProperty("exp").GetInt64() > 0);
+        Assert.True(payload.GetProperty("iat").GetInt64() > 0);
+    }
+
+    private static JsonElement ReadJwtPayload(string token)
+    {
+        var parts = token.Split('.');
+        Assert.Equal(3, parts.Length);
+        var jsonBytes = Base64UrlDecode(parts[1]);
+        using var doc = JsonDocument.Parse(jsonBytes);
+        return doc.RootElement.Clone();
+    }
+
+    private static byte[] Base64UrlDecode(string input)
+    {
+        var base64 = input.Replace('-', '+').Replace('_', '/');
+        var pad = 4 - (base64.Length % 4);
+        if (pad is > 0 and < 4)
+            base64 += new string('=', pad);
+
+        return Convert.FromBase64String(base64);
+    }
+}

--- a/AuthService.Tests/PermissionAuthorizationPolicyProviderUnitTests.cs
+++ b/AuthService.Tests/PermissionAuthorizationPolicyProviderUnitTests.cs
@@ -1,0 +1,36 @@
+using AuthService.Auth;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace AuthService.Tests;
+
+public class PermissionAuthorizationPolicyProviderUnitTests
+{
+    [Fact]
+    public async Task GetPolicyAsync_WithPermPrefix_BuildsPolicyWithRequirementAndBearerScheme()
+    {
+        var options = Options.Create(new AuthorizationOptions());
+        var provider = new PermissionAuthorizationPolicyProvider(options);
+
+        var policy = await provider.GetPolicyAsync("perm:Users.Read");
+
+        Assert.NotNull(policy);
+        Assert.Contains(BearerAuthenticationDefaults.AuthenticationScheme, policy.AuthenticationSchemes);
+        var requirement = Assert.Single(policy.Requirements.OfType<PermissionRequirement>());
+        Assert.Equal("Users.Read", requirement.Key);
+    }
+
+    [Fact]
+    public async Task GetPolicyAsync_WithoutPermPrefix_UsesFallbackPolicyProvider()
+    {
+        var authOptions = new AuthorizationOptions();
+        authOptions.AddPolicy("custom", p => p.RequireAssertion(_ => true));
+        var provider = new PermissionAuthorizationPolicyProvider(Options.Create(authOptions));
+
+        var policy = await provider.GetPolicyAsync("custom");
+
+        Assert.NotNull(policy);
+        Assert.Empty(policy.Requirements.OfType<PermissionRequirement>());
+    }
+}

--- a/AuthService.Tests/UserPasswordHasherUnitTests.cs
+++ b/AuthService.Tests/UserPasswordHasherUnitTests.cs
@@ -1,0 +1,53 @@
+using AuthService.Models;
+using AuthService.Security;
+using Xunit;
+
+namespace AuthService.Tests;
+
+public class UserPasswordHasherUnitTests
+{
+    [Fact]
+    public void HashPlainPassword_ThenVerify_ReturnsSuccessWithoutRehash()
+    {
+        var plainPassword = "StrongP@ssw0rd!";
+        var user = new User
+        {
+            Password = UserPasswordHasher.HashPlainPassword(plainPassword)
+        };
+
+        var result = UserPasswordHasher.Verify(user, plainPassword);
+
+        Assert.True(result.Success);
+        Assert.Null(result.NewStoredPassword);
+    }
+
+    [Fact]
+    public void Verify_WithLegacyPlainTextPassword_ReturnsSuccessAndRehash()
+    {
+        var plainPassword = "LegacyPass123";
+        var user = new User
+        {
+            Password = plainPassword
+        };
+
+        var result = UserPasswordHasher.Verify(user, plainPassword);
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.NewStoredPassword);
+        Assert.NotEqual(plainPassword, result.NewStoredPassword);
+    }
+
+    [Fact]
+    public void Verify_WithWrongPassword_ReturnsFailure()
+    {
+        var user = new User
+        {
+            Password = UserPasswordHasher.HashPlainPassword("Correct#123")
+        };
+
+        var result = UserPasswordHasher.Verify(user, "Wrong#123");
+
+        Assert.False(result.Success);
+        Assert.Null(result.NewStoredPassword);
+    }
+}

--- a/AuthService/Security/UserPasswordHasher.cs
+++ b/AuthService/Security/UserPasswordHasher.cs
@@ -17,11 +17,18 @@ public static class UserPasswordHasher
     /// <returns>Sucesso da autenticação e, se necessário, novo valor a gravar em <see cref="User.Password"/>.</returns>
     public static (bool Success, string? NewStoredPassword) Verify(User user, string plainPassword)
     {
-        var result = Hasher.VerifyHashedPassword(user, user.Password, plainPassword);
-        if (result == PasswordVerificationResult.Success)
-            return (true, null);
-        if (result == PasswordVerificationResult.SuccessRehashNeeded)
-            return (true, Hasher.HashPassword(user, plainPassword));
+        try
+        {
+            var result = Hasher.VerifyHashedPassword(user, user.Password, plainPassword);
+            if (result == PasswordVerificationResult.Success)
+                return (true, null);
+            if (result == PasswordVerificationResult.SuccessRehashNeeded)
+                return (true, Hasher.HashPassword(user, plainPassword));
+        }
+        catch (FormatException)
+        {
+            // Valor legado em texto plano/não-hash: segue para fallback compatível.
+        }
 
         if (user.Password == plainPassword)
             return (true, Hasher.HashPassword(user, plainPassword));

--- a/README.md
+++ b/README.md
@@ -411,6 +411,15 @@ dotnet ef migrations add NomeDescritivoDaMigration \
 ## Testes automatizados
 
 - Projeto: **`AuthService.Tests`**
+- Há dois tipos de suíte:
+  - **Unitária**: valida componentes isolados (sem banco/infra externa).
+  - **Integração**: usa SQL Server real e sobe a aplicação completa em memória.
+- Para executar apenas testes unitários:
+
+```bash
+dotnet test AuthService.Tests/AuthService.Tests.csproj --filter "FullyQualifiedName~UnitTests"
+```
+
 - Utilizam **SQL Server real**; cada execução cria um banco `auth_svc_it_<guid>`, aplica migrations, executa seeders de catálogo e usuário bootstrap, e remove o banco ao final.
 - **Obrigatório** definir `AUTH_SERVICE_TEST_SQL_BASE` **sem** catálogo inicial:
 
@@ -452,7 +461,8 @@ Sem essa variável, o `WebApplicationFactory` falha na construção — comporta
 1. Crie branch no padrão do time (ex.: `feature/<issue>/<descricao>`).
 2. Alterações de modelo exigem **migration** gerada com `dotnet ef migrations add`.
 3. Adicione ou atualize **testes de integração** para novos endpoints ou regras.
-4. Atualize esta documentação (rotas, variáveis, troubleshooting) no mesmo PR quando o contrato público mudar.
+4. Adicione ou atualize **testes unitários** para regras críticas e serviços utilitários.
+5. Atualize esta documentação (rotas, variáveis, troubleshooting) no mesmo PR quando o contrato público mudar.
 
 **Roadmap alinhado ao domínio**
 


### PR DESCRIPTION
## Contexto
Implementação da issue #39 para fortalecer a qualidade com cobertura unitária em componentes críticos, mantendo os testes de integração existentes.

## Objetivo
Adicionar testes unitários úteis para prevenir regressões e dar segurança para evolução do código.

## O que foi feito
- Adicionados testes unitários para:
  - `UserPasswordHasher`
  - `JwtTokenService`
  - `PermissionAuthorizationPolicyProvider`
- Cobertos cenários de sucesso, falha e borda (incluindo claims JWT e fallback de expiração).
- Corrigido fallback de compatibilidade de senha legada no `UserPasswordHasher` para tratar hash inválido sem quebrar autenticação.
- Documentada execução de suíte unitária no `README`.

## Arquivos impactados
- `AuthService.Tests/UserPasswordHasherUnitTests.cs`
- `AuthService.Tests/JwtTokenServiceUnitTests.cs`
- `AuthService.Tests/PermissionAuthorizationPolicyProviderUnitTests.cs`
- `AuthService/Security/UserPasswordHasher.cs`
- `README.md`

## Segurança
- Sem exposição de segredos.
- Cobertura adicional para regras de token e autenticação.

## Riscos
- Baixo risco funcional; alterações restritas a testes e correção pontual de fallback legado.

## Testes executados
- `docker run --rm -v "$PWD:/workspace" -w /workspace mcr.microsoft.com/dotnet/sdk:10.0 dotnet test AuthService.Tests/AuthService.Tests.csproj --filter "FullyQualifiedName~UnitTests" -v minimal`
  - Resultado: **8 passed**
- `docker compose --profile test run --rm test`
  - Resultado: **127 passed**

Closes #39.

Made with [Cursor](https://cursor.com)