### PR TITLE
#69 | [Sonar][Security Hotspot] Revisar execucao do container com usuario root no Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,16 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0
 
 WORKDIR /app
 
+# Executa como usuário não-root para hardening do container (Sonar docker:S6471).
+# A imagem base já fornece o usuário "ubuntu" (UID/GID 1000), compatível com
+# volumes montados do host na maioria das distros Linux.
+RUN chown ubuntu:ubuntu /app
+
+USER ubuntu
+
 # Ferramenta EF Core disponível globalmente no container
 RUN dotnet tool install --global dotnet-ef --version 10.0.5
-ENV PATH="${PATH}:/root/.dotnet/tools"
+ENV PATH="${PATH}:/home/ubuntu/.dotnet/tools"
 
 # (Opcional) melhora estabilidade de file-watch em volume Docker
 ENV DOTNET_USE_POLLING_FILE_WATCHER=1


### PR DESCRIPTION
## 📌 Contexto

O SonarCloud identificou um **security hotspot** (`docker:S6471`, probabilidade **MEDIUM**) no `Dockerfile` porque a imagem executa com o usuário padrão `root`. Executar containers como root amplia a superfície de ataque em caso de comprometimento.

## 🎯 Objetivo

Ajustar o `Dockerfile` para que o container execute com um usuário não-privilegiado, resolvendo o hotspot de segurança sem regressão funcional.

## ⚙️ O que foi feito

- Adicionada diretiva `USER ubuntu` no `Dockerfile` para execução como não-root
- Reutilizado o usuário `ubuntu` (UID/GID 1000) já existente na imagem base `dotnet/sdk:10.0`
- Ajustado ownership de `/app` para o usuário `ubuntu` via `chown`
- Ferramenta `dotnet-ef` agora é instalada e acessível pelo usuário não-root (`/home/ubuntu/.dotnet/tools`)
- PATH atualizado de `/root/.dotnet/tools` para `/home/ubuntu/.dotnet/tools`

## 📁 Arquivos impactados

| Arquivo | Tipo de alteração |
|---------|-------------------|
| `Dockerfile` | Modificado — adicionado `USER ubuntu`, `chown`, ajuste de PATH |

## 🧪 Testes

- **165 testes de integração passando** (0 falhas, 0 skips)
- **Coverage:** Line 95.6% | Branch 72.84% | Method 94.06%
- Build da imagem Docker validado com sucesso
- Verificado que o container executa como `ubuntu` (UID 1000), não `root`
- Verificado que `dotnet-ef` funciona corretamente com o novo PATH

```
Passed!  - Failed: 0, Passed: 165, Skipped: 0, Total: 165
```

## 🛡️ Segurança

- **Hotspot resolvido:** `docker:S6471` — container não executa mais como root
- **Nenhum segredo exposto** — nenhuma credencial adicionada ou alterada
- **Sem impacto funcional** — apenas hardening do container

## ⚠️ Riscos

- Volumes montados do host precisam ter UID 1000 para compatibilidade de escrita (padrão na maioria das distros Linux)
- O serviço `migrate` do docker-compose usa a mesma imagem e herda o usuário não-root — validado via build

## 🔗 Issue relacionada

Closes #69

Made with [Cursor](https://cursor.com)