### PR TITLE
#46 | [Sonar][CRITICAL] Reduzir complexidade cognitiva em JwtBearerAuthenticationHandler

### DIFF
--- a/AuthService.Tests/AuthApiTests.cs
+++ b/AuthService.Tests/AuthApiTests.cs
@@ -1,8 +1,12 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
 using AuthService.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -10,6 +14,7 @@ namespace AuthService.Tests;
 
 public class AuthApiTests : IAsyncLifetime
 {
+    private const string TestJwtSecret = "integration-tests-jwt-secret-key-32chars!!";
     private WebAppFactory _factory = null!;
     private HttpClient _admin = null!;
     private HttpClient _anon = null!;
@@ -219,6 +224,96 @@ public class AuthApiTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task VerifyToken_WithInvalidJwtConfiguration_ReturnsUnauthorized()
+    {
+        using var invalidSecretFactory = _factory.WithWebHostBuilder(static builder =>
+        {
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Auth:Jwt:Secret"] = "short-secret"
+                });
+            });
+        });
+        using var client = invalidSecretFactory.CreateClient();
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "abc");
+        var response = await client.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task VerifyToken_ExpiredJwt_ReturnsUnauthorized()
+    {
+        var token = CreateHs256Token(
+            TestJwtSecret,
+            new Dictionary<string, object>
+            {
+                ["sub"] = Guid.NewGuid().ToString("D"),
+                ["tv"] = 0,
+                ["exp"] = DateTimeOffset.UtcNow.AddMinutes(-5).ToUnixTimeSeconds()
+            });
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var response = await _anon.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task VerifyToken_WrongSignatureJwt_ReturnsUnauthorized()
+    {
+        var token = CreateHs256Token(
+            "wrong-signature-secret-key-32chars!!",
+            new Dictionary<string, object>
+            {
+                ["sub"] = Guid.NewGuid().ToString("D"),
+                ["tv"] = 0,
+                ["exp"] = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds()
+            });
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var response = await _anon.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task VerifyToken_WithoutSubClaim_ReturnsUnauthorized()
+    {
+        var token = CreateHs256Token(
+            TestJwtSecret,
+            new Dictionary<string, object>
+            {
+                ["tv"] = 0,
+                ["exp"] = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds()
+            });
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var response = await _anon.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task VerifyToken_WithoutTokenVersionClaim_ReturnsUnauthorized()
+    {
+        var token = CreateHs256Token(
+            TestJwtSecret,
+            new Dictionary<string, object>
+            {
+                ["sub"] = Guid.NewGuid().ToString("D"),
+                ["exp"] = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds()
+            });
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var response = await _anon.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
     public async Task Users_WithoutToken_ReturnsUnauthorized()
     {
         using var anon = _factory.CreateApiClient();
@@ -244,5 +339,28 @@ public class AuthApiTests : IAsyncLifetime
         var response = await _anon.SendAsync(req);
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    private static string CreateHs256Token(string secret, IDictionary<string, object> payload)
+    {
+        var header = new Dictionary<string, object>
+        {
+            ["alg"] = "HS256",
+            ["typ"] = "JWT"
+        };
+        var headerSegment = Base64UrlEncode(JsonSerializer.SerializeToUtf8Bytes(header));
+        var payloadSegment = Base64UrlEncode(JsonSerializer.SerializeToUtf8Bytes(payload));
+        var signingInput = $"{headerSegment}.{payloadSegment}";
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+        var signature = hmac.ComputeHash(Encoding.UTF8.GetBytes(signingInput));
+        return $"{signingInput}.{Base64UrlEncode(signature)}";
+    }
+
+    private static string Base64UrlEncode(byte[] bytes)
+    {
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
     }
 }

--- a/AuthService.Tests/AuthApiTests.cs
+++ b/AuthService.Tests/AuthApiTests.cs
@@ -201,6 +201,24 @@ public class AuthApiTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task VerifyToken_MalformedAuthorizationHeader_ReturnsUnauthorized()
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.TryAddWithoutValidation("Authorization", "Basic abc123");
+        var response = await _anon.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task VerifyToken_EmptyBearerToken_ReturnsUnauthorized()
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.TryAddWithoutValidation("Authorization", "Bearer   ");
+        var response = await _anon.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
     public async Task Users_WithoutToken_ReturnsUnauthorized()
     {
         using var anon = _factory.CreateApiClient();

--- a/AuthService/Auth/JwtBearerAuthenticationHandler.cs
+++ b/AuthService/Auth/JwtBearerAuthenticationHandler.cs
@@ -22,52 +22,21 @@ public sealed class JwtBearerAuthenticationHandler(
 
     protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        if (!Request.Headers.TryGetValue("Authorization", out var values))
-            return AuthenticateResult.NoResult();
+        var tokenReadResult = TryReadBearerToken(out var token);
+        if (tokenReadResult is not null)
+            return tokenReadResult;
 
-        var auth = values.ToString();
-        if (string.IsNullOrWhiteSpace(auth) || !auth.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
-            return AuthenticateResult.Fail("Cabeçalho Authorization inválido.");
+        var secretValidation = ValidateJwtSecret();
+        if (secretValidation is not null)
+            return secretValidation;
 
-        var token = auth["Bearer ".Length..].Trim();
-        if (string.IsNullOrEmpty(token))
-            return AuthenticateResult.Fail("Token ausente.");
+        var payloadResult = TryDecodePayload(token);
+        if (payloadResult.Error is not null)
+            return payloadResult.Error;
 
-        if (string.IsNullOrWhiteSpace(_jwt.Secret) || _jwt.Secret.Length < 32)
-        {
-            Logger.LogError("Auth:Jwt:Secret inválido ou ausente.");
-            return AuthenticateResult.Fail("Configuração de autenticação inválida.");
-        }
-
-        IDictionary<string, object> payload;
-        try
-        {
-            payload = JwtBuilder.Create()
-                .WithAlgorithm(new HMACSHA256Algorithm())
-                .WithSecret(_jwt.Secret)
-                .MustVerifySignature()
-                .Decode<IDictionary<string, object>>(token);
-        }
-        catch (TokenExpiredException)
-        {
-            return AuthenticateResult.Fail("Token expirado.");
-        }
-        catch (SignatureVerificationException)
-        {
-            return AuthenticateResult.Fail("Assinatura do token inválida.");
-        }
-        catch (Exception ex)
-        {
-            Logger.LogDebug(ex, "Falha ao validar JWT.");
-            return AuthenticateResult.Fail("Token inválido.");
-        }
-
-        if (!payload.TryGetValue("sub", out var subObj) || subObj?.ToString() is not { } subStr
-            || !Guid.TryParse(subStr, out var userId))
-            return AuthenticateResult.Fail("Token sem identificador de usuário válido.");
-
-        if (!payload.TryGetValue("tv", out var tvObj) || !TryGetInt32(tvObj, out var tokenVersionClaim))
-            return AuthenticateResult.Fail("Token sem versão de sessão válida.");
+        var claimExtraction = TryExtractIdentityClaims(payloadResult.Payload!, out var userId, out var tokenVersionClaim);
+        if (claimExtraction is not null)
+            return claimExtraction;
 
         await using var scope = _services.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
@@ -90,6 +59,73 @@ public sealed class JwtBearerAuthenticationHandler(
         var identity = new ClaimsIdentity(claims, Scheme.Name);
         var principal = new ClaimsPrincipal(identity);
         return AuthenticateResult.Success(new AuthenticationTicket(principal, Scheme.Name));
+    }
+
+    private AuthenticateResult? TryReadBearerToken(out string token)
+    {
+        token = string.Empty;
+        if (!Request.Headers.TryGetValue("Authorization", out var values))
+            return AuthenticateResult.NoResult();
+
+        var auth = values.ToString();
+        if (string.IsNullOrWhiteSpace(auth) || !auth.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            return AuthenticateResult.Fail("Cabeçalho Authorization inválido.");
+
+        token = auth["Bearer ".Length..].Trim();
+        return string.IsNullOrEmpty(token) ? AuthenticateResult.Fail("Token ausente.") : null;
+    }
+
+    private AuthenticateResult? ValidateJwtSecret()
+    {
+        if (!string.IsNullOrWhiteSpace(_jwt.Secret) && _jwt.Secret.Length >= 32)
+            return null;
+
+        Logger.LogError("Auth:Jwt:Secret inválido ou ausente.");
+        return AuthenticateResult.Fail("Configuração de autenticação inválida.");
+    }
+
+    private (IDictionary<string, object>? Payload, AuthenticateResult? Error) TryDecodePayload(string token)
+    {
+        try
+        {
+            var payload = JwtBuilder.Create()
+                .WithAlgorithm(new HMACSHA256Algorithm())
+                .WithSecret(_jwt.Secret)
+                .MustVerifySignature()
+                .Decode<IDictionary<string, object>>(token);
+            return (payload, null);
+        }
+        catch (TokenExpiredException)
+        {
+            return (null, AuthenticateResult.Fail("Token expirado."));
+        }
+        catch (SignatureVerificationException)
+        {
+            return (null, AuthenticateResult.Fail("Assinatura do token inválida."));
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Falha ao validar JWT.");
+            return (null, AuthenticateResult.Fail("Token inválido."));
+        }
+    }
+
+    private static AuthenticateResult? TryExtractIdentityClaims(
+        IDictionary<string, object> payload,
+        out Guid userId,
+        out int tokenVersionClaim)
+    {
+        userId = Guid.Empty;
+        tokenVersionClaim = 0;
+
+        if (!payload.TryGetValue("sub", out var subObj) || subObj?.ToString() is not { } subStr
+            || !Guid.TryParse(subStr, out userId))
+            return AuthenticateResult.Fail("Token sem identificador de usuário válido.");
+
+        if (!payload.TryGetValue("tv", out var tvObj) || !TryGetInt32(tvObj, out tokenVersionClaim))
+            return AuthenticateResult.Fail("Token sem versão de sessão válida.");
+
+        return null;
     }
 
     private static bool TryGetInt32(object? value, out int n)


### PR DESCRIPTION
## Resumo objetivo
Reduz a complexidade cognitiva do método `HandleAuthenticateAsync` no `JwtBearerAuthenticationHandler` para atender a regra Sonar `csharpsquid:S3776`, mantendo o comportamento de autenticação JWT e mensagens de falha existentes.

## O que foi feito
- Refatoração pontual do fluxo de autenticação em helpers privados (`TryReadBearerToken`, `ValidateJwtSecret`, `TryDecodePayload`, `TryExtractIdentityClaims`).
- Preservação do contrato funcional do handler (mesmos cenários de sucesso/falha observáveis).
- Inclusão de testes de integração para contratos de erro:
  - `VerifyToken_MalformedAuthorizationHeader_ReturnsUnauthorized`
  - `VerifyToken_EmptyBearerToken_ReturnsUnauthorized`

## Por que foi feito
Método alvo excedia limite de complexidade cognitiva (16 > 15), gerando code smell crítico no SonarCloud e aumentando risco de manutenção/regressão.

## Riscos
- Baixo risco funcional por manter ordem e mensagens de validação; mitigado com suíte de integração completa e novos casos de erro.

## Evidências de testes e cobertura
Comandos executados:
- `docker run --rm -v "$PWD:/src" -w /src mcr.microsoft.com/dotnet/sdk:10.0 dotnet build AuthService/AuthService.csproj -c Release`
- `docker run --rm --network auth-it-net -e AUTH_SERVICE_TEST_SQL_BASE='Server=auth-it-sql,1433;User Id=sa;Password=Your_password123;TrustServerCertificate=True' -v "$PWD:/src" -w /src mcr.microsoft.com/dotnet/sdk:10.0 dotnet test AuthService.Tests/AuthService.Tests.csproj -c Release /p:CollectCoverage=true /p:CoverletOutput=./TestResults/Coverage/ /p:CoverletOutputFormat=cobertura`
- `docker run --rm -v "$PWD:/src" -w /src mcr.microsoft.com/dotnet/sdk:10.0 dotnet format AuthService/AuthService.csproj --verify-no-changes`

Resultados:
- Build: OK
- Testes: 149/149 passando
- Cobertura (Coverlet): Lines 94.24%, Branches 63.79%, Methods 91.68%
- Arquivo de cobertura: `AuthService.Tests/TestResults/Coverage/coverage.cobertura.xml`

## Impacto
- Melhora manutenibilidade do fluxo JWT.
- Suporte ao quality gate ao remover principal causa de não conformidade da issue.

Closes #46

Made with [Cursor](https://cursor.com)