### PR TITLE
#51 | [Sonar][MINOR] Simplificar loop com LINQ Where em AppDbContext (S3267)

### DIFF
--- a/AuthService/Data/AppDbContext.cs
+++ b/AuthService/Data/AppDbContext.cs
@@ -119,17 +119,15 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
                 .OnDelete(DeleteBehavior.Restrict);
         });
 
-        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes()
+                     .Where(et => typeof(ISoftDelete).IsAssignableFrom(et.ClrType)))
         {
-            if (typeof(ISoftDelete).IsAssignableFrom(entityType.ClrType))
-            {
-                var parameter = Expression.Parameter(entityType.ClrType, "e");
-                var property = Expression.Property(parameter, nameof(ISoftDelete.DeletedAt));
-                var nullConstant = Expression.Constant(null, typeof(DateTime?));
-                var body = Expression.Equal(property, nullConstant);
-                var lambda = Expression.Lambda(body, parameter);
-                modelBuilder.Entity(entityType.ClrType).HasQueryFilter(lambda);
-            }
+            var parameter = Expression.Parameter(entityType.ClrType, "e");
+            var property = Expression.Property(parameter, nameof(ISoftDelete.DeletedAt));
+            var nullConstant = Expression.Constant(null, typeof(DateTime?));
+            var body = Expression.Equal(property, nullConstant);
+            var lambda = Expression.Lambda(body, parameter);
+            modelBuilder.Entity(entityType.ClrType).HasQueryFilter(lambda);
         }
     }
 }

--- a/AuthService/Data/AppDbContext.cs
+++ b/AuthService/Data/AppDbContext.cs
@@ -119,15 +119,16 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
                 .OnDelete(DeleteBehavior.Restrict);
         });
 
-        foreach (var entityType in modelBuilder.Model.GetEntityTypes()
-                     .Where(et => typeof(ISoftDelete).IsAssignableFrom(et.ClrType)))
+        foreach (var clrType in modelBuilder.Model.GetEntityTypes()
+                     .Where(et => typeof(ISoftDelete).IsAssignableFrom(et.ClrType))
+                     .Select(et => et.ClrType))
         {
-            var parameter = Expression.Parameter(entityType.ClrType, "e");
+            var parameter = Expression.Parameter(clrType, "e");
             var property = Expression.Property(parameter, nameof(ISoftDelete.DeletedAt));
             var nullConstant = Expression.Constant(null, typeof(DateTime?));
             var body = Expression.Equal(property, nullConstant);
             var lambda = Expression.Lambda(body, parameter);
-            modelBuilder.Entity(entityType.ClrType).HasQueryFilter(lambda);
+            modelBuilder.Entity(clrType).HasQueryFilter(lambda);
         }
     }
 }


### PR DESCRIPTION
## 📌 Contexto

Issue #51 — SonarCloud reportou `csharpsquid:S3267` (MINOR) em `AppDbContext.cs:122`: loop com condição `if` que pode ser simplificado com LINQ `.Where()`.

## 🎯 Objetivo

Resolver o code smell S3267, melhorando legibilidade do código sem alterar semântica.

## ⚙️ O que foi feito

- Substituído padrão `foreach + if` por `foreach` com `.Where(...)` no setup de query filters de soft-delete em `OnModelCreating`
- Semântica 100% preservada — mesma filtragem, mesma ordem de chamadas ao Fluent API

## 📁 Arquivos impactados

- `AuthService/Data/AppDbContext.cs` (linhas 122-133)

## 🧪 Testes

- **160 testes** executados via `docker compose --profile test` — todos passaram
- **Coverage:** Line 94.62% | Branch 63.83% | Method 91.25%

## 🛡️ Segurança

- Sem impacto de segurança. Apenas refatoração estilística.

## ⚠️ Riscos

- Risco mínimo: a refatoração apenas move a condição do `if` para `.Where()` — comportamento idêntico
- Mitigado por testes de integração completos (160/160 OK)

## 🔗 Issue relacionada

Closes #51

Made with [Cursor](https://cursor.com)