### PR TITLE
feat(users): add minimal lookup endpoints for issue #134

### DIFF
--- a/AuthService.Tests/UsersApiTests.cs
+++ b/AuthService.Tests/UsersApiTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using AuthService.Data;
-using AuthService.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -180,6 +180,14 @@ public class UsersApiTests : IAsyncLifetime
 
         var getOk = await _client.GetAsync($"/api/v1/users/{dto.Id}");
         Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
+        using (var payload = JsonDocument.Parse(await getOk.Content.ReadAsStringAsync()))
+        {
+            var root = payload.RootElement;
+            Assert.Equal(3, root.EnumerateObject().Count());
+            Assert.Equal(dto.Id, root.GetProperty("id").GetGuid());
+            Assert.Equal("S", root.GetProperty("name").GetString());
+            Assert.Equal("g1@example.com", root.GetProperty("email").GetString());
+        }
 
         await _client.DeleteAsync($"/api/v1/users/{dto.Id}");
         var get404 = await _client.GetAsync($"/api/v1/users/{dto.Id}");
@@ -334,78 +342,42 @@ public class UsersApiTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task GetById_ReturnsRolesAndPermissions_WhenLinkedInDatabase()
+    public async Task GetByIds_ReturnsMinimalProjection_InRequestedOrder()
     {
-        var create = await _client.PostAsJsonAsync("/api/v1/users",
-            UserCreateBody("Com vínculos", "user.links@example.com"), TestApiClient.JsonOptions);
-        create.EnsureSuccessStatusCode();
-        var created = await create.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
-        Assert.NotNull(created);
-
-        var roleResp = await _client.PostAsJsonAsync("/api/v1/roles",
-            new { name = "Papel teste vínculo", code = $"ut-user-detail-{Guid.NewGuid():N}" },
+        var create = await _client.PostAsJsonAsync("/api/v1/users", UserCreateBody("Com vínculo", "batch.one@example.com"),
             TestApiClient.JsonOptions);
-        roleResp.EnsureSuccessStatusCode();
-        var roleDto = await roleResp.Content.ReadFromJsonAsync<IdOnlyDto>(TestApiClient.JsonOptions);
-        Assert.NotNull(roleDto);
-        var roleId = roleDto.Id;
+        create.EnsureSuccessStatusCode();
+        var userA = await create.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(userA);
 
-        Guid permissionId;
-        using (var scope = _factory.Services.CreateScope())
-        {
-            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-            permissionId = await db.Permissions.Select(p => p.Id).FirstAsync();
-            var utc = DateTime.UtcNow;
-            db.UserRoles.Add(new AppUserRole
-            {
-                UserId = created.Id,
-                RoleId = roleId,
-                CreatedAt = utc,
-                UpdatedAt = utc,
-                DeletedAt = null
-            });
-            db.UserPermissions.Add(new AppUserPermission
-            {
-                UserId = created.Id,
-                PermissionId = permissionId,
-                CreatedAt = utc,
-                UpdatedAt = utc,
-                DeletedAt = null
-            });
-            await db.SaveChangesAsync();
-        }
+        var createSecond = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("Dois", "batch.two@example.com"), TestApiClient.JsonOptions);
+        createSecond.EnsureSuccessStatusCode();
+        var userB = await createSecond.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(userB);
 
-        var getResp = await _client.GetAsync($"/api/v1/users/{created.Id}");
+        var getResp = await _client.GetAsync($"/api/v1/users?ids={userB.Id},{userA.Id}");
         getResp.EnsureSuccessStatusCode();
-        var detail = await getResp.Content.ReadFromJsonAsync<UserDetailDto>(TestApiClient.JsonOptions);
-        Assert.NotNull(detail);
-        Assert.Single(detail.Roles);
-        Assert.Equal(roleId, detail.Roles[0].RoleId);
-        Assert.Equal(created.Id, detail.Roles[0].UserId);
-        Assert.Single(detail.Permissions);
-        Assert.Equal(permissionId, detail.Permissions[0].PermissionId);
-        Assert.Equal(created.Id, detail.Permissions[0].UserId);
+        using var payload = JsonDocument.Parse(await getResp.Content.ReadAsStringAsync());
+        var rows = payload.RootElement.EnumerateArray().ToList();
+        Assert.Equal(2, rows.Count);
+
+        Assert.Equal(userB.Id, rows[0].GetProperty("id").GetGuid());
+        Assert.Equal("Dois", rows[0].GetProperty("name").GetString());
+        Assert.Equal("batch.two@example.com", rows[0].GetProperty("email").GetString());
+        Assert.Equal(3, rows[0].EnumerateObject().Count());
+
+        Assert.Equal(userA.Id, rows[1].GetProperty("id").GetGuid());
+        Assert.Equal("Com vínculo", rows[1].GetProperty("name").GetString());
+        Assert.Equal("batch.one@example.com", rows[1].GetProperty("email").GetString());
+        Assert.Equal(3, rows[1].EnumerateObject().Count());
     }
 
     [Fact]
-    public async Task GetById_RootUser_ReturnsRoleLink_AndNoDirectPermissions_FromSeeder()
+    public async Task GetByIds_InvalidGuid_ReturnsBadRequest()
     {
-        Guid rootId;
-        using (var scope = _factory.Services.CreateScope())
-        {
-            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-            rootId = await db.Users
-                .Where(u => u.Email == DefaultSystemUserSeeder.RootEmail)
-                .Select(u => u.Id)
-                .SingleAsync();
-        }
-
-        var getResp = await _client.GetAsync($"/api/v1/users/{rootId}");
-        getResp.EnsureSuccessStatusCode();
-        var detail = await getResp.Content.ReadFromJsonAsync<UserDetailDto>(TestApiClient.JsonOptions);
-        Assert.NotNull(detail);
-        Assert.Single(detail.Roles);
-        Assert.Empty(detail.Permissions);
+        var getResp = await _client.GetAsync("/api/v1/users?ids=not-a-guid");
+        Assert.Equal(HttpStatusCode.BadRequest, getResp.StatusCode);
     }
 
     [Fact]
@@ -466,8 +438,6 @@ public class UsersApiTests : IAsyncLifetime
         DateTime CreatedAt,
         DateTime UpdatedAt,
         DateTime? DeletedAt);
-
-    private sealed record IdOnlyDto(Guid Id);
 
     private sealed record ClientIdDto(Guid Id);
 

--- a/AuthService.Tests/UsersApiTests.cs
+++ b/AuthService.Tests/UsersApiTests.cs
@@ -381,6 +381,23 @@ public class UsersApiTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task GetByIds_EmptyValue_ReturnsBadRequest()
+    {
+        var getResp = await _client.GetAsync("/api/v1/users?ids=");
+        Assert.Equal(HttpStatusCode.BadRequest, getResp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetByIds_MoreThanMaxBatchIds_ReturnsBadRequest()
+    {
+        var ids = Enumerable.Range(0, 101).Select(_ => Guid.NewGuid().ToString());
+        var query = string.Join(',', ids);
+
+        var getResp = await _client.GetAsync($"/api/v1/users?ids={query}");
+        Assert.Equal(HttpStatusCode.BadRequest, getResp.StatusCode);
+    }
+
+    [Fact]
     public async Task GetAll_ReturnsEmptyRolesAndPermissions_OnEachUser()
     {
         await _client.PostAsJsonAsync("/api/v1/users", UserCreateBody("Lista", "list.empty@example.com"), TestApiClient.JsonOptions);

--- a/AuthService/Controllers/Users/UsersController.cs
+++ b/AuthService/Controllers/Users/UsersController.cs
@@ -178,6 +178,7 @@ public class UsersController : ControllerBase
         ids = [];
         var distinct = new HashSet<Guid>();
         var segments = rawIds
+            .Where(value => !string.IsNullOrWhiteSpace(value))
             .SelectMany(value => value.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
             .ToArray();
 

--- a/AuthService/Controllers/Users/UsersController.cs
+++ b/AuthService/Controllers/Users/UsersController.cs
@@ -17,6 +17,7 @@ namespace AuthService.Controllers.Users;
 public class UsersController : ControllerBase
 {
     private const string UserNotFoundMessage = "Usuário não encontrado.";
+    private const int MaxBatchIds = 100;
 
     private readonly AppDbContext _db;
 
@@ -104,6 +105,11 @@ public class UsersController : ControllerBase
         IReadOnlyList<UserRoleLinkResponse> Roles,
         IReadOnlyList<UserPermissionLinkResponse> Permissions);
 
+    public record UserMinimalResponse(
+        Guid Id,
+        string Name,
+        string Email);
+
     private static UserResponse ToResponse(
         UserEntity u,
         IReadOnlyList<UserRoleLinkResponse>? roles = null,
@@ -163,6 +169,44 @@ public class UsersController : ControllerBase
 
     private static ConflictObjectResult EmailConflictResult() =>
         new(new { message = "Já existe um usuário com este Email." });
+
+    private static bool TryParseBatchIds(
+        IEnumerable<string> rawIds,
+        ModelStateDictionary modelState,
+        out List<Guid> ids)
+    {
+        ids = [];
+        var distinct = new HashSet<Guid>();
+        var segments = rawIds
+            .SelectMany(value => value.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+            .ToArray();
+
+        if (segments.Length == 0)
+        {
+            modelState.AddModelError("ids", "Informe pelo menos um id em `ids`.");
+            return false;
+        }
+
+        if (segments.Length > MaxBatchIds)
+        {
+            modelState.AddModelError("ids", $"A lista `ids` permite no máximo {MaxBatchIds} itens por requisição.");
+            return false;
+        }
+
+        foreach (var segment in segments)
+        {
+            if (!Guid.TryParse(segment, out var parsed))
+            {
+                modelState.AddModelError("ids", "A lista `ids` deve conter apenas GUIDs válidos.");
+                return false;
+            }
+
+            if (distinct.Add(parsed))
+                ids.Add(parsed);
+        }
+
+        return true;
+    }
 
     /// <summary>
     /// Compara por igualdade na coluna (sem função na coluna) para permitir uso do índice único em Email.
@@ -246,8 +290,30 @@ public class UsersController : ControllerBase
 
     [HttpGet]
     [Authorize(Policy = PermissionPolicies.UsersRead)]
-    public async Task<IActionResult> GetAll()
+    public async Task<IActionResult> GetAll([FromQuery] string[]? ids = null)
     {
+        if (ids is { Length: > 0 })
+        {
+            if (!TryParseBatchIds(ids, ModelState, out var parsedIds))
+                return ValidationProblem(ModelState);
+
+            var batchUsers = await _db.Users
+                .Where(u => parsedIds.Contains(u.Id))
+                .Select(u => new UserMinimalResponse(
+                    u.Id,
+                    u.Name,
+                    u.Email))
+                .ToListAsync();
+
+            var usersById = batchUsers.ToDictionary(u => u.Id);
+            var ordered = parsedIds
+                .Where(usersById.ContainsKey)
+                .Select(id => usersById[id])
+                .ToList();
+
+            return Ok(ordered);
+        }
+
         var users = await _db.Users
             .OrderBy(u => u.CreatedAt)
             .ToListAsync();
@@ -262,34 +328,7 @@ public class UsersController : ControllerBase
         if (user is null)
             return NotFound(new { message = UserNotFoundMessage });
 
-        var roles = await _db.UserRoles
-            .AsNoTracking()
-            .Where(ur => ur.UserId == id)
-            .OrderBy(ur => ur.Id)
-            .Select(ur => new UserRoleLinkResponse(
-                ur.Id,
-                ur.UserId,
-                ur.RoleId,
-                ur.CreatedAt,
-                ur.UpdatedAt,
-                ur.DeletedAt))
-            .ToListAsync();
-
-        var permissions = await _db.UserPermissions
-            .AsNoTracking()
-            .Where(up => up.UserId == id)
-            .OrderBy(up => up.CreatedAt)
-            .ThenBy(up => up.Id)
-            .Select(up => new UserPermissionLinkResponse(
-                up.Id,
-                up.UserId,
-                up.PermissionId,
-                up.CreatedAt,
-                up.UpdatedAt,
-                up.DeletedAt))
-            .ToListAsync();
-
-        return Ok(ToResponse(user, roles, permissions));
+        return Ok(new UserMinimalResponse(user.Id, user.Name, user.Email));
     }
 
     [HttpPut("{id:guid}")]


### PR DESCRIPTION
## Resumo
- altera `GET /users/{id}` para retornar apenas `id`, `name` e `email`
- adiciona suporte a consulta em lote em `GET /users?ids=...` com validação de entrada e ordenação conforme ids solicitados
- atualiza testes de integração para cobrir projeção mínima e cenário de erro para `ids` inválido

## Impacto de segurança
- corrige tratamento de entrada em `ids` para evitar exceção de runtime em payload vazio (`ids=`), retornando `400 Bad Request` de forma controlada
- mantém validação de limite máximo (`MaxBatchIds`) para reduzir risco de abuso por requisições excessivamente grandes
- não houve mudança em autenticação/autorização, nem exposição adicional de dados

## Plano de testes
- [x] `docker run --rm -v "$PWD:/src" -w /src mcr.microsoft.com/dotnet/sdk:10.0 dotnet format --verify-no-changes`
- [x] `docker run --rm -v "$PWD:/src" -w /src mcr.microsoft.com/dotnet/sdk:10.0 bash -lc "dotnet restore AuthService/AuthService.csproj && dotnet build AuthService/AuthService.csproj -warnaserror --no-restore"`
- [x] `docker compose --profile test run --rm test`

Closes #134

Made with [Cursor](https://cursor.com)