### PR TITLE
#85 | [Sonar][CODE_SMELL][MINOR] csharpsquid:S2094 — ClientsController.cs:48

### DIFF
--- a/AuthService/Controllers/Clients/ClientsController.cs
+++ b/AuthService/Controllers/Clients/ClientsController.cs
@@ -48,8 +48,6 @@ public class ClientsController : ControllerBase
         public string? CorporateName { get; set; }
     }
 
-    public class UpdateClientRequest : CreateClientRequest;
-
     public sealed class AddEmailRequest
     {
         [Required]
@@ -159,7 +157,7 @@ public class ClientsController : ControllerBase
 
     [HttpPut("{id:guid}")]
     [Authorize(Policy = PermissionPolicies.ClientsUpdate)]
-    public async Task<IActionResult> UpdateById(Guid id, [FromBody] UpdateClientRequest request)
+    public async Task<IActionResult> UpdateById(Guid id, [FromBody] CreateClientRequest request)
     {
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);


### PR DESCRIPTION
## Resumo
Remove a classe vazia UpdateClientRequest no ClientsController para atender a regra S2094, reutilizando o DTO CreateClientRequest no endpoint de atualização.

## Alterações
- Removida a classe vazia UpdateClientRequest
- UpdateById agora recebe CreateClientRequest no corpo da requisição

## Validação
- Comando obrigatório executado:
  - docker compose --profile test run --rm test
- Resultado:
  - Passed: 172, Failed: 0

Closes #85
