### PR TITLE
#76 | [Sonar][CODE_SMELL][INFO] `external_roslyn:CA1861` — `20260402021307_CreateClientsDomain.cs`:93

### DIFF
--- a/AuthService/Data/Migrations/20260402021307_CreateClientsDomain.cs
+++ b/AuthService/Data/Migrations/20260402021307_CreateClientsDomain.cs
@@ -15,6 +15,7 @@ namespace AuthService.Data.Migrations
         private const string ClientIdColumn = "ClientId";
         private const string UniqueIdentifierType = "uniqueidentifier";
         private const string DateTime2Type = "datetime2";
+        private static readonly string[] ClientEmailsUniqueIndexColumns = { "ClientId", "Email" };
 
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -93,7 +94,7 @@ namespace AuthService.Data.Migrations
             migrationBuilder.CreateIndex(
                 name: "UX_ClientEmails_ClientId_Email",
                 table: ClientEmailsTable,
-                columns: new[] { "ClientId", "Email" },
+                columns: ClientEmailsUniqueIndexColumns,
                 unique: true);
 
             migrationBuilder.CreateIndex(


### PR DESCRIPTION
## Resumo
- substitui o array literal de colunas do índice `UX_ClientEmails_ClientId_Email` por campo `static readonly`
- mantém comportamento da migration, removendo o padrão apontado por `external_roslyn:CA1861` no trecho da issue

## Validação
- `docker compose --profile test run --rm test`
  - restore/build concluídos; nesta máquina o runner não retornou sumário final do `dotnet test` (mesmo padrão observado anteriormente)

Closes #76

Closes LF-Calegari/lfc-authenticator#76