### PR TITLE
#50 | [Sonar][MINOR] Extrair literais de string duplicados (S1192)

### DIFF
--- a/AuthService/Controllers/Auth/AuthController.cs
+++ b/AuthService/Controllers/Auth/AuthController.cs
@@ -13,6 +13,10 @@ namespace AuthService.Controllers.Auth;
 [Route("auth")]
 public class AuthController : ControllerBase
 {
+    private const string InvalidCredentialsMessage = "Credenciais inválidas.";
+    private const string InvalidTokenMessage = "Token inválido.";
+    private const string UserNotFoundMessage = "Usuário não encontrado.";
+
     private readonly AppDbContext _db;
     private readonly IJwtTokenService _jwt;
     private readonly ILogger<AuthController> _logger;
@@ -56,20 +60,20 @@ public class AuthController : ControllerBase
         var password = request.Password.Trim();
 
         if (string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(password))
-            return Unauthorized(new { message = "Credenciais inválidas." });
+            return Unauthorized(new { message = InvalidCredentialsMessage });
 
         var user = await _db.Users.FirstOrDefaultAsync(u => u.Email == email);
         if (user is null)
         {
             _logger.LogWarning("Tentativa de login falhou para o email {Email}.", email);
-            return Unauthorized(new { message = "Credenciais inválidas." });
+            return Unauthorized(new { message = InvalidCredentialsMessage });
         }
 
         var (passwordOk, newStoredPassword) = UserPasswordHasher.Verify(user, password);
         if (!passwordOk)
         {
             _logger.LogWarning("Tentativa de login falhou para o email {Email}.", email);
-            return Unauthorized(new { message = "Credenciais inválidas." });
+            return Unauthorized(new { message = InvalidCredentialsMessage });
         }
 
         if (newStoredPassword is not null)
@@ -82,7 +86,7 @@ public class AuthController : ControllerBase
         if (!user.Active)
         {
             _logger.LogWarning("Tentativa de login para usuário inativo {UserId}.", user.Id);
-            return Unauthorized(new { message = "Credenciais inválidas." });
+            return Unauthorized(new { message = InvalidCredentialsMessage });
         }
 
         var token = _jwt.CreateAccessToken(user.Id, user.TokenVersion, out _);
@@ -95,11 +99,11 @@ public class AuthController : ControllerBase
     {
         var sub = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (string.IsNullOrEmpty(sub) || !Guid.TryParse(sub, out var userId))
-            return Unauthorized(new { message = "Token inválido." });
+            return Unauthorized(new { message = InvalidTokenMessage });
 
         var user = await _db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == userId);
         if (user is null)
-            return Unauthorized(new { message = "Usuário não encontrado." });
+            return Unauthorized(new { message = UserNotFoundMessage });
 
         var permissionIds = (await EffectivePermissionIds.GetForUserAsync(_db, userId))
             .OrderBy(x => x)
@@ -118,11 +122,11 @@ public class AuthController : ControllerBase
     {
         var sub = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (string.IsNullOrEmpty(sub) || !Guid.TryParse(sub, out var userId))
-            return Unauthorized(new { message = "Token inválido." });
+            return Unauthorized(new { message = InvalidTokenMessage });
 
         var user = await _db.Users.FirstOrDefaultAsync(u => u.Id == userId);
         if (user is null)
-            return Unauthorized(new { message = "Usuário não encontrado." });
+            return Unauthorized(new { message = UserNotFoundMessage });
 
         user.TokenVersion++;
         user.UpdatedAt = DateTime.UtcNow;

--- a/AuthService/Controllers/Users/UsersController.cs
+++ b/AuthService/Controllers/Users/UsersController.cs
@@ -16,6 +16,8 @@ namespace AuthService.Controllers.Users;
 [Route("users")]
 public class UsersController : ControllerBase
 {
+    private const string UserNotFoundMessage = "Usuário não encontrado.";
+
     private readonly AppDbContext _db;
 
     public UsersController(AppDbContext db)
@@ -278,7 +280,7 @@ public class UsersController : ControllerBase
     {
         var user = await _db.Users.FirstOrDefaultAsync(u => u.Id == id);
         if (user is null)
-            return NotFound(new { message = "Usuário não encontrado." });
+            return NotFound(new { message = UserNotFoundMessage });
 
         var roles = await _db.UserRoles
             .AsNoTracking()
@@ -326,7 +328,7 @@ public class UsersController : ControllerBase
 
         var user = await _db.Users.FirstOrDefaultAsync(u => u.Id == id);
         if (user is null)
-            return NotFound(new { message = "Usuário não encontrado." });
+            return NotFound(new { message = UserNotFoundMessage });
 
         if (await EmailExistsNormalizedAsync(_db, email, id))
             return new ConflictObjectResult(new { message = "Já existe outro usuário com este Email." });
@@ -384,7 +386,7 @@ public class UsersController : ControllerBase
 
         var user = await _db.Users.FirstOrDefaultAsync(u => u.Id == id);
         if (user is null)
-            return NotFound(new { message = "Usuário não encontrado." });
+            return NotFound(new { message = UserNotFoundMessage });
 
         user.Password = UserPasswordHasher.HashPlainPassword(password);
         user.UpdatedAt = DateTime.UtcNow;
@@ -398,7 +400,7 @@ public class UsersController : ControllerBase
     {
         var user = await _db.Users.FirstOrDefaultAsync(u => u.Id == id);
         if (user is null)
-            return NotFound(new { message = "Usuário não encontrado." });
+            return NotFound(new { message = UserNotFoundMessage });
 
         user.DeletedAt = DateTime.UtcNow;
         user.UpdatedAt = DateTime.UtcNow;

--- a/AuthService/Data/Migrations/20260326210604_CreateUsersTable.cs
+++ b/AuthService/Data/Migrations/20260326210604_CreateUsersTable.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -8,11 +8,13 @@ namespace AuthService.Data.Migrations
     /// <inheritdoc />
     public partial class CreateUsersTable : Migration
     {
+        private const string TableName = "Users";
+
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateTable(
-                name: "Users",
+                name: TableName,
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
@@ -32,12 +34,12 @@ namespace AuthService.Data.Migrations
 
             migrationBuilder.CreateIndex(
                 name: "IX_Users_DeletedAt",
-                table: "Users",
+                table: TableName,
                 column: "DeletedAt");
 
             migrationBuilder.CreateIndex(
                 name: "UX_Users_Email",
-                table: "Users",
+                table: TableName,
                 column: "Email",
                 unique: true);
         }
@@ -46,7 +48,7 @@ namespace AuthService.Data.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(
-                name: "Users");
+                name: TableName);
         }
     }
 }

--- a/AuthService/Data/Migrations/20260328140000_CreateSystemsTable.cs
+++ b/AuthService/Data/Migrations/20260328140000_CreateSystemsTable.cs
@@ -8,11 +8,13 @@ namespace AuthService.Data.Migrations
     /// <inheritdoc />
     public partial class CreateSystemsTable : Migration
     {
+        private const string TableName = "Systems";
+
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateTable(
-                name: "Systems",
+                name: TableName,
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
@@ -30,12 +32,12 @@ namespace AuthService.Data.Migrations
 
             migrationBuilder.CreateIndex(
                 name: "IX_Systems_DeletedAt",
-                table: "Systems",
+                table: TableName,
                 column: "DeletedAt");
 
             migrationBuilder.CreateIndex(
                 name: "UX_Systems_Code",
-                table: "Systems",
+                table: TableName,
                 column: "Code",
                 unique: true);
         }
@@ -44,7 +46,7 @@ namespace AuthService.Data.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(
-                name: "Systems");
+                name: TableName);
         }
     }
 }

--- a/AuthService/Data/Migrations/20260328190000_CreateRoutesTable.cs
+++ b/AuthService/Data/Migrations/20260328190000_CreateRoutesTable.cs
@@ -8,11 +8,13 @@ namespace AuthService.Data.Migrations
     /// <inheritdoc />
     public partial class CreateRoutesTable : Migration
     {
+        private const string TableName = "Routes";
+
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateTable(
-                name: "Routes",
+                name: TableName,
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
@@ -37,17 +39,17 @@ namespace AuthService.Data.Migrations
 
             migrationBuilder.CreateIndex(
                 name: "IX_Routes_DeletedAt",
-                table: "Routes",
+                table: TableName,
                 column: "DeletedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Routes_SystemId",
-                table: "Routes",
+                table: TableName,
                 column: "SystemId");
 
             migrationBuilder.CreateIndex(
                 name: "UX_Routes_Code",
-                table: "Routes",
+                table: TableName,
                 column: "Code",
                 unique: true);
         }
@@ -56,7 +58,7 @@ namespace AuthService.Data.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(
-                name: "Routes");
+                name: TableName);
         }
     }
 }

--- a/AuthService/Data/Migrations/20260329120000_CreatePermissionTypesTable.cs
+++ b/AuthService/Data/Migrations/20260329120000_CreatePermissionTypesTable.cs
@@ -8,11 +8,13 @@ namespace AuthService.Data.Migrations
     /// <inheritdoc />
     public partial class CreatePermissionTypesTable : Migration
     {
+        private const string TableName = "PermissionTypes";
+
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateTable(
-                name: "PermissionTypes",
+                name: TableName,
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
@@ -30,12 +32,12 @@ namespace AuthService.Data.Migrations
 
             migrationBuilder.CreateIndex(
                 name: "IX_PermissionTypes_DeletedAt",
-                table: "PermissionTypes",
+                table: TableName,
                 column: "DeletedAt");
 
             migrationBuilder.CreateIndex(
                 name: "UX_PermissionTypes_Code",
-                table: "PermissionTypes",
+                table: TableName,
                 column: "Code",
                 unique: true);
         }
@@ -44,7 +46,7 @@ namespace AuthService.Data.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(
-                name: "PermissionTypes");
+                name: TableName);
         }
     }
 }

--- a/AuthService/Data/Migrations/20260329130100_CreateRolesTable.cs
+++ b/AuthService/Data/Migrations/20260329130100_CreateRolesTable.cs
@@ -8,11 +8,13 @@ namespace AuthService.Data.Migrations
     /// <inheritdoc />
     public partial class CreateRolesTable : Migration
     {
+        private const string TableName = "Roles";
+
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateTable(
-                name: "Roles",
+                name: TableName,
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
@@ -29,12 +31,12 @@ namespace AuthService.Data.Migrations
 
             migrationBuilder.CreateIndex(
                 name: "IX_Roles_DeletedAt",
-                table: "Roles",
+                table: TableName,
                 column: "DeletedAt");
 
             migrationBuilder.CreateIndex(
                 name: "UX_Roles_Code",
-                table: "Roles",
+                table: TableName,
                 column: "Code",
                 unique: true);
         }
@@ -43,7 +45,7 @@ namespace AuthService.Data.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(
-                name: "Roles");
+                name: TableName);
         }
     }
 }

--- a/AuthService/Data/Migrations/20260329140000_CreatePermissionsTable.cs
+++ b/AuthService/Data/Migrations/20260329140000_CreatePermissionsTable.cs
@@ -8,11 +8,13 @@ namespace AuthService.Data.Migrations
     /// <inheritdoc />
     public partial class CreatePermissionsTable : Migration
     {
+        private const string TableName = "Permissions";
+
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateTable(
-                name: "Permissions",
+                name: TableName,
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
@@ -42,17 +44,17 @@ namespace AuthService.Data.Migrations
 
             migrationBuilder.CreateIndex(
                 name: "IX_Permissions_DeletedAt",
-                table: "Permissions",
+                table: TableName,
                 column: "DeletedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Permissions_PermissionTypeId",
-                table: "Permissions",
+                table: TableName,
                 column: "PermissionTypeId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Permissions_SystemId",
-                table: "Permissions",
+                table: TableName,
                 column: "SystemId");
         }
 
@@ -60,7 +62,7 @@ namespace AuthService.Data.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(
-                name: "Permissions");
+                name: TableName);
         }
     }
 }

--- a/AuthService/Data/Migrations/20260329150000_CreateUserRolesTable.cs
+++ b/AuthService/Data/Migrations/20260329150000_CreateUserRolesTable.cs
@@ -8,11 +8,13 @@ namespace AuthService.Data.Migrations
     /// <inheritdoc />
     public partial class CreateUserRolesTable : Migration
     {
+        private const string TableName = "UserRoles";
+
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateTable(
-                name: "UserRoles",
+                name: TableName,
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
@@ -42,17 +44,17 @@ namespace AuthService.Data.Migrations
 
             migrationBuilder.CreateIndex(
                 name: "IX_UserRoles_DeletedAt",
-                table: "UserRoles",
+                table: TableName,
                 column: "DeletedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_UserRoles_RoleId",
-                table: "UserRoles",
+                table: TableName,
                 column: "RoleId");
 
             migrationBuilder.CreateIndex(
                 name: "UX_UserRoles_UserId_RoleId",
-                table: "UserRoles",
+                table: TableName,
                 columns: new[] { "UserId", "RoleId" },
                 unique: true);
         }
@@ -61,7 +63,7 @@ namespace AuthService.Data.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(
-                name: "UserRoles");
+                name: TableName);
         }
     }
 }

--- a/AuthService/Data/Migrations/20260329160000_CreateUserPermissionsTable.cs
+++ b/AuthService/Data/Migrations/20260329160000_CreateUserPermissionsTable.cs
@@ -8,11 +8,13 @@ namespace AuthService.Data.Migrations
     /// <inheritdoc />
     public partial class CreateUserPermissionsTable : Migration
     {
+        private const string TableName = "UserPermissions";
+
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateTable(
-                name: "UserPermissions",
+                name: TableName,
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
@@ -41,22 +43,22 @@ namespace AuthService.Data.Migrations
 
             migrationBuilder.CreateIndex(
                 name: "IX_UserPermissions_DeletedAt",
-                table: "UserPermissions",
+                table: TableName,
                 column: "DeletedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_UserPermissions_PermissionId",
-                table: "UserPermissions",
+                table: TableName,
                 column: "PermissionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_UserPermissions_UserId",
-                table: "UserPermissions",
+                table: TableName,
                 column: "UserId");
 
             migrationBuilder.CreateIndex(
                 name: "UX_UserPermissions_UserId_PermissionId",
-                table: "UserPermissions",
+                table: TableName,
                 columns: new[] { "UserId", "PermissionId" },
                 unique: true);
         }
@@ -65,7 +67,7 @@ namespace AuthService.Data.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(
-                name: "UserPermissions");
+                name: TableName);
         }
     }
 }

--- a/AuthService/Data/Migrations/20260329170000_CreateRolePermissionsTable.cs
+++ b/AuthService/Data/Migrations/20260329170000_CreateRolePermissionsTable.cs
@@ -8,11 +8,13 @@ namespace AuthService.Data.Migrations
     /// <inheritdoc />
     public partial class CreateRolePermissionsTable : Migration
     {
+        private const string TableName = "RolePermissions";
+
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateTable(
-                name: "RolePermissions",
+                name: TableName,
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
@@ -41,22 +43,22 @@ namespace AuthService.Data.Migrations
 
             migrationBuilder.CreateIndex(
                 name: "IX_RolePermissions_DeletedAt",
-                table: "RolePermissions",
+                table: TableName,
                 column: "DeletedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_RolePermissions_PermissionId",
-                table: "RolePermissions",
+                table: TableName,
                 column: "PermissionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_RolePermissions_RoleId",
-                table: "RolePermissions",
+                table: TableName,
                 column: "RoleId");
 
             migrationBuilder.CreateIndex(
                 name: "UX_RolePermissions_RoleId_PermissionId",
-                table: "RolePermissions",
+                table: TableName,
                 columns: new[] { "RoleId", "PermissionId" },
                 unique: true);
         }
@@ -65,7 +67,7 @@ namespace AuthService.Data.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(
-                name: "RolePermissions");
+                name: TableName);
         }
     }
 }

--- a/AuthService/Data/Migrations/20260329181114_AddSystemTokenTypes.cs
+++ b/AuthService/Data/Migrations/20260329181114_AddSystemTokenTypes.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -8,11 +8,13 @@ namespace AuthService.Data.Migrations
     /// <inheritdoc />
     public partial class AddSystemTokenTypes : Migration
     {
+        private const string TableName = "SystemTokenTypes";
+
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateTable(
-                name: "SystemTokenTypes",
+                name: TableName,
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
@@ -30,12 +32,12 @@ namespace AuthService.Data.Migrations
 
             migrationBuilder.CreateIndex(
                 name: "IX_SystemTokenTypes_DeletedAt",
-                table: "SystemTokenTypes",
+                table: TableName,
                 column: "DeletedAt");
 
             migrationBuilder.CreateIndex(
                 name: "UX_SystemTokenTypes_Code",
-                table: "SystemTokenTypes",
+                table: TableName,
                 column: "Code",
                 unique: true);
         }
@@ -44,7 +46,7 @@ namespace AuthService.Data.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(
-                name: "SystemTokenTypes");
+                name: TableName);
         }
     }
 }

--- a/AuthService/Data/Migrations/20260402021307_CreateClientsDomain.cs
+++ b/AuthService/Data/Migrations/20260402021307_CreateClientsDomain.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -8,17 +8,22 @@ namespace AuthService.Data.Migrations
     /// <inheritdoc />
     public partial class CreateClientsDomain : Migration
     {
+        private const string UsersTable = "Users";
+        private const string ClientsTable = "Clients";
+        private const string ClientEmailsTable = "ClientEmails";
+        private const string ClientPhonesTable = "ClientPhones";
+
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AddColumn<Guid>(
                 name: "ClientId",
-                table: "Users",
+                table: UsersTable,
                 type: "uniqueidentifier",
                 nullable: true);
 
             migrationBuilder.CreateTable(
-                name: "Clients",
+                name: ClientsTable,
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
@@ -37,7 +42,7 @@ namespace AuthService.Data.Migrations
                 });
 
             migrationBuilder.CreateTable(
-                name: "ClientEmails",
+                name: ClientEmailsTable,
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
@@ -51,13 +56,13 @@ namespace AuthService.Data.Migrations
                     table.ForeignKey(
                         name: "FK_ClientEmails_Clients_ClientId",
                         column: x => x.ClientId,
-                        principalTable: "Clients",
+                        principalTable: ClientsTable,
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.CreateTable(
-                name: "ClientPhones",
+                name: ClientPhonesTable,
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
@@ -72,52 +77,52 @@ namespace AuthService.Data.Migrations
                     table.ForeignKey(
                         name: "FK_ClientPhones_Clients_ClientId",
                         column: x => x.ClientId,
-                        principalTable: "Clients",
+                        principalTable: ClientsTable,
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.CreateIndex(
                 name: "IX_Users_ClientId",
-                table: "Users",
+                table: UsersTable,
                 column: "ClientId");
 
             migrationBuilder.CreateIndex(
                 name: "UX_ClientEmails_ClientId_Email",
-                table: "ClientEmails",
+                table: ClientEmailsTable,
                 columns: new[] { "ClientId", "Email" },
                 unique: true);
 
             migrationBuilder.CreateIndex(
                 name: "UX_ClientPhones_ClientId_Type_Number",
-                table: "ClientPhones",
+                table: ClientPhonesTable,
                 columns: new[] { "ClientId", "Type", "Number" },
                 unique: true);
 
             migrationBuilder.CreateIndex(
                 name: "IX_Clients_DeletedAt",
-                table: "Clients",
+                table: ClientsTable,
                 column: "DeletedAt");
 
             migrationBuilder.CreateIndex(
                 name: "UX_Clients_Cnpj",
-                table: "Clients",
+                table: ClientsTable,
                 column: "Cnpj",
                 unique: true,
                 filter: "[Cnpj] IS NOT NULL");
 
             migrationBuilder.CreateIndex(
                 name: "UX_Clients_Cpf",
-                table: "Clients",
+                table: ClientsTable,
                 column: "Cpf",
                 unique: true,
                 filter: "[Cpf] IS NOT NULL");
 
             migrationBuilder.AddForeignKey(
                 name: "FK_Users_Clients_ClientId",
-                table: "Users",
+                table: UsersTable,
                 column: "ClientId",
-                principalTable: "Clients",
+                principalTable: ClientsTable,
                 principalColumn: "Id",
                 onDelete: ReferentialAction.Restrict);
         }
@@ -127,24 +132,24 @@ namespace AuthService.Data.Migrations
         {
             migrationBuilder.DropForeignKey(
                 name: "FK_Users_Clients_ClientId",
-                table: "Users");
+                table: UsersTable);
 
             migrationBuilder.DropTable(
-                name: "ClientEmails");
+                name: ClientEmailsTable);
 
             migrationBuilder.DropTable(
-                name: "ClientPhones");
+                name: ClientPhonesTable);
 
             migrationBuilder.DropTable(
-                name: "Clients");
+                name: ClientsTable);
 
             migrationBuilder.DropIndex(
                 name: "IX_Users_ClientId",
-                table: "Users");
+                table: UsersTable);
 
             migrationBuilder.DropColumn(
                 name: "ClientId",
-                table: "Users");
+                table: UsersTable);
         }
     }
 }


### PR DESCRIPTION
## 📌 Contexto

O SonarCloud detectou 12 ocorrências da regra `csharpsquid:S1192` (String literals should not be duplicated) nos controllers e migrations do projeto, classificadas como CODE_SMELL de severidade MINOR.

Closes #50

## 🎯 Objetivo

Extrair literais de string duplicados para constantes `private const`, eliminando os code smells do Sonar sem alterar comportamento funcional.

## ⚙️ O que foi feito

### Controllers
- **AuthController.cs**: extraído `"Credenciais inválidas."` (4x), `"Token inválido."` (2x) e `"Usuário não encontrado."` (2x) para constantes privadas (`InvalidCredentialsMessage`, `InvalidTokenMessage`, `UserNotFoundMessage`)
- **UsersController.cs**: extraído `"Usuário não encontrado."` (4x) para constante privada (`UserNotFoundMessage`)

### Migrations (constante local por arquivo, sem compartilhar estado)
- `CreateUsersTable` → `TableName = "Users"`
- `CreateSystemsTable` → `TableName = "Systems"`
- `CreateRoutesTable` → `TableName = "Routes"`
- `CreatePermissionTypesTable` → `TableName = "PermissionTypes"`
- `CreateRolesTable` → `TableName = "Roles"`
- `CreatePermissionsTable` → `TableName = "Permissions"`
- `CreateUserRolesTable` → `TableName = "UserRoles"`
- `CreateUserPermissionsTable` → `TableName = "UserPermissions"`
- `CreateRolePermissionsTable` → `TableName = "RolePermissions"`
- `AddSystemTokenTypes` → `TableName = "SystemTokenTypes"`
- `CreateClientsDomain` → `UsersTable`, `ClientsTable`, `ClientEmailsTable`, `ClientPhonesTable`

## 📁 Arquivos impactados

- `AuthService/Controllers/Auth/AuthController.cs`
- `AuthService/Controllers/Users/UsersController.cs`
- 11 arquivos em `AuthService/Data/Migrations/`

## 🧪 Testes

- **160 testes passando** (0 falhas, 0 ignorados)
- **Coverage**: Line 94.72% | Branch 64.81% | Method 91.47%
- Comando: `docker compose --profile test run --rm test`

## 🛡️ Segurança

Nenhum impacto de segurança. Alteração puramente mecânica — os valores literais das strings permanecem idênticos.

## ⚠️ Riscos

- **Baixo**: alterações em migrations já aplicadas são seguras porque os valores efetivos das strings não mudam (apenas extraídos para constante no mesmo arquivo)
- Nenhuma migration nova foi gerada — padrão SQL permanece equivalente

## 🔗 Issue relacionada

Closes #50

Made with [Cursor](https://cursor.com)