### PR TITLE
#47 | [Sonar][MAJOR] Ajustar DTOs de entrada com tipos valor nos controllers (S6964)

### DIFF
--- a/AuthService.Tests/PermissionsApiTests.cs
+++ b/AuthService.Tests/PermissionsApiTests.cs
@@ -95,6 +95,16 @@ public class PermissionsApiTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Create_WithoutSystemId_ReturnsBadRequest()
+    {
+        var typeId = await CreatePermissionTypeAsync("PERM_TYPE_MISSING_SYS");
+
+        var response = await _client.PostAsJsonAsync("/api/v1/permissions",
+            new { permissionTypeId = typeId, description = "sem sistema" }, TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
     public async Task Create_WithInvalidPermissionTypeId_ReturnsBadRequest()
     {
         var sysId = await CreateSystemAsync("PERM_SYS_INV_T");
@@ -197,6 +207,20 @@ public class PermissionsApiTests : IAsyncLifetime
 
         var put = await _client.PutAsJsonAsync($"/api/v1/permissions/{dto.Id}",
             PermUpdateBody(Guid.NewGuid(), typeId), TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_WithoutPermissionTypeId_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("PERM_SYS_MISSING_TYPE");
+        var typeId = await CreatePermissionTypeAsync("PERM_TYPE_MISSING_TYPE");
+        var create = await _client.PostAsJsonAsync("/api/v1/permissions", PermCreateBody(sysId, typeId), TestApiClient.JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto);
+
+        var put = await _client.PutAsJsonAsync($"/api/v1/permissions/{dto.Id}",
+            new { systemId = sysId, description = "sem tipo" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
     }
 

--- a/AuthService.Tests/RoutesApiTests.cs
+++ b/AuthService.Tests/RoutesApiTests.cs
@@ -68,6 +68,14 @@ public class RoutesApiTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Create_WithoutSystemId_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            new { name = "Rota sem sistema", code = "RT_NO_SYS" }, TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
     public async Task Create_DuplicateCode_ReturnsConflict()
     {
         var sysId = await CreateSystemAsync("RT_SYS_DUP");
@@ -172,6 +180,19 @@ public class RoutesApiTests : IAsyncLifetime
 
         var put = await _client.PutAsJsonAsync($"/api/v1/systems/routes/{dto.Id}",
             RouteUpdateBody(Guid.NewGuid(), "S", "RT_INV"), TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_WithoutSystemId_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_MISSING");
+        var create = await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "S", "RT_MISSING"), TestApiClient.JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto);
+
+        var put = await _client.PutAsJsonAsync($"/api/v1/systems/routes/{dto.Id}",
+            new { name = "S atualizado", code = "RT_MISSING" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
     }
 

--- a/AuthService.Tests/UsersApiTests.cs
+++ b/AuthService.Tests/UsersApiTests.cs
@@ -132,6 +132,15 @@ public class UsersApiTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Create_WithoutIdentity_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsJsonAsync("/api/v1/users",
+            new { name = "Sem Identity", email = "no.identity@example.com", password = "SenhaSegura1!", active = true },
+            TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
     public async Task Put_WhitespaceOnlyName_ReturnsBadRequest()
     {
         var create = await _client.PostAsJsonAsync("/api/v1/users", UserCreateBody("S", "w1@example.com"), TestApiClient.JsonOptions);
@@ -192,6 +201,18 @@ public class UsersApiTests : IAsyncLifetime
         var put404 = await _client.PutAsJsonAsync($"/api/v1/users/{dto.Id}",
             UserUpdateBody("S3", "u1@example.com"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.NotFound, put404.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_WithoutIdentityOrActive_ReturnsBadRequest()
+    {
+        var create = await _client.PostAsJsonAsync("/api/v1/users", UserCreateBody("S", "missing.update@example.com"), TestApiClient.JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto);
+
+        var put = await _client.PutAsJsonAsync($"/api/v1/users/{dto.Id}",
+            new { name = "S2", email = "missing.update@example.com" }, TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
     }
 
     [Fact]

--- a/AuthService/Controllers/Permissions/PermissionsController.cs
+++ b/AuthService/Controllers/Permissions/PermissionsController.cs
@@ -26,10 +26,10 @@ public class PermissionsController : ControllerBase
     public class CreatePermissionRequest
     {
         [Required(ErrorMessage = "SystemId é obrigatório.")]
-        public Guid SystemId { get; set; }
+        public Guid? SystemId { get; set; }
 
         [Required(ErrorMessage = "PermissionTypeId é obrigatório.")]
-        public Guid PermissionTypeId { get; set; }
+        public Guid? PermissionTypeId { get; set; }
 
         [MaxLength(500, ErrorMessage = "Description deve ter no máximo 500 caracteres.")]
         public string? Description { get; set; }
@@ -38,10 +38,10 @@ public class PermissionsController : ControllerBase
     public class UpdatePermissionRequest
     {
         [Required(ErrorMessage = "SystemId é obrigatório.")]
-        public Guid SystemId { get; set; }
+        public Guid? SystemId { get; set; }
 
         [Required(ErrorMessage = "PermissionTypeId é obrigatório.")]
-        public Guid PermissionTypeId { get; set; }
+        public Guid? PermissionTypeId { get; set; }
 
         [MaxLength(500, ErrorMessage = "Description deve ter no máximo 500 caracteres.")]
         public string? Description { get; set; }
@@ -105,13 +105,16 @@ public class PermissionsController : ControllerBase
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);
 
-        var systemOk = await SystemExistsAndActiveAsync(request.SystemId);
-        var typeOk = await PermissionTypeExistsAndActiveAsync(request.PermissionTypeId);
+        var systemId = request.SystemId!.Value;
+        var permissionTypeId = request.PermissionTypeId!.Value;
+
+        var systemOk = await SystemExistsAndActiveAsync(systemId);
+        var typeOk = await PermissionTypeExistsAndActiveAsync(permissionTypeId);
         if (!systemOk || !typeOk)
         {
             _logger.LogWarning(
                 "Criação de permissão rejeitada: SystemId {SystemId} ok={SystemOk}, PermissionTypeId {TypeId} ok={TypeOk}.",
-                request.SystemId, systemOk, request.PermissionTypeId, typeOk);
+                systemId, systemOk, permissionTypeId, typeOk);
             return InvalidReferencesResult(systemOk, typeOk);
         }
 
@@ -123,8 +126,8 @@ public class PermissionsController : ControllerBase
         var now = DateTime.UtcNow;
         var entity = new AppPermission
         {
-            SystemId = request.SystemId,
-            PermissionTypeId = request.PermissionTypeId,
+            SystemId = systemId,
+            PermissionTypeId = permissionTypeId,
             Description = description,
             CreatedAt = now,
             UpdatedAt = now,
@@ -139,8 +142,8 @@ public class PermissionsController : ControllerBase
         catch (DbUpdateException ex) when (IsForeignKeyViolation(ex))
         {
             _logger.LogWarning(ex, "Violação de FK ao criar permissão.");
-            var s = await SystemExistsAndActiveAsync(request.SystemId);
-            var t = await PermissionTypeExistsAndActiveAsync(request.PermissionTypeId);
+            var s = await SystemExistsAndActiveAsync(systemId);
+            var t = await PermissionTypeExistsAndActiveAsync(permissionTypeId);
             return InvalidReferencesResult(s, t);
         }
         catch (Exception ex)
@@ -192,8 +195,11 @@ public class PermissionsController : ControllerBase
         if (entity is null)
             return NotFound(new { message = "Permissão não encontrada." });
 
-        var systemOk = await SystemExistsAndActiveAsync(request.SystemId);
-        var typeOk = await PermissionTypeExistsAndActiveAsync(request.PermissionTypeId);
+        var systemId = request.SystemId!.Value;
+        var permissionTypeId = request.PermissionTypeId!.Value;
+
+        var systemOk = await SystemExistsAndActiveAsync(systemId);
+        var typeOk = await PermissionTypeExistsAndActiveAsync(permissionTypeId);
         if (!systemOk || !typeOk)
         {
             _logger.LogWarning(
@@ -207,8 +213,8 @@ public class PermissionsController : ControllerBase
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);
 
-        entity.SystemId = request.SystemId;
-        entity.PermissionTypeId = request.PermissionTypeId;
+        entity.SystemId = systemId;
+        entity.PermissionTypeId = permissionTypeId;
         entity.Description = description;
         entity.UpdatedAt = DateTime.UtcNow;
 
@@ -219,8 +225,8 @@ public class PermissionsController : ControllerBase
         catch (DbUpdateException ex) when (IsForeignKeyViolation(ex))
         {
             _logger.LogWarning(ex, "Violação de FK ao atualizar permissão {PermissionId}.", id);
-            var s = await SystemExistsAndActiveAsync(request.SystemId);
-            var t = await PermissionTypeExistsAndActiveAsync(request.PermissionTypeId);
+            var s = await SystemExistsAndActiveAsync(systemId);
+            var t = await PermissionTypeExistsAndActiveAsync(permissionTypeId);
             return InvalidReferencesResult(s, t);
         }
         catch (Exception ex)

--- a/AuthService/Controllers/Routes/RoutesController.cs
+++ b/AuthService/Controllers/Routes/RoutesController.cs
@@ -24,7 +24,7 @@ public class RoutesController : ControllerBase
     public class CreateRouteRequest
     {
         [Required(ErrorMessage = "SystemId é obrigatório.")]
-        public Guid SystemId { get; set; }
+        public Guid? SystemId { get; set; }
 
         [Required(ErrorMessage = "Name é obrigatório.")]
         [MaxLength(80, ErrorMessage = "Name deve ter no máximo 80 caracteres.")]
@@ -41,7 +41,7 @@ public class RoutesController : ControllerBase
     public class UpdateRouteRequest
     {
         [Required(ErrorMessage = "SystemId é obrigatório.")]
-        public Guid SystemId { get; set; }
+        public Guid? SystemId { get; set; }
 
         [Required(ErrorMessage = "Name é obrigatório.")]
         [MaxLength(80, ErrorMessage = "Name deve ter no máximo 80 caracteres.")]
@@ -145,7 +145,9 @@ public class RoutesController : ControllerBase
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);
 
-        if (!await SystemExistsAndActiveAsync(request.SystemId))
+        var systemId = request.SystemId!.Value;
+
+        if (!await SystemExistsAndActiveAsync(systemId))
             return InvalidSystemIdResult();
 
         var name = request.Name.Trim();
@@ -162,7 +164,7 @@ public class RoutesController : ControllerBase
         var now = DateTime.UtcNow;
         var entity = new AppRoute
         {
-            SystemId = request.SystemId,
+            SystemId = systemId,
             Name = name,
             Code = code,
             Description = description,
@@ -228,7 +230,9 @@ public class RoutesController : ControllerBase
         if (entity is null)
             return NotFound(new { message = "Route não encontrada." });
 
-        if (!await SystemExistsAndActiveAsync(request.SystemId))
+        var systemId = request.SystemId!.Value;
+
+        if (!await SystemExistsAndActiveAsync(systemId))
             return InvalidSystemIdResult();
 
         var name = request.Name.Trim();
@@ -242,7 +246,7 @@ public class RoutesController : ControllerBase
         if (await _db.Routes.IgnoreQueryFilters().AnyAsync(r => r.Id != id && r.Code == code))
             return new ConflictObjectResult(new { message = "Já existe outra route com este Code." });
 
-        entity.SystemId = request.SystemId;
+        entity.SystemId = systemId;
         entity.Name = name;
         entity.Code = code;
         entity.Description = description;

--- a/AuthService/Controllers/Users/UsersController.cs
+++ b/AuthService/Controllers/Users/UsersController.cs
@@ -39,7 +39,7 @@ public class UsersController : ControllerBase
         public string Password { get; set; } = string.Empty;
 
         [Required]
-        public int Identity { get; set; }
+        public int? Identity { get; set; }
 
         public Guid? ClientId { get; set; }
 
@@ -58,12 +58,12 @@ public class UsersController : ControllerBase
         public string Email { get; set; } = string.Empty;
 
         [Required]
-        public int Identity { get; set; }
+        public int? Identity { get; set; }
 
         public Guid? ClientId { get; set; }
 
         [Required]
-        public bool Active { get; set; }
+        public bool? Active { get; set; }
     }
 
     public class UpdatePasswordRequest
@@ -235,13 +235,14 @@ public class UsersController : ControllerBase
         }
 
         var now = DateTime.UtcNow;
+        var identity = request.Identity!.Value;
         var user = new UserEntity
         {
             Name = name,
             Email = email,
             Password = UserPasswordHasher.HashPlainPassword(password),
             ClientId = clientId,
-            Identity = request.Identity,
+            Identity = identity,
             Active = request.Active,
             CreatedAt = now,
             UpdatedAt = now,
@@ -337,12 +338,15 @@ public class UsersController : ControllerBase
                 return BadRequest(new { message = "ClientId informado não existe." });
         }
 
+        var identity = request.Identity!.Value;
+        var active = request.Active!.Value;
+
         user.Name = name;
         user.Email = email;
         // Não desassocia cliente quando ClientId não é informado no update.
         user.ClientId = request.ClientId ?? user.ClientId;
-        user.Identity = request.Identity;
-        user.Active = request.Active;
+        user.Identity = identity;
+        user.Active = active;
         user.UpdatedAt = DateTime.UtcNow;
 
         try


### PR DESCRIPTION
## 📌 Contexto

A regra `csharpsquid:S6964` do SonarCloud reportava **9 ocorrências MAJOR** nos controllers de Permissions, Routes e Users. Propriedades de tipo valor (`Guid`, `int`, `bool`) em DTOs de request não estavam anotadas como nullable, fazendo com que campos omitidos no JSON fossem silenciosamente preenchidos com valores default (`Guid.Empty`, `0`, `false`) ao invés de falharem na validação.

## 🎯 Objetivo

Tornar explícito o contrato de obrigatoriedade dos campos de request, eliminando todos os achados S6964 e garantindo que campos omitidos resultem em `400 Bad Request`.

## ⚙️ O que foi feito

- Tornadas nullable as 9 propriedades de tipo valor nos DTOs de request mantendo `[Required]`:
  - `PermissionsController`: `CreatePermissionRequest.SystemId`, `.PermissionTypeId`, `UpdatePermissionRequest.SystemId`, `.PermissionTypeId`
  - `RoutesController`: `CreateRouteRequest.SystemId`, `UpdateRouteRequest.SystemId`
  - `UsersController`: `CreateUserRequest.Identity`, `UpdateUserRequest.Identity`, `UpdateUserRequest.Active`
- Code paths nos actions ajustados para fazer `.Value` unwrap após validação do ModelState
- 6 novos testes de integração cobrindo cenários de omissão de campo obrigatório → 400

## 📁 Arquivos impactados

| Arquivo | Tipo de alteração |
|---|---|
| `AuthService/Controllers/Permissions/PermissionsController.cs` | DTOs nullable + unwrap |
| `AuthService/Controllers/Routes/RoutesController.cs` | DTOs nullable + unwrap |
| `AuthService/Controllers/Users/UsersController.cs` | DTOs nullable + unwrap |
| `AuthService.Tests/PermissionsApiTests.cs` | +2 testes (omissão SystemId, PermissionTypeId) |
| `AuthService.Tests/RoutesApiTests.cs` | +2 testes (omissão SystemId create/update) |
| `AuthService.Tests/UsersApiTests.cs` | +2 testes (omissão Identity, Identity+Active) |

## 🧪 Testes

- **160 testes passando** (0 falhas, 0 skipped)
- **Coverage: 94.46% line | 65.31% branch | 91.68% method**
- Novos testes cobrem contratos de entrada/saída para campos obrigatórios omitidos

## 🛡️ Segurança

Nenhum impacto de segurança. A alteração **reforça** a validação de input ao rejeitar campos obrigatórios omitidos que antes eram aceitos silenciosamente com valores default.

## ⚠️ Riscos

- **Breaking change controlado**: Clientes que omitiam `Identity`, `Active` ou `SystemId` (recebendo default silencioso) agora receberão `400 Bad Request`. Este é o comportamento **correto e desejado** conforme contrato da API.
- Risco mitigado por: testes de integração + validação via ModelState que já existia.

Closes #47

Made with [Cursor](https://cursor.com)