### PR TITLE
#78 | [Sonar][CODE_SMELL][INFO] external_roslyn:CA1859 — LegacyClientFactory.cs:24

### DIFF
--- a/AuthService/Data/LegacyClientFactory.cs
+++ b/AuthService/Data/LegacyClientFactory.cs
@@ -21,7 +21,7 @@ internal static class LegacyClientFactory
         };
     }
 
-    private static string GenerateUniqueCpf(ISet<string> usedCpfs, int seed)
+    private static string GenerateUniqueCpf(HashSet<string> usedCpfs, int seed)
     {
         var counter = Math.Max(seed, 1);
         while (true)


### PR DESCRIPTION
## Resumo
Ajusta o tipo do parâmetro usedCpfs no método interno de geração de CPF para o tipo concreto HashSet<string>, conforme recomendação do Sonar (CA1859), preservando o comportamento atual.

## Alterações
- LegacyClientFactory.GenerateUniqueCpf: ISet<string> -> HashSet<string>

## Validação
- Comando obrigatório executado:
  - docker compose --profile test run --rm test
- Resultado:
  - Passed: 172, Failed: 0

Closes #78
