### PR TITLE
#77 | [Sonar][CODE_SMELL][INFO] external_roslyn:CA1861 — 20260402021307_CreateClientsDomain.cs:99

### DIFF
--- a/AuthService/Data/Migrations/20260402021307_CreateClientsDomain.cs
+++ b/AuthService/Data/Migrations/20260402021307_CreateClientsDomain.cs
@@ -16,6 +16,7 @@ namespace AuthService.Data.Migrations
         private const string UniqueIdentifierType = "uniqueidentifier";
         private const string DateTime2Type = "datetime2";
         private static readonly string[] ClientEmailsUniqueIndexColumns = { "ClientId", "Email" };
+        private static readonly string[] ClientPhonesUniqueIndexColumns = { "ClientId", "Type", "Number" };
 
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -100,7 +101,7 @@ namespace AuthService.Data.Migrations
             migrationBuilder.CreateIndex(
                 name: "UX_ClientPhones_ClientId_Type_Number",
                 table: ClientPhonesTable,
-                columns: new[] { "ClientId", "Type", "Number" },
+                columns: ClientPhonesUniqueIndexColumns,
                 unique: true);
 
             migrationBuilder.CreateIndex(


### PR DESCRIPTION
## Resumo\nAjusta a migration para remover o array literal usado repetidamente em CreateIndex, conforme recomendação do Sonar (CA1861), sem alteração de comportamento.\n\n## Alterações\n- Adicionado campo static readonly para as colunas do índice único de ClientPhones\n- Substituído o argumento `new[] { "ClientId", "Type", "Number" }` por referência ao campo static readonly\n\n## Validação\n- Falha inicial esperada de ambiente ao rodar sem variável: INTEGRATION_BOOTSTRAP_PASSWORD obrigatória\n- Execução validada com variável definida:\n  - `INTEGRATION_BOOTSTRAP_PASSWORD='SenhaSegura1!' docker compose --profile test run --rm test`\n  - Resultado: 172 passed\n\nCloses #77