### PR TITLE
#87 | [Sonar][CODE_SMELL][INFO] external_roslyn:CA1861 — ClientsApiTests.cs:462

### DIFF
--- a/AuthService.Tests/ClientsApiTests.cs
+++ b/AuthService.Tests/ClientsApiTests.cs
@@ -9,6 +9,8 @@ namespace AuthService.Tests;
 
 public class ClientsApiTests : IAsyncLifetime
 {
+    private static readonly int[] CnpjWeights1 = { 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2 };
+    private static readonly int[] CnpjWeights2 = { 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2 };
     private WebAppFactory _factory = null!;
     private HttpClient _client = null!;
 
@@ -459,8 +461,8 @@ public class ClientsApiTests : IAsyncLifetime
     private static string GenerateCnpj(int baseDigits)
     {
         var twelve = (baseDigits % 100_000_000).ToString("D8") + "0001";
-        var d1 = CheckDigitCnpj(twelve, new[] { 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2 });
-        var d2 = CheckDigitCnpj(twelve + d1, new[] { 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2 });
+        var d1 = CheckDigitCnpj(twelve, CnpjWeights1);
+        var d2 = CheckDigitCnpj(twelve + d1, CnpjWeights2);
         return twelve + d1 + d2;
     }
 


### PR DESCRIPTION
## Resumo
Substitui arrays literais repetidos por campos static readonly em ClientsApiTests para atender a recomendação CA1861 sem alterar a lógica dos testes.

## Alterações
- Adicionados campos static readonly CnpjWeights1 e CnpjWeights2
- GenerateCnpj passou a usar esses campos em vez de arrays literais inline

## Validação
- Comando obrigatório executado:
  - docker compose --profile test run --rm test
- Resultado:
  - Passed: 172, Failed: 0

Closes #87
