### PR TITLE
chore(agents): treat any new SonarCloud issue as BLOCKER in reviewer

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -220,6 +220,15 @@ Antes de aprovar, verificar CI ou evidências no PR:
   - Alteração em `.editorconfig` ou configurações de formatação sem necessidade da issue → BLOCKER
 - **build** (`dotnet build` sem warnings)
 - **testes** (`docker compose --profile test run --rm test`)
+- **SonarCloud — zero issues novas na PR** (obrigatório):
+  - Após validar Quality Gate, listar todas as issues novas da PR:
+    ```bash
+    curl -sS -u "$SONAR_TOKEN:" \
+      "https://sonarcloud.io/api/issues/search?organization=${SONAR_ORGANIZATION}&projects=${SONAR_PROJECT_KEY}&pullRequest=${PR_NUMBER}&resolved=false&ps=100"
+    ```
+  - Qualquer issue retornada — **independente de severity (BLOCKER/CRITICAL/MAJOR/MINOR/INFO), impact (HIGH/MEDIUM/LOW), effort (mesmo `0min`) ou status do Quality Gate (mesmo com QG `OK`)** — é tratada como **BLOCKER**.
+  - Detalhar cada issue no review (seção "🔍 Problemas") com label `[BLOCKER]`, indicando arquivo, linha, código da regra (ex.: `CA1859`, `CA1861`) e correção esperada.
+  - Exceção única: issues em código **não tocado pelo PR** (existentes em `development` antes do diff) ficam fora do escopo desta análise. Apenas issues **novas introduzidas pelo PR** bloqueiam.
 
 Falha silenciosa ou ausência de pipeline quando o repositório exige → NEEDS IMPROVEMENT ou BLOCKER conforme gravidade.
 
@@ -259,6 +268,7 @@ Falha silenciosa ou ausência de pipeline quando o repositório exige → NEEDS 
 - SVE crítica
 - escopo errado
 - migration/schema inconsistente (EF Core + PostgreSQL) quando o PR exige
+- qualquer issue nova do SonarCloud na PR (independente de severity, impact, effort ou Quality Gate) — ver Etapa 8
 
 ## ⚠️ NEEDS IMPROVEMENT
 - melhoria de código

--- a/.cursor/agents/reviewer.md
+++ b/.cursor/agents/reviewer.md
@@ -220,6 +220,15 @@ Antes de aprovar, verificar CI ou evidências no PR:
   - Alteração em `.editorconfig` ou configurações de formatação sem necessidade da issue → BLOCKER
 - **build** (`dotnet build` sem warnings)
 - **testes** (`docker compose --profile test run --rm test`)
+- **SonarCloud — zero issues novas na PR** (obrigatório):
+  - Após validar Quality Gate, listar todas as issues novas da PR:
+    ```bash
+    curl -sS -u "$SONAR_TOKEN:" \
+      "https://sonarcloud.io/api/issues/search?organization=${SONAR_ORGANIZATION}&projects=${SONAR_PROJECT_KEY}&pullRequest=${PR_NUMBER}&resolved=false&ps=100"
+    ```
+  - Qualquer issue retornada — **independente de severity (BLOCKER/CRITICAL/MAJOR/MINOR/INFO), impact (HIGH/MEDIUM/LOW), effort (mesmo `0min`) ou status do Quality Gate (mesmo com QG `OK`)** — é tratada como **BLOCKER**.
+  - Detalhar cada issue no review (seção "🔍 Problemas") com label `[BLOCKER]`, indicando arquivo, linha, código da regra (ex.: `CA1859`, `CA1861`) e correção esperada.
+  - Exceção única: issues em código **não tocado pelo PR** (existentes em `development` antes do diff) ficam fora do escopo desta análise. Apenas issues **novas introduzidas pelo PR** bloqueiam.
 
 Falha silenciosa ou ausência de pipeline quando o repositório exige → NEEDS IMPROVEMENT ou BLOCKER conforme gravidade.
 
@@ -259,6 +268,7 @@ Falha silenciosa ou ausência de pipeline quando o repositório exige → NEEDS 
 - SVE crítica
 - escopo errado
 - migration/schema inconsistente (EF Core + PostgreSQL) quando o PR exige
+- qualquer issue nova do SonarCloud na PR (independente de severity, impact, effort ou Quality Gate) — ver Etapa 8
 
 ## ⚠️ NEEDS IMPROVEMENT
 - melhoria de código


### PR DESCRIPTION
## 📌 Contexto

Endurece o contrato do reviewer (`.cursor/agents/reviewer.md` e `.claude/agents/reviewer.md`): **qualquer issue nova retornada pela API do SonarCloud para a PR passa a ser BLOCKER**, independente de severity, impact, effort ou status do Quality Gate.

Motivação: na review de PR #140, o SonarCloud reportou 4 issues novas (CA1859 x3 + CA1861 x1, todas severity INFO, 0min effort) e o veredito foi APPROVED — porque o contrato anterior tratava INFO como não-bloqueante. A nova regra fecha essa porta: se o Sonar viu, tem que sair.

## 🎯 Objetivo

Garantir que nenhum débito técnico identificado pelo SonarCloud entre na base via merge de PR, mesmo quando o Quality Gate global passa.

## ⚙️ O que foi feito

- **Etapa 8 (Qualidade de build)**: adiciona sub-bullet "**SonarCloud — zero issues novas na PR**" com:
  - comando `curl` para `/api/issues/search?...&pullRequest=<PR>&resolved=false`
  - regra explícita de que qualquer issue retornada → BLOCKER
  - exigência de detalhar cada issue no review (arquivo, linha, código da regra)
  - exceção única: issues em código não tocado pelo PR (pré-existentes em `development`)
- **Classificação ❌ BLOCKER**: adiciona bullet "qualquer issue nova do SonarCloud na PR (independente de severity, impact, effort ou Quality Gate) — ver Etapa 8"

## 📁 Arquivos impactados

- `M .cursor/agents/reviewer.md` — +10 linhas
- `M .claude/agents/reviewer.md` — +10 linhas

(Aplicado em ambas as pastas conforme regra de espelhamento estabelecida em PR #139.)

## 🧪 Testes

N/A — alteração apenas em arquivos de configuração de agents (markdown).

Validado:
\`\`\`bash
diff -r .cursor/agents .claude/agents
\`\`\`
Única divergência continua sendo as referências internas a `programmer-lessons.md` em `programmer.md` (exceção prevista pela regra).

## 🛡️ Segurança

Nenhum impacto. Sem código executável, sem credenciais, sem mudança de runtime.

## ⚠️ Riscos

- **Aperto de gate**: PRs futuras com qualquer issue Sonar (mesmo INFO/0min) serão bloqueadas — pode aumentar levemente o ciclo de revisão. Aceitável e desejado.
- **Aplicação retroativa**: PR #140 (em vôo) está APPROVED sob a regra antiga; após este chore mergear, será re-revisada sob a nova regra → vai virar BLOCKER pelos 4 INFOs e exigir FIX iteration.

## 🔗 Issue relacionada

N/A — chore de tooling (endurecimento de contrato do reviewer).