### PR TITLE
#48 | [Sonar][MAJOR] Tratar ou relançar exceções com contexto em Permissions e Roles (S2139)

### DIFF
--- a/AuthService/Controllers/Permissions/PermissionsController.cs
+++ b/AuthService/Controllers/Permissions/PermissionsController.cs
@@ -146,11 +146,6 @@ public class PermissionsController : ControllerBase
             var t = await PermissionTypeExistsAndActiveAsync(permissionTypeId);
             return InvalidReferencesResult(s, t);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Erro inesperado ao persistir nova permissão.");
-            throw;
-        }
 
         _logger.LogInformation("Permissão criada: {PermissionId}.", entity.Id);
         return CreatedAtAction(nameof(GetById), new { id = entity.Id }, ToResponse(entity));
@@ -229,11 +224,6 @@ public class PermissionsController : ControllerBase
             var t = await PermissionTypeExistsAndActiveAsync(permissionTypeId);
             return InvalidReferencesResult(s, t);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Erro inesperado ao persistir atualização da permissão {PermissionId}.", id);
-            throw;
-        }
 
         _logger.LogInformation("Permissão atualizada: {PermissionId}.", id);
         return Ok(ToResponse(entity));
@@ -249,15 +239,7 @@ public class PermissionsController : ControllerBase
 
         entity.DeletedAt = DateTime.UtcNow;
         entity.UpdatedAt = DateTime.UtcNow;
-        try
-        {
-            await _db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Erro inesperado ao excluir (soft) permissão {PermissionId}.", id);
-            throw;
-        }
+        await _db.SaveChangesAsync();
 
         _logger.LogInformation("Permissão excluída (soft): {PermissionId}.", id);
         return NoContent();
@@ -284,15 +266,7 @@ public class PermissionsController : ControllerBase
 
         entity.DeletedAt = null;
         entity.UpdatedAt = DateTime.UtcNow;
-        try
-        {
-            await _db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Erro inesperado ao restaurar permissão {PermissionId}.", id);
-            throw;
-        }
+        await _db.SaveChangesAsync();
 
         _logger.LogInformation("Permissão restaurada: {PermissionId}.", id);
         return Ok(new { message = "Permissão restaurada com sucesso." });

--- a/AuthService/Controllers/Roles/RolesController.cs
+++ b/AuthService/Controllers/Roles/RolesController.cs
@@ -138,11 +138,6 @@ public class RolesController : ControllerBase
             _logger.LogWarning(ex, "Conflito de unicidade ao criar role com Code {Code}.", code);
             return UniqueConflictResult();
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Erro inesperado ao persistir novo role (Code {Code}).", code);
-            throw;
-        }
 
         _logger.LogInformation("Role criado: {RoleId}, Code {Code}.", entity.Id, code);
         return CreatedAtAction(nameof(GetById), new { id = entity.Id }, ToResponse(entity));
@@ -212,11 +207,6 @@ public class RolesController : ControllerBase
             _logger.LogWarning(ex, "Conflito de unicidade ao atualizar role {RoleId} para Code {Code}.", id, code);
             return new ConflictObjectResult(new { message = "Já existe outro role com este Code." });
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Erro inesperado ao persistir atualização do role {RoleId}.", id);
-            throw;
-        }
 
         _logger.LogInformation("Role atualizado: {RoleId}.", id);
         return Ok(ToResponse(entity));
@@ -232,15 +222,7 @@ public class RolesController : ControllerBase
 
         entity.DeletedAt = DateTime.UtcNow;
         entity.UpdatedAt = DateTime.UtcNow;
-        try
-        {
-            await _db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Erro inesperado ao excluir (soft) role {RoleId}.", id);
-            throw;
-        }
+        await _db.SaveChangesAsync();
 
         _logger.LogInformation("Role excluído (soft): {RoleId}.", id);
         return NoContent();
@@ -259,15 +241,7 @@ public class RolesController : ControllerBase
 
         entity.DeletedAt = null;
         entity.UpdatedAt = DateTime.UtcNow;
-        try
-        {
-            await _db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Erro inesperado ao restaurar role {RoleId}.", id);
-            throw;
-        }
+        await _db.SaveChangesAsync();
 
         _logger.LogInformation("Role restaurado: {RoleId}.", id);
         return Ok(new { message = "Role restaurado com sucesso." });


### PR DESCRIPTION
## 📌 Contexto

SonarCloud reporta **8 ocorrências** da regra `csharpsquid:S2139` (MAJOR) em `PermissionsController` e `RolesController`, onde blocos `catch (Exception ex)` fazem **log E rethrow** simultaneamente — anti-pattern que causa log duplo.

## 🎯 Objetivo

Eliminar as 8 violações de S2139 alinhando ao padrão já praticado nos controllers `Systems` e `Routes` do projeto.

## ⚙️ O que foi feito

- **Removidos 8 blocos `catch (Exception ex) { _logger.LogError(ex, ...); throw; }`:**
  - 4 em `PermissionsController.cs` (Create, UpdateById, DeleteById, RestoreById)
  - 4 em `RolesController.cs` (Create, UpdateById, DeleteById, RestoreById)

- **Catch específicos preservados:** Os blocos `catch (DbUpdateException ex) when (IsForeignKeyViolation/IsUniqueConstraintViolation)` que fazem **log + handle** permanecem intactos — esses são corretos por S2139.

- **Para Delete e Restore:** O `try/catch` inteiro foi removido, deixando apenas `await _db.SaveChangesAsync()` direto — exatamente como já feito em `SystemsController` e `RoutesController`.

### Justificativa técnica

A regra S2139 diz: _"Either log this exception and handle it, or rethrow it with some contextual information"_. O padrão `log + throw;` (sem alterar a exceção) é redundante porque:
1. O framework ASP.NET Core já trata exceções não-capturadas
2. O log duplicado (catch + framework) polui a observabilidade
3. Os demais controllers do projeto já seguem o padrão correto

## 📁 Arquivos impactados

| Arquivo | Alteração |
|---------|-----------|
| `AuthService/Controllers/Permissions/PermissionsController.cs` | -26 linhas (4 catch genéricos removidos) |
| `AuthService/Controllers/Roles/RolesController.cs` | -26 linhas (4 catch genéricos removidos) |

## 🧪 Testes

- **160/160 testes passando** (zero falhas, zero skipped)
- Coverage: **94.69% linha** | 64.55% branch | 91.47% método
- Executado via: `docker compose --profile test run --rm test`

```
Passed!  - Failed:     0, Passed:   160, Skipped:     0, Total:   160
```

## 🛡️ Segurança

Nenhum impacto. Não há alteração em validação de input, autorização, autenticação ou exposição de dados. Não há segredos expostos.

## ⚠️ Riscos

- **Nenhum risco funcional:** As respostas HTTP e status codes permanecem idênticos para os clientes.
- **Comportamento em exceção inesperada:** Antes, o controller logava e relançava. Agora, a exceção propaga direto ao framework, que retorna 500 e loga automaticamente. O comportamento visível para o cliente é o mesmo.

Closes #48

Made with [Cursor](https://cursor.com)