### PR TITLE
#89 | [Sonar][CODE_SMELL][INFO] external_roslyn:CA1859 — ClientsApiTests.cs:467

### DIFF
--- a/AuthService.Tests/ClientsApiTests.cs
+++ b/AuthService.Tests/ClientsApiTests.cs
@@ -466,7 +466,7 @@ public class ClientsApiTests : IAsyncLifetime
         return twelve + d1 + d2;
     }
 
-    private static int CheckDigitCnpj(string input, IReadOnlyList<int> weights)
+    private static int CheckDigitCnpj(string input, int[] weights)
     {
         var sum = 0;
         for (var i = 0; i < input.Length; i++)


### PR DESCRIPTION
## Resumo
Ajusta o tipo do parâmetro weights no método CheckDigitCnpj em ClientsApiTests para int[], conforme recomendação CA1859, preservando semântica.

## Alterações
- CheckDigitCnpj(string input, IReadOnlyList<int> weights) -> CheckDigitCnpj(string input, int[] weights)

## Validação
- Comando obrigatório executado:
  - docker compose --profile test run --rm test
- Resultado:
  - Passed: 172, Failed: 0

Closes #89
