### PR TITLE
#68 | [Sonar][Security Hotspot] Revisar uso de protocolo em texto claro no Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,15 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0
 
 WORKDIR /app
 
+# HTTPS no bind 0.0.0.0:5042 (evita protocolo em texto claro — Sonar docker:S5332). Certificado de desenvolvimento
+# gerado na imagem; em ambientes reais o TLS costuma terminar no proxy/load balancer.
+RUN mkdir -p /https \
+    && dotnet dev-certs https -ep /https/aspnetapp.pfx -p "AuthDockerDevOnly"
+
+ENV ASPNETCORE_Kestrel__Certificates__Default__Password="AuthDockerDevOnly"
+ENV ASPNETCORE_Kestrel__Certificates__Default__Path="/https/aspnetapp.pfx"
+ENV ASPNETCORE_URLS="https://0.0.0.0:5042"
+
 # Ferramenta EF Core disponível globalmente no container
 RUN dotnet tool install --global dotnet-ef --version 10.0.5
 ENV PATH="${PATH}:/root/.dotnet/tools"
@@ -13,4 +22,4 @@ ENV DOTNET_USE_POLLING_FILE_WATCHER=1
 EXPOSE 5042
 
 # Em dev, você já monta o volume ./AuthService:/app via docker-compose
-CMD ["dotnet", "watch", "run", "--no-launch-profile", "--urls", "http://0.0.0.0:5042"]
+CMD ["dotnet", "watch", "run", "--no-launch-profile"]

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Ações padrão de permissão: `create`, `read`, `update`, `delete`, `restore`.
 2. Subir API + SQL: `docker compose up -d --build`
 3. Aplicar migrations (primeira vez ou após alteração do modelo):  
    `docker compose --profile migrate run --rm migrate`
-4. API no host: **http://localhost:8080** (mapeamento `8080:5042`; dentro do container a app escuta na porta **5042**).
+4. API no host: **https://localhost:8080** (mapeamento `8080:5042`; Kestrel usa certificado de desenvolvimento gerado na imagem Docker — o navegador pode alertar até você confiar no certificado ou usar `-k` no `curl`).
 
 ### Opção B — `dotnet run` no host
 
@@ -327,7 +327,7 @@ Corpo: `systemId`, `permissionTypeId`, `description` (opcional). Restauração e
 
 ## Exemplos de uso
 
-Substitua a base pela URL da sua instância (`http://localhost:5052`, `http://localhost:8080`, etc.).
+Substitua a base pela URL da sua instância (`http://localhost:5052`, `https://localhost:8080` no Compose, etc.).
 
 **Login**
 
@@ -387,7 +387,7 @@ O arquivo **`docker-compose.yml`** está na **raiz** do repositório.
 | Serviço | Função |
 |---------|--------|
 | `db` | SQL Server 2022; porta **1433** no host; volume `mssql_data`. |
-| `app` | API com `dotnet watch`, volume `./AuthService:/app`, porta **8080→5042**. |
+| `app` | API com `dotnet watch`, volume `./AuthService:/app`, porta **8080→5042** (HTTPS no container). |
 | `migrate` (profile `migrate`) | `dotnet ef database update` contra o `db`. |
 | `test` (profile `test`) | Executa `dotnet test` com `AUTH_SERVICE_TEST_SQL_BASE` apontando para `db`. |
 


### PR DESCRIPTION
## Contexto
Hotspot Sonar `docker:S5332` no `Dockerfile` (protocolo em texto claro na URL do Kestrel).

## O que foi feito
- Geração de certificado de desenvolvimento com `dotnet dev-certs https` na imagem e configuração do Kestrel para HTTPS em `0.0.0.0:5042` via `ASPNETCORE_URLS` (sem `http://` no CMD).
- README atualizado: acesso via `https://localhost:8080` e nota sobre alerta de certificado no navegador.

## Testes
```bash
docker compose --profile test run --rm test
```
Resultado: **165 testes passando**.

## Riscos
- Navegadores exibem aviso de certificado até confiar manualmente (esperado para dev cert na imagem).
- Build Docker emite aviso BuildKit sobre senha do .pfx em ENV (senha apenas para o .pfx de desenvolvimento na imagem).

## Segurança
Elimina bind HTTP explícito no Dockerfile; TLS no listener do container de desenvolvimento.

Closes #68

Made with [Cursor](https://cursor.com)