### PR TITLE
feat(auth): expose readable permission codes in verify-token

### DIFF
--- a/AuthService.Tests/AuthApiTests.cs
+++ b/AuthService.Tests/AuthApiTests.cs
@@ -48,6 +48,7 @@ public class AuthApiTests : IAsyncLifetime
         public string Email { get; set; } = string.Empty;
         public int Identity { get; set; }
         public List<Guid>? Permissions { get; set; }
+        public List<string>? PermissionCodes { get; set; }
         public List<string>? RouteCodes { get; set; }
     }
 
@@ -160,6 +161,7 @@ public class AuthApiTests : IAsyncLifetime
         Assert.NotNull(body);
         Assert.Equal("v.user@example.com", body.Email);
         Assert.NotNull(body.Permissions);
+        Assert.NotNull(body.PermissionCodes);
         Assert.NotNull(body.RouteCodes);
     }
 
@@ -182,6 +184,113 @@ public class AuthApiTests : IAsyncLifetime
 
         foreach (var code in expected)
             Assert.Contains(code, body.RouteCodes);
+    }
+
+    [Fact]
+    public async Task VerifyToken_RootUser_ReturnsAllPermissionPolicyCodes()
+    {
+        var response = await _admin.GetAsync("/api/v1/auth/verify-token");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<VerifyDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(body);
+        Assert.NotNull(body.PermissionCodes);
+
+        var expected = new[]
+        {
+            // authenticator system
+            "perm:Clients.Create", "perm:Clients.Read", "perm:Clients.Update", "perm:Clients.Delete", "perm:Clients.Restore",
+            "perm:Users.Create", "perm:Users.Read", "perm:Users.Update", "perm:Users.Delete", "perm:Users.Restore",
+            "perm:Systems.Create", "perm:Systems.Read", "perm:Systems.Update", "perm:Systems.Delete", "perm:Systems.Restore",
+            "perm:SystemsRoutes.Create", "perm:SystemsRoutes.Read", "perm:SystemsRoutes.Update", "perm:SystemsRoutes.Delete", "perm:SystemsRoutes.Restore",
+            "perm:SystemTokensTypes.Create", "perm:SystemTokensTypes.Read", "perm:SystemTokensTypes.Update", "perm:SystemTokensTypes.Delete", "perm:SystemTokensTypes.Restore",
+            "perm:Permissions.Create", "perm:Permissions.Read", "perm:Permissions.Update", "perm:Permissions.Delete", "perm:Permissions.Restore",
+            "perm:PermissionsTypes.Create", "perm:PermissionsTypes.Read", "perm:PermissionsTypes.Update", "perm:PermissionsTypes.Delete", "perm:PermissionsTypes.Restore",
+            "perm:Roles.Create", "perm:Roles.Read", "perm:Roles.Update", "perm:Roles.Delete", "perm:Roles.Restore",
+            // kurtto system
+            "perm:Kurtto.Create", "perm:Kurtto.Read", "perm:Kurtto.Update", "perm:Kurtto.Delete", "perm:Kurtto.Restore"
+        };
+
+        foreach (var code in expected)
+            Assert.Contains(code, body.PermissionCodes);
+
+        // Garante que todo code segue o formato perm:<Recurso>.<Acao>
+        foreach (var code in body.PermissionCodes)
+            Assert.StartsWith("perm:", code, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task VerifyToken_UserWithoutPermissions_ReturnsEmptyPermissionCodes()
+    {
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "No Perms", email = "no.perms@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        var login = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            LoginBody("no.perms@example.com", "SenhaSegura1!"), TestApiClient.JsonOptions);
+        var loginDto = await login.Content.ReadFromJsonAsync<LoginResponseDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(loginDto);
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        var response = await _anon.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<VerifyDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(body);
+        Assert.NotNull(body.PermissionCodes);
+        Assert.Empty(body.PermissionCodes);
+        // Permissions e RouteCodes mantem comportamento atual (presentes no payload).
+        Assert.NotNull(body.Permissions);
+        Assert.NotNull(body.RouteCodes);
+    }
+
+    [Fact]
+    public async Task VerifyToken_UserWithOnlyKurttoRead_ReturnsKurttoReadCodeOnly()
+    {
+        // Cria usuario sem role
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "Kurtto Reader", email = "kurtto.reader@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        // Concede apenas a permissao kurtto+read direto ao usuario
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var user = await db.Users.AsNoTracking().FirstAsync(u => u.Email == "kurtto.reader@example.com");
+            var kurttoReadId = await db.Permissions.AsNoTracking()
+                .Where(p => p.SystemId == db.Systems.Where(s => s.Code == "kurtto").Select(s => s.Id).First()
+                    && p.PermissionTypeId == db.PermissionTypes.Where(t => t.Code == "read").Select(t => t.Id).First())
+                .Select(p => p.Id)
+                .FirstAsync();
+
+            db.UserPermissions.Add(new AuthService.Models.AppUserPermission
+            {
+                UserId = user.Id,
+                PermissionId = kurttoReadId,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                DeletedAt = null
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var login = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            LoginBody("kurtto.reader@example.com", "SenhaSegura1!"), TestApiClient.JsonOptions);
+        var loginDto = await login.Content.ReadFromJsonAsync<LoginResponseDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(loginDto);
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        var response = await _anon.SendAsync(req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<VerifyDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(body);
+        Assert.NotNull(body.PermissionCodes);
+        Assert.Equal(new[] { "perm:Kurtto.Read" }, body.PermissionCodes);
+        // Nao expoe codes de outros recursos (Users.Read etc.) — kurtto e isolado.
+        Assert.DoesNotContain("perm:Users.Read", body.PermissionCodes);
     }
 
     [Fact]

--- a/AuthService.Tests/AuthApiTests.cs
+++ b/AuthService.Tests/AuthApiTests.cs
@@ -15,6 +15,7 @@ namespace AuthService.Tests;
 public class AuthApiTests : IAsyncLifetime
 {
     private const string TestJwtSecret = "integration-tests-jwt-secret-key-32chars!!";
+    private static readonly string[] ExpectedKurttoReadOnlyCodes = new[] { "perm:Kurtto.Read" };
     private WebAppFactory _factory = null!;
     private HttpClient _admin = null!;
     private HttpClient _anon = null!;
@@ -288,7 +289,7 @@ public class AuthApiTests : IAsyncLifetime
         var body = await response.Content.ReadFromJsonAsync<VerifyDto>(TestApiClient.JsonOptions);
         Assert.NotNull(body);
         Assert.NotNull(body.PermissionCodes);
-        Assert.Equal(new[] { "perm:Kurtto.Read" }, body.PermissionCodes);
+        Assert.Equal(ExpectedKurttoReadOnlyCodes, body.PermissionCodes);
         // Nao expoe codes de outros recursos (Users.Read etc.) — kurtto e isolado.
         Assert.DoesNotContain("perm:Users.Read", body.PermissionCodes);
     }

--- a/AuthService.Tests/PermissionCatalogUnitTests.cs
+++ b/AuthService.Tests/PermissionCatalogUnitTests.cs
@@ -1,0 +1,37 @@
+using AuthService.Auth;
+using Xunit;
+
+namespace AuthService.Tests;
+
+public class PermissionCatalogUnitTests
+{
+    [Fact]
+    public void GetResourcesForSystem_WithAuthenticator_ReturnsAllResourcesInOrdinalOrder()
+    {
+        var resources = PermissionCatalog.GetResourcesForSystem("authenticator");
+
+        var expected = new[]
+        {
+            "Clients",
+            "Permissions",
+            "PermissionsTypes",
+            "Roles",
+            "SystemTokensTypes",
+            "Systems",
+            "SystemsRoutes",
+            "Users"
+        };
+
+        Assert.Equal(expected, resources);
+        Assert.Equal(8, resources.Count);
+    }
+
+    [Fact]
+    public void GetResourcesForSystem_WithUnknownSystem_ReturnsEmptyArray()
+    {
+        var resources = PermissionCatalog.GetResourcesForSystem("inexistente");
+
+        Assert.Same(Array.Empty<string>(), resources);
+        Assert.Empty(resources);
+    }
+}

--- a/AuthService.Tests/PermissionCodeFormatterUnitTests.cs
+++ b/AuthService.Tests/PermissionCodeFormatterUnitTests.cs
@@ -1,0 +1,63 @@
+using AuthService.Auth;
+using Xunit;
+
+namespace AuthService.Tests;
+
+public class PermissionCodeFormatterUnitTests
+{
+    [Fact]
+    public void Format_WithUppercaseTypeCode_ReturnsPascalCaseCode()
+    {
+        var code = PermissionCodeFormatter.Format("Users", "READ");
+
+        Assert.Equal("perm:Users.Read", code);
+    }
+
+    [Fact]
+    public void Format_WithLowercaseTypeCode_ReturnsPascalCaseCode()
+    {
+        var code = PermissionCodeFormatter.Format("Users", "read");
+
+        Assert.Equal("perm:Users.Read", code);
+    }
+
+    [Fact]
+    public void Format_WithMixedCaseTypeCode_ReturnsPascalCaseCode()
+    {
+        var code = PermissionCodeFormatter.Format("SystemsRoutes", "CrEaTe");
+
+        Assert.Equal("perm:SystemsRoutes.Create", code);
+    }
+
+    [Fact]
+    public void Format_WithNullResource_ThrowsArgumentException()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => PermissionCodeFormatter.Format(null!, "read"));
+
+        Assert.Equal("resourcePascal", ex.ParamName);
+    }
+
+    [Fact]
+    public void Format_WithEmptyResource_ThrowsArgumentException()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => PermissionCodeFormatter.Format(string.Empty, "read"));
+
+        Assert.Equal("resourcePascal", ex.ParamName);
+    }
+
+    [Fact]
+    public void Format_WithEmptyTypeCode_ThrowsArgumentException()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => PermissionCodeFormatter.Format("Users", string.Empty));
+
+        Assert.Equal("typeCode", ex.ParamName);
+    }
+
+    [Fact]
+    public void Format_WithWhitespaceTypeCode_ThrowsArgumentException()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => PermissionCodeFormatter.Format("Users", "  "));
+
+        Assert.Equal("typeCode", ex.ParamName);
+    }
+}

--- a/AuthService/Auth/PermissionCatalog.cs
+++ b/AuthService/Auth/PermissionCatalog.cs
@@ -10,8 +10,8 @@ internal static class PermissionCatalog
     /// Fonte única de verdade compartilhada entre <see cref="PermissionResolver"/> e geração reversa
     /// de codes legíveis em <c>verify-token</c>.
     /// </summary>
-    private static readonly IReadOnlyDictionary<string, string> ResourceToSystem =
-        new Dictionary<string, string>(StringComparer.Ordinal)
+    private static readonly Dictionary<string, string> ResourceToSystem =
+        new(StringComparer.Ordinal)
         {
             ["Clients"] = AuthenticatorSystemCode,
             ["Users"] = AuthenticatorSystemCode,
@@ -24,7 +24,7 @@ internal static class PermissionCatalog
             ["Kurtto"] = KurttoSystemCode
         };
 
-    private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> ResourcesBySystem =
+    private static readonly Dictionary<string, IReadOnlyList<string>> ResourcesBySystem =
         ResourceToSystem
             .GroupBy(kvp => kvp.Value, StringComparer.Ordinal)
             .ToDictionary(

--- a/AuthService/Auth/PermissionCatalog.cs
+++ b/AuthService/Auth/PermissionCatalog.cs
@@ -5,25 +5,54 @@ internal static class PermissionCatalog
     private const string AuthenticatorSystemCode = "authenticator";
     private const string KurttoSystemCode = "kurtto";
 
+    /// <summary>
+    /// Mapeamento canônico recurso lógico (PascalCase) → código do sistema oficial.
+    /// Fonte única de verdade compartilhada entre <see cref="PermissionResolver"/> e geração reversa
+    /// de codes legíveis em <c>verify-token</c>.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> ResourceToSystem =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["Clients"] = AuthenticatorSystemCode,
+            ["Users"] = AuthenticatorSystemCode,
+            ["Systems"] = AuthenticatorSystemCode,
+            ["SystemsRoutes"] = AuthenticatorSystemCode,
+            ["SystemTokensTypes"] = AuthenticatorSystemCode,
+            ["Permissions"] = AuthenticatorSystemCode,
+            ["PermissionsTypes"] = AuthenticatorSystemCode,
+            ["Roles"] = AuthenticatorSystemCode,
+            ["Kurtto"] = KurttoSystemCode
+        };
+
+    private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> ResourcesBySystem =
+        ResourceToSystem
+            .GroupBy(kvp => kvp.Value, StringComparer.Ordinal)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<string>)g.Select(kvp => kvp.Key).OrderBy(r => r, StringComparer.Ordinal).ToArray(),
+                StringComparer.Ordinal);
+
     /// <summary>Mapeia o prefixo da chave (ex.: Users, SystemsRoutes) para o código do sistema no cadastro oficial.</summary>
     public static bool TryGetSystemCode(string resourcePascal, out string systemCode)
     {
-        systemCode = resourcePascal switch
+        if (ResourceToSystem.TryGetValue(resourcePascal, out var resolved))
         {
-            // Só existem 2 sistemas oficiais no catálogo: authenticator e kurtto.
-            // Estes nomes são recursos/políticas internos do sistema authenticator.
-            "Clients" => AuthenticatorSystemCode,
-            "Users" => AuthenticatorSystemCode,
-            "Systems" => AuthenticatorSystemCode,
-            "SystemsRoutes" => AuthenticatorSystemCode,
-            "SystemTokensTypes" => AuthenticatorSystemCode,
-            "Permissions" => AuthenticatorSystemCode,
-            "PermissionsTypes" => AuthenticatorSystemCode,
-            "Roles" => AuthenticatorSystemCode,
-            "Kurtto" => KurttoSystemCode,
-            _ => ""
-        };
+            systemCode = resolved;
+            return true;
+        }
 
-        return systemCode.Length > 0;
+        systemCode = string.Empty;
+        return false;
+    }
+
+    /// <summary>
+    /// Retorna a lista (ordenada) de recursos lógicos PascalCase associados a um <paramref name="systemCode"/>.
+    /// Devolve coleção vazia quando o sistema é desconhecido.
+    /// </summary>
+    public static IReadOnlyList<string> GetResourcesForSystem(string systemCode)
+    {
+        return ResourcesBySystem.TryGetValue(systemCode, out var resources)
+            ? resources
+            : Array.Empty<string>();
     }
 }

--- a/AuthService/Auth/PermissionCodeFormatter.cs
+++ b/AuthService/Auth/PermissionCodeFormatter.cs
@@ -1,0 +1,36 @@
+using System.Globalization;
+
+namespace AuthService.Auth;
+
+/// <summary>
+/// Formata codes legíveis de permissões no padrão <c>perm:&lt;Recurso&gt;.&lt;Acao&gt;</c>,
+/// consistente com as constantes de <see cref="PermissionPolicies"/>.
+/// </summary>
+internal static class PermissionCodeFormatter
+{
+    /// <summary>
+    /// Compõe a chave <c>perm:&lt;resourcePascal&gt;.&lt;PascalCase(typeCode)&gt;</c>.
+    /// </summary>
+    /// <param name="resourcePascal">Recurso lógico em PascalCase (ex.: <c>Users</c>, <c>SystemsRoutes</c>).</param>
+    /// <param name="typeCode">Código do tipo de permissão em minúsculas (ex.: <c>read</c>, <c>create</c>).</param>
+    public static string Format(string resourcePascal, string typeCode)
+    {
+        if (string.IsNullOrWhiteSpace(resourcePascal))
+            throw new ArgumentException("Recurso é obrigatório.", nameof(resourcePascal));
+        if (string.IsNullOrWhiteSpace(typeCode))
+            throw new ArgumentException("Tipo de permissão é obrigatório.", nameof(typeCode));
+
+        return string.Concat("perm:", resourcePascal, ".", ToPascalCase(typeCode));
+    }
+
+    private static string ToPascalCase(string value)
+    {
+        var trimmed = value.Trim();
+        if (trimmed.Length == 0)
+            return trimmed;
+
+        var lower = trimmed.ToLowerInvariant();
+        var first = char.ToUpper(lower[0], CultureInfo.InvariantCulture);
+        return lower.Length == 1 ? first.ToString() : string.Concat(first.ToString(), lower.AsSpan(1));
+    }
+}

--- a/AuthService/Auth/PermissionCodeFormatter.cs
+++ b/AuthService/Auth/PermissionCodeFormatter.cs
@@ -26,9 +26,6 @@ internal static class PermissionCodeFormatter
     private static string ToPascalCase(string value)
     {
         var trimmed = value.Trim();
-        if (trimmed.Length == 0)
-            return trimmed;
-
         var lower = trimmed.ToLowerInvariant();
         var first = char.ToUpper(lower[0], CultureInfo.InvariantCulture);
         return lower.Length == 1 ? first.ToString() : string.Concat(first.ToString(), lower.AsSpan(1));

--- a/AuthService/Controllers/Auth/AuthController.cs
+++ b/AuthService/Controllers/Auth/AuthController.cs
@@ -48,6 +48,7 @@ public partial class AuthController : ControllerBase
         string Email,
         int Identity,
         IReadOnlyList<Guid> Permissions,
+        IReadOnlyList<string> PermissionCodes,
         IReadOnlyList<string> RouteCodes);
 
     [HttpPost("login")]
@@ -109,6 +110,7 @@ public partial class AuthController : ControllerBase
         var permissionIds = (await EffectivePermissionIds.GetForUserAsync(_db, userId))
             .OrderBy(x => x)
             .ToList();
+        var permissionCodes = await ResolvePermissionCodesAsync(permissionIds, HttpContext.RequestAborted);
         var routeCodes = await ResolveRouteCodesAsync(permissionIds, HttpContext.RequestAborted);
         return Ok(new VerifyTokenResponse(
             user.Id,
@@ -116,6 +118,7 @@ public partial class AuthController : ControllerBase
             user.Email,
             user.Identity,
             permissionIds,
+            permissionCodes,
             routeCodes)
         );
     }
@@ -142,6 +145,45 @@ public partial class AuthController : ControllerBase
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Logout concluído para o usuário {UserId}.")]
     private partial void LogLogoutCompleted(Guid userId);
+
+    private async Task<IReadOnlyList<string>> ResolvePermissionCodesAsync(
+        IReadOnlyCollection<Guid> permissionIds,
+        CancellationToken cancellationToken)
+    {
+        if (permissionIds.Count == 0)
+            return Array.Empty<string>();
+
+        var systemTypePairs = await _db.Permissions.AsNoTracking()
+            .Where(p => permissionIds.Contains(p.Id))
+            .Join(
+                _db.Systems.AsNoTracking(),
+                p => p.SystemId,
+                s => s.Id,
+                (p, s) => new { p.PermissionTypeId, SystemCode = s.Code })
+            .Join(
+                _db.PermissionTypes.AsNoTracking(),
+                x => x.PermissionTypeId,
+                t => t.Id,
+                (x, t) => new { x.SystemCode, TypeCode = t.Code })
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        if (systemTypePairs.Count == 0)
+            return Array.Empty<string>();
+
+        var codes = new SortedSet<string>(StringComparer.Ordinal);
+        foreach (var pair in systemTypePairs)
+        {
+            var resources = PermissionCatalog.GetResourcesForSystem(pair.SystemCode);
+            if (resources.Count == 0)
+                continue;
+
+            foreach (var resource in resources)
+                codes.Add(PermissionCodeFormatter.Format(resource, pair.TypeCode));
+        }
+
+        return codes.ToArray();
+    }
 
     private async Task<IReadOnlyList<string>> ResolveRouteCodesAsync(
         IReadOnlyCollection<Guid> permissionIds,

--- a/AuthService/Controllers/Auth/AuthController.cs
+++ b/AuthService/Controllers/Auth/AuthController.cs
@@ -147,7 +147,7 @@ public partial class AuthController : ControllerBase
     private partial void LogLogoutCompleted(Guid userId);
 
     private async Task<IReadOnlyList<string>> ResolvePermissionCodesAsync(
-        IReadOnlyCollection<Guid> permissionIds,
+        List<Guid> permissionIds,
         CancellationToken cancellationToken)
     {
         if (permissionIds.Count == 0)

--- a/AuthService/OpenApi/ContractExamplesOperationFilter.cs
+++ b/AuthService/OpenApi/ContractExamplesOperationFilter.cs
@@ -7,6 +7,8 @@ namespace AuthService.OpenApi;
 public sealed class ContractExamplesOperationFilter : IOperationFilter
 {
     private static readonly string[] ExamplePermissions = ["11111111-1111-1111-1111-111111111111"];
+    private static readonly string[] ExamplePermissionCodes = ["perm:Users.Read", "perm:Roles.Read"];
+    private static readonly string[] ExampleRouteCodes = ["KURTTO_V1_URLS_LIST_INCLUDE_DELETED"];
 
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
@@ -41,7 +43,9 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
                 name = "User Name",
                 email = "user@example.com",
                 identity = 1,
-                permissions = ExamplePermissions
+                permissions = ExamplePermissions,
+                permissionCodes = ExamplePermissionCodes,
+                routeCodes = ExampleRouteCodes
             });
             return;
         }


### PR DESCRIPTION
## 📌 Contexto

O `lfc-admin-gui` consome `GET /api/v1/auth/verify-token` para hidratar a sessao com user + permissoes. Hoje o campo `permissions` retorna apenas GUIDs, e `routeCodes` traz strings filtradas somente para o sistema **kurtto**. Resultado: os guards `<RequirePermission code="Systems.Read">` no admin-gui ficam sem mapeamento string para autorizar paginas administrativas (Systems, Roles, Users, Permissions, Tokens, Routes), mesmo para o usuario root.

O backend ja conhece os codes legiveis em `AuthService/Auth/PermissionPolicies.cs` (constantes `perm:<Recurso>.<Acao>`), mas nunca os expunha via API.

## 🎯 Objetivo

Estender `VerifyTokenResponse` com `PermissionCodes: string[]` no formato `perm:<Recurso>.<Acao>`, derivado das permissoes efetivas do usuario, sem breaking change nos campos existentes.

## ⚙️ O que foi feito

- `VerifyTokenResponse` ganha `IReadOnlyList<string> PermissionCodes` entre `Permissions` (GUIDs) e `RouteCodes`.
- Novo helper `PermissionCodeFormatter` formata `perm:<Recurso>.<Acao>` (PascalCase no Acao).
- `PermissionCatalog` passa a expor `GetResourcesForSystem(systemCode)` (mapeamento reverso recurso lógico → sistema oficial), reaproveitando a fonte unica de verdade ja usada por `PermissionResolver`.
- `AuthController.ResolvePermissionCodesAsync`: 1 query EF (`Permission ⨝ System ⨝ PermissionType`) com `Distinct`, depois explosao do par `(SystemCode, TypeCode)` em codes legiveis para todos os recursos do catálogo associados ao sistema.
- `ContractExamplesOperationFilter` reflete o novo campo no exemplo OpenAPI/Swagger.

### Codes resultantes para o usuario root (45 no total)

`perm:{Clients|Users|Systems|SystemsRoutes|SystemTokensTypes|Permissions|PermissionsTypes|Roles}.{Create|Read|Update|Delete|Restore}` + `perm:Kurtto.{Create|Read|Update|Delete|Restore}`.

Para usuarios sem permissao em determinado sistema (ex.: so kurtto), retorna apenas os codes daquele recurso (`perm:Kurtto.Read`, etc.). Recurso/sistema fora do catálogo é silenciosamente ignorado (mantem contrato estavel).

## 📁 Arquivos impactados

- `AuthService/Auth/PermissionCatalog.cs` — fonte unica de verdade + reverso `GetResourcesForSystem`.
- `AuthService/Auth/PermissionCodeFormatter.cs` (novo) — formatacao `perm:<R>.<A>`.
- `AuthService/Controllers/Auth/AuthController.cs` — record + `ResolvePermissionCodesAsync`.
- `AuthService/OpenApi/ContractExamplesOperationFilter.cs` — exemplo do response inclui `permissionCodes` e `routeCodes`.
- `AuthService.Tests/AuthApiTests.cs` — DTO + 3 novos testes.

## 🧪 Testes

- `docker compose --profile test run --rm test` → **179/179 passed**, 0 failed (~1m30s).
- Cobertura adicionada:
  - `VerifyToken_RootUser_ReturnsAllPermissionPolicyCodes` — root recebe todos os 45 codes do `PermissionPolicies`.
  - `VerifyToken_UserWithoutPermissions_ReturnsEmptyPermissionCodes` — usuario sem role/permissao recebe array vazio (e demais campos preservados).
  - `VerifyToken_UserWithOnlyKurttoRead_ReturnsKurttoReadCodeOnly` — concessao direta de uma unica `Permission` retorna unicamente o code do recurso correspondente.
- `dotnet format --verify-no-changes` (Docker SDK 10.0) → zero diff.
- `dotnet ef migrations has-pending-model-changes` → "No changes" (mudanca read-side, sem migration).

> Property-based testing nao foi aplicado: o espaco de entradas e fechado e enumeravel (≤45 codes derivados de 9 recursos × 5 tipos), com cobertura por enumeracao explicita ja garantida. Justificado por escopo limitado.

## 🛡️ Segurança

- Sem mudanca de modelo, autorizacao ou autenticacao.
- Endpoint continua exigindo Bearer token valido (`[Authorize]` mantido).
- Codes expostos sao apenas representacoes legiveis das permissoes que o JWT do usuario ja resolveria — nao adiciona surface de ataque, nao vaza dados de outros usuarios, nao loga payload.
- Sem N+1: `ResolvePermissionCodesAsync` faz 1 query unica com 2 joins e `Distinct`. A explosao Cartesiana acontece em memoria sobre uma lista pequena (≤10 pares × ≤9 recursos = ≤90 codes).
- Sem risco de memory leak: sem ciclo de vida, sem cache, sem timer/listener.

## ⚠️ Riscos

- Consumo no `lfc-admin-gui` ainda precisa ser ajustado (issue separada, conforme escopo cross-repo descrito na issue #138).
- Caso novos recursos logicos sejam adicionados a `PermissionCatalog`, o response ganhara codes correspondentes automaticamente — comportamento desejado e consistente com `PermissionPolicies.cs` quando ambos forem atualizados em conjunto.

## 🔗 Issue relacionada

Closes #138