### PR TITLE
#81 | [Sonar][CODE_SMELL][INFO] external_roslyn:CA1859 — ClientsController.cs:493

### DIFF
--- a/AuthService/Controllers/Clients/ClientsController.cs
+++ b/AuthService/Controllers/Clients/ClientsController.cs
@@ -495,7 +495,7 @@ public class ClientsController : ControllerBase
         return mod < 2 ? 0 : 11 - mod;
     }
 
-    private static int CheckDigit(string input, IReadOnlyList<int> weights)
+    private static int CheckDigit(string input, int[] weights)
     {
         var sum = 0;
         for (var i = 0; i < input.Length; i++)


### PR DESCRIPTION
## Resumo
Ajusta o tipo do parâmetro weights no overload de CheckDigit para int[], conforme recomendação CA1859, preservando semântica.

## Alterações
- ClientsController.CheckDigit(input, weights): IReadOnlyList<int> -> int[]

## Validação
- Comando obrigatório executado:
  - docker compose --profile test run --rm test
- Resultado:
  - Passed: 172, Failed: 0

Closes #81
