### PR TITLE
chore(agents): port admin-gui disciplines (5 improvements)

### DIFF
--- a/.claude/agents/maestro.md
+++ b/.claude/agents/maestro.md
@@ -12,6 +12,53 @@ Você coordena, passa contexto e controla o loop.
 
 ---
 
+# 📁 Espelhamento `.cursor/agents/` ↔ `.claude/agents/` (obrigatório)
+
+As pastas `.cursor/agents/` e `.claude/agents/` são gêmeas e devem permanecer espelhadas.
+
+Toda alteração (criar, editar ou remover arquivo) em uma das duas pastas DEVE ser replicada na pasta-irmã, no **mesmo commit**.
+
+Regras:
+
+- Conteúdo deve ser **idêntico** entre as duas pastas (sem exceções de path — referências a outros arquivos do diretório usam caminho relativo portável)
+- Arquivo novo em uma pasta → criar o equivalente na outra
+- Arquivo removido em uma pasta → remover o equivalente na outra
+
+Validação obrigatória antes de finalizar:
+
+```bash
+diff -r .cursor/agents .claude/agents
+```
+
+Qualquer divergência deve ser corrigida antes do push.
+
+Esquecer de espelhar é tratado como erro de escopo.
+
+---
+
+# 🌐 Mapeamento de projetos (contexto multi-repo)
+
+Use este mapa como verdade de domínio quando houver citação de serviços/projetos:
+
+| Serviço | Responsabilidade | Relação com `lfc-authenticator` |
+|---------|------------------|------------------------------|
+| `lfc-authenticator` | Backend central de autenticação, autorização e catálogo administrativo (este repo) | Repo alvo |
+| `lfc-admin-gui` | SPA administrativa para operação do catálogo do ecossistema | Cliente da API REST `/api/v1` |
+| `lfc-kurtto-admin-gui` | Outro painel administrativo do ecossistema | Cliente da API REST `/api/v1` |
+
+### Caminhos locais
+
+- LFC Authenticator: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/auth-service`
+- LFC Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/admin-gui`
+- LFC Kurtto Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/Kurtto/kurtto-admin-gui`
+
+Regras:
+
+- Sempre que a issue citar `lfc-admin-gui`, `lfc-kurtto-admin-gui` ou consumidores externos, considere impacto cross-repo no fluxo do maestro.
+- Sinalize ao programmer e ao reviewer quando a issue tiver dependência cross-repo (ex.: contrato de API que afeta `lfc-admin-gui`).
+
+---
+
 # 🎯 Objetivo
 
 Receber o número de uma issue, acionar o programmer para implementar, acionar o reviewer para revisar, e repetir o ciclo até aprovação e merge.

--- a/.claude/agents/programmer.md
+++ b/.claude/agents/programmer.md
@@ -15,7 +15,7 @@ Você entrega uma implementação pronta para revisão técnica.
 
 # 📖 Lições Aprendidas (obrigatório — ler antes de tudo)
 
-Antes de qualquer ação, leia o arquivo `.claude/agents/programmer-lessons.md`.
+Antes de qualquer ação, leia o arquivo `programmer-lessons.md` no mesmo diretório do agente em execução (`.cursor/agents/programmer-lessons.md` ou `.claude/agents/programmer-lessons.md`).
 
 Esse arquivo contém erros que geraram BLOCKER em reviews anteriores. Você DEVE:
 
@@ -35,8 +35,7 @@ Toda alteração (criar, editar ou remover arquivo) em uma das duas pastas DEVE 
 
 Regras:
 
-- Conteúdo deve ser equivalente entre as duas pastas
-- Única diferença permitida: referências internas de caminho (ex.: `.cursor/agents/programmer-lessons.md` no arquivo de `.cursor/`, `.claude/agents/programmer-lessons.md` no arquivo de `.claude/`)
+- Conteúdo deve ser **idêntico** entre as duas pastas (sem exceções de path — referências a outros arquivos do diretório usam caminho relativo portável)
 - Arquivo novo em uma pasta → criar o equivalente na outra
 - Arquivo removido em uma pasta → remover o equivalente na outra
 
@@ -46,9 +45,62 @@ Validação obrigatória antes de finalizar:
 diff -r .cursor/agents .claude/agents
 ```
 
-Se a única divergência forem prefixos de caminho `.cursor/` ↔ `.claude/` em referências internas, está OK. Qualquer outra diferença deve ser corrigida antes do push.
+Qualquer divergência deve ser corrigida antes do push.
 
 Esquecer de espelhar é tratado como erro de escopo.
+
+---
+
+# 🌐 Mapeamento de projetos (contexto multi-repo)
+
+Use este mapa como verdade de domínio quando houver citação de serviços/projetos:
+
+| Serviço | Responsabilidade | Relação com `lfc-authenticator` |
+|---------|------------------|------------------------------|
+| `lfc-authenticator` | Backend central de autenticação, autorização e catálogo administrativo (este repo) | Repo alvo |
+| `lfc-admin-gui` | SPA administrativa para operação do catálogo do ecossistema | Cliente da API REST `/api/v1` |
+| `lfc-kurtto-admin-gui` | Outro painel administrativo do ecossistema | Cliente da API REST `/api/v1` |
+
+### Caminhos locais
+
+- LFC Authenticator: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/auth-service`
+- LFC Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/admin-gui`
+- LFC Kurtto Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/Kurtto/kurtto-admin-gui`
+
+Regras:
+
+- Sempre que houver menção a `lfc-admin-gui`, `lfc-kurtto-admin-gui` ou consumidores externos, carregue contexto dos projetos citados antes de prosseguir.
+- Em mudanças que afetam contrato de API (payloads, status codes, headers, permissões), avalie impacto cross-repo e cite explicitamente em **Riscos / Pendências**.
+
+---
+
+# 🐳 Ambiente de Execução — CONTAINER ONLY (obrigatório)
+
+Regra absoluta: nada de `dotnet` no host. Todos os comandos `dotnet build`, `dotnet test`, `dotnet format`, `dotnet ef`, `dotnet run`, `dotnet restore` devem rodar via container Docker SDK 10.0.
+
+Permitido no host:
+
+- `docker` e `docker compose`
+- `gh`, `git`
+- comandos básicos de filesystem (`ls`, `cat`, `grep`, etc.)
+
+Proibido no host:
+
+- `dotnet` em qualquer subcomando
+
+Padrões de execução:
+
+```bash
+# build / format / ef / run via container
+docker run --rm -v "$PWD:/src" -w /src mcr.microsoft.com/dotnet/sdk:10.0 dotnet <command>
+
+# tests via perfil dedicado do compose
+docker compose --profile test run --rm test
+```
+
+Se um comando falhar no container, corrija no container — não rode no host como workaround.
+
+Evidência de execução de `dotnet` no host (path do host em logs, ausência de menção a Docker em comando `dotnet`) → tratar como **BLOCKER** no review.
 
 ---
 
@@ -250,6 +302,8 @@ feature/<issue-number>/<descricao-curta>
 
 - Comentários em Issue/PR/review devem ser escritos sempre em **Markdown**.
 - Toda PR deve ser aberta sempre com base na branch `development` (ex.: `gh pr create --base development`).
+- Toda PR deve incluir no corpo a linha `Closes #<issue-number>` para fechar automaticamente a issue vinculada no merge.
+- Se houver mais de uma issue no escopo, incluir uma linha `Closes #<id>` para cada issue.
 
 ---
 
@@ -398,7 +452,7 @@ Você DEVE terminar com:
 
 Quando você receber um review com veredito **❌ BLOCKER**, antes de corrigir o código:
 
-1. Abra o arquivo `.claude/agents/programmer-lessons.md`
+1. Abra o arquivo `programmer-lessons.md` no mesmo diretório do agente em execução (`.cursor/agents/programmer-lessons.md` ou `.claude/agents/programmer-lessons.md`)
 2. Adicione uma nova linha no final com o formato:
    ```
    - [PR #XX] Descrição concisa do erro cometido e como evitar no futuro

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -10,6 +10,70 @@ Seu papel é validar se o PR atende ao contrato esperado do programador e aos cr
 
 ---
 
+# 📁 Espelhamento `.cursor/agents/` ↔ `.claude/agents/` (obrigatório)
+
+As pastas `.cursor/agents/` e `.claude/agents/` são gêmeas e devem permanecer espelhadas.
+
+Toda alteração (criar, editar ou remover arquivo) em uma das duas pastas DEVE ser replicada na pasta-irmã, no **mesmo commit**.
+
+Regras:
+
+- Conteúdo deve ser **idêntico** entre as duas pastas (sem exceções de path — referências a outros arquivos do diretório usam caminho relativo portável)
+- Arquivo novo em uma pasta → criar o equivalente na outra
+- Arquivo removido em uma pasta → remover o equivalente na outra
+
+Validação obrigatória antes de finalizar:
+
+```bash
+diff -r .cursor/agents .claude/agents
+```
+
+Qualquer divergência deve ser corrigida antes do push.
+
+Esquecer de espelhar é tratado como erro de escopo.
+
+---
+
+# 🌐 Mapeamento de projetos (contexto multi-repo)
+
+Use este mapa como verdade de domínio quando houver citação de serviços/projetos:
+
+| Serviço | Responsabilidade | Relação com `lfc-authenticator` |
+|---------|------------------|------------------------------|
+| `lfc-authenticator` | Backend central de autenticação, autorização e catálogo administrativo (este repo) | Repo alvo |
+| `lfc-admin-gui` | SPA administrativa para operação do catálogo do ecossistema | Cliente da API REST `/api/v1` |
+| `lfc-kurtto-admin-gui` | Outro painel administrativo do ecossistema | Cliente da API REST `/api/v1` |
+
+### Caminhos locais
+
+- LFC Authenticator: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/auth-service`
+- LFC Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/admin-gui`
+- LFC Kurtto Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/Kurtto/kurtto-admin-gui`
+
+Regras:
+
+- Sempre que a issue/PR citar `lfc-admin-gui`, `lfc-kurtto-admin-gui` ou consumidores externos, carregue contexto dos projetos citados antes de revisar.
+- Em mudanças que afetam contrato de API (payloads, status codes, headers, permissões), avalie risco cross-repo e classifique impacto explicitamente no review.
+
+---
+
+# 🐳 Ambiente de Execução — CONTAINER ONLY (verificação obrigatória)
+
+Todos os comandos `dotnet` (`build`, `test`, `format`, `ef`, `run`, `restore`, etc.) devem ter sido executados pelo programmer via container Docker SDK 10.0 — nunca no host.
+
+Permitido no host (programmer + reviewer): `docker`, `docker compose`, `gh`, `git`, comandos básicos de filesystem.
+
+Você deve validar evidências de container nos logs/saída do programmer:
+
+- `dotnet format --verify-no-changes` via Docker SDK
+- `docker compose --profile test run --rm test` para testes
+- `dotnet build` via Docker SDK
+- migrations via `dotnet ef migrations add ...` em Docker SDK quando o host não tiver `dotnet`
+
+Evidência de execução de `dotnet` no host (path do host em logs, ausência de menção a Docker quando comando `dotnet` foi rodado, tooling instalado fora do container) → **BLOCKER**.
+
+---
+
 # 🎯 Objetivo
 
 Garantir:
@@ -128,8 +192,10 @@ Verifique se existem:
 - Testes
 - Impacto de segurança
 - PR estruturado
+- Corpo da PR contendo `Closes #<issue-number>` da issue corrente (ou múltiplas linhas `Closes #<id>` se houver mais de uma issue no escopo)
 
 Se faltar qualquer item → PROBLEMA
+Se faltar `Closes #<issue-number>` → BLOCKER (sem isso a issue não fecha automaticamente no merge)
 
 ---
 
@@ -269,6 +335,8 @@ Falha silenciosa ou ausência de pipeline quando o repositório exige → NEEDS 
 - escopo errado
 - migration/schema inconsistente (EF Core + PostgreSQL) quando o PR exige
 - qualquer issue nova do SonarCloud na PR (independente de severity, impact, effort ou Quality Gate) — ver Etapa 8
+- corpo da PR sem `Closes #<issue-number>` da issue corrente
+- evidência de execução de `dotnet` no host (deve ser via container Docker SDK 10.0)
 
 ## ⚠️ NEEDS IMPROVEMENT
 - melhoria de código

--- a/.cursor/agents/maestro.md
+++ b/.cursor/agents/maestro.md
@@ -12,6 +12,53 @@ Você coordena, passa contexto e controla o loop.
 
 ---
 
+# 📁 Espelhamento `.cursor/agents/` ↔ `.claude/agents/` (obrigatório)
+
+As pastas `.cursor/agents/` e `.claude/agents/` são gêmeas e devem permanecer espelhadas.
+
+Toda alteração (criar, editar ou remover arquivo) em uma das duas pastas DEVE ser replicada na pasta-irmã, no **mesmo commit**.
+
+Regras:
+
+- Conteúdo deve ser **idêntico** entre as duas pastas (sem exceções de path — referências a outros arquivos do diretório usam caminho relativo portável)
+- Arquivo novo em uma pasta → criar o equivalente na outra
+- Arquivo removido em uma pasta → remover o equivalente na outra
+
+Validação obrigatória antes de finalizar:
+
+```bash
+diff -r .cursor/agents .claude/agents
+```
+
+Qualquer divergência deve ser corrigida antes do push.
+
+Esquecer de espelhar é tratado como erro de escopo.
+
+---
+
+# 🌐 Mapeamento de projetos (contexto multi-repo)
+
+Use este mapa como verdade de domínio quando houver citação de serviços/projetos:
+
+| Serviço | Responsabilidade | Relação com `lfc-authenticator` |
+|---------|------------------|------------------------------|
+| `lfc-authenticator` | Backend central de autenticação, autorização e catálogo administrativo (este repo) | Repo alvo |
+| `lfc-admin-gui` | SPA administrativa para operação do catálogo do ecossistema | Cliente da API REST `/api/v1` |
+| `lfc-kurtto-admin-gui` | Outro painel administrativo do ecossistema | Cliente da API REST `/api/v1` |
+
+### Caminhos locais
+
+- LFC Authenticator: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/auth-service`
+- LFC Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/admin-gui`
+- LFC Kurtto Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/Kurtto/kurtto-admin-gui`
+
+Regras:
+
+- Sempre que a issue citar `lfc-admin-gui`, `lfc-kurtto-admin-gui` ou consumidores externos, considere impacto cross-repo no fluxo do maestro.
+- Sinalize ao programmer e ao reviewer quando a issue tiver dependência cross-repo (ex.: contrato de API que afeta `lfc-admin-gui`).
+
+---
+
 # 🎯 Objetivo
 
 Receber o número de uma issue, acionar o programmer para implementar, acionar o reviewer para revisar, e repetir o ciclo até aprovação e merge.

--- a/.cursor/agents/programmer.md
+++ b/.cursor/agents/programmer.md
@@ -15,7 +15,7 @@ Você entrega uma implementação pronta para revisão técnica.
 
 # 📖 Lições Aprendidas (obrigatório — ler antes de tudo)
 
-Antes de qualquer ação, leia o arquivo `.cursor/agents/programmer-lessons.md`.
+Antes de qualquer ação, leia o arquivo `programmer-lessons.md` no mesmo diretório do agente em execução (`.cursor/agents/programmer-lessons.md` ou `.claude/agents/programmer-lessons.md`).
 
 Esse arquivo contém erros que geraram BLOCKER em reviews anteriores. Você DEVE:
 
@@ -35,8 +35,7 @@ Toda alteração (criar, editar ou remover arquivo) em uma das duas pastas DEVE 
 
 Regras:
 
-- Conteúdo deve ser equivalente entre as duas pastas
-- Única diferença permitida: referências internas de caminho (ex.: `.cursor/agents/programmer-lessons.md` no arquivo de `.cursor/`, `.claude/agents/programmer-lessons.md` no arquivo de `.claude/`)
+- Conteúdo deve ser **idêntico** entre as duas pastas (sem exceções de path — referências a outros arquivos do diretório usam caminho relativo portável)
 - Arquivo novo em uma pasta → criar o equivalente na outra
 - Arquivo removido em uma pasta → remover o equivalente na outra
 
@@ -46,9 +45,62 @@ Validação obrigatória antes de finalizar:
 diff -r .cursor/agents .claude/agents
 ```
 
-Se a única divergência forem prefixos de caminho `.cursor/` ↔ `.claude/` em referências internas, está OK. Qualquer outra diferença deve ser corrigida antes do push.
+Qualquer divergência deve ser corrigida antes do push.
 
 Esquecer de espelhar é tratado como erro de escopo.
+
+---
+
+# 🌐 Mapeamento de projetos (contexto multi-repo)
+
+Use este mapa como verdade de domínio quando houver citação de serviços/projetos:
+
+| Serviço | Responsabilidade | Relação com `lfc-authenticator` |
+|---------|------------------|------------------------------|
+| `lfc-authenticator` | Backend central de autenticação, autorização e catálogo administrativo (este repo) | Repo alvo |
+| `lfc-admin-gui` | SPA administrativa para operação do catálogo do ecossistema | Cliente da API REST `/api/v1` |
+| `lfc-kurtto-admin-gui` | Outro painel administrativo do ecossistema | Cliente da API REST `/api/v1` |
+
+### Caminhos locais
+
+- LFC Authenticator: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/auth-service`
+- LFC Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/admin-gui`
+- LFC Kurtto Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/Kurtto/kurtto-admin-gui`
+
+Regras:
+
+- Sempre que houver menção a `lfc-admin-gui`, `lfc-kurtto-admin-gui` ou consumidores externos, carregue contexto dos projetos citados antes de prosseguir.
+- Em mudanças que afetam contrato de API (payloads, status codes, headers, permissões), avalie impacto cross-repo e cite explicitamente em **Riscos / Pendências**.
+
+---
+
+# 🐳 Ambiente de Execução — CONTAINER ONLY (obrigatório)
+
+Regra absoluta: nada de `dotnet` no host. Todos os comandos `dotnet build`, `dotnet test`, `dotnet format`, `dotnet ef`, `dotnet run`, `dotnet restore` devem rodar via container Docker SDK 10.0.
+
+Permitido no host:
+
+- `docker` e `docker compose`
+- `gh`, `git`
+- comandos básicos de filesystem (`ls`, `cat`, `grep`, etc.)
+
+Proibido no host:
+
+- `dotnet` em qualquer subcomando
+
+Padrões de execução:
+
+```bash
+# build / format / ef / run via container
+docker run --rm -v "$PWD:/src" -w /src mcr.microsoft.com/dotnet/sdk:10.0 dotnet <command>
+
+# tests via perfil dedicado do compose
+docker compose --profile test run --rm test
+```
+
+Se um comando falhar no container, corrija no container — não rode no host como workaround.
+
+Evidência de execução de `dotnet` no host (path do host em logs, ausência de menção a Docker em comando `dotnet`) → tratar como **BLOCKER** no review.
 
 ---
 
@@ -250,6 +302,8 @@ feature/<issue-number>/<descricao-curta>
 
 - Comentários em Issue/PR/review devem ser escritos sempre em **Markdown**.
 - Toda PR deve ser aberta sempre com base na branch `development` (ex.: `gh pr create --base development`).
+- Toda PR deve incluir no corpo a linha `Closes #<issue-number>` para fechar automaticamente a issue vinculada no merge.
+- Se houver mais de uma issue no escopo, incluir uma linha `Closes #<id>` para cada issue.
 
 ---
 
@@ -398,7 +452,7 @@ Você DEVE terminar com:
 
 Quando você receber um review com veredito **❌ BLOCKER**, antes de corrigir o código:
 
-1. Abra o arquivo `.cursor/agents/programmer-lessons.md`
+1. Abra o arquivo `programmer-lessons.md` no mesmo diretório do agente em execução (`.cursor/agents/programmer-lessons.md` ou `.claude/agents/programmer-lessons.md`)
 2. Adicione uma nova linha no final com o formato:
    ```
    - [PR #XX] Descrição concisa do erro cometido e como evitar no futuro

--- a/.cursor/agents/reviewer.md
+++ b/.cursor/agents/reviewer.md
@@ -10,6 +10,70 @@ Seu papel é validar se o PR atende ao contrato esperado do programador e aos cr
 
 ---
 
+# 📁 Espelhamento `.cursor/agents/` ↔ `.claude/agents/` (obrigatório)
+
+As pastas `.cursor/agents/` e `.claude/agents/` são gêmeas e devem permanecer espelhadas.
+
+Toda alteração (criar, editar ou remover arquivo) em uma das duas pastas DEVE ser replicada na pasta-irmã, no **mesmo commit**.
+
+Regras:
+
+- Conteúdo deve ser **idêntico** entre as duas pastas (sem exceções de path — referências a outros arquivos do diretório usam caminho relativo portável)
+- Arquivo novo em uma pasta → criar o equivalente na outra
+- Arquivo removido em uma pasta → remover o equivalente na outra
+
+Validação obrigatória antes de finalizar:
+
+```bash
+diff -r .cursor/agents .claude/agents
+```
+
+Qualquer divergência deve ser corrigida antes do push.
+
+Esquecer de espelhar é tratado como erro de escopo.
+
+---
+
+# 🌐 Mapeamento de projetos (contexto multi-repo)
+
+Use este mapa como verdade de domínio quando houver citação de serviços/projetos:
+
+| Serviço | Responsabilidade | Relação com `lfc-authenticator` |
+|---------|------------------|------------------------------|
+| `lfc-authenticator` | Backend central de autenticação, autorização e catálogo administrativo (este repo) | Repo alvo |
+| `lfc-admin-gui` | SPA administrativa para operação do catálogo do ecossistema | Cliente da API REST `/api/v1` |
+| `lfc-kurtto-admin-gui` | Outro painel administrativo do ecossistema | Cliente da API REST `/api/v1` |
+
+### Caminhos locais
+
+- LFC Authenticator: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/auth-service`
+- LFC Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/admin-gui`
+- LFC Kurtto Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/Kurtto/kurtto-admin-gui`
+
+Regras:
+
+- Sempre que a issue/PR citar `lfc-admin-gui`, `lfc-kurtto-admin-gui` ou consumidores externos, carregue contexto dos projetos citados antes de revisar.
+- Em mudanças que afetam contrato de API (payloads, status codes, headers, permissões), avalie risco cross-repo e classifique impacto explicitamente no review.
+
+---
+
+# 🐳 Ambiente de Execução — CONTAINER ONLY (verificação obrigatória)
+
+Todos os comandos `dotnet` (`build`, `test`, `format`, `ef`, `run`, `restore`, etc.) devem ter sido executados pelo programmer via container Docker SDK 10.0 — nunca no host.
+
+Permitido no host (programmer + reviewer): `docker`, `docker compose`, `gh`, `git`, comandos básicos de filesystem.
+
+Você deve validar evidências de container nos logs/saída do programmer:
+
+- `dotnet format --verify-no-changes` via Docker SDK
+- `docker compose --profile test run --rm test` para testes
+- `dotnet build` via Docker SDK
+- migrations via `dotnet ef migrations add ...` em Docker SDK quando o host não tiver `dotnet`
+
+Evidência de execução de `dotnet` no host (path do host em logs, ausência de menção a Docker quando comando `dotnet` foi rodado, tooling instalado fora do container) → **BLOCKER**.
+
+---
+
 # 🎯 Objetivo
 
 Garantir:
@@ -128,8 +192,10 @@ Verifique se existem:
 - Testes
 - Impacto de segurança
 - PR estruturado
+- Corpo da PR contendo `Closes #<issue-number>` da issue corrente (ou múltiplas linhas `Closes #<id>` se houver mais de uma issue no escopo)
 
 Se faltar qualquer item → PROBLEMA
+Se faltar `Closes #<issue-number>` → BLOCKER (sem isso a issue não fecha automaticamente no merge)
 
 ---
 
@@ -269,6 +335,8 @@ Falha silenciosa ou ausência de pipeline quando o repositório exige → NEEDS 
 - escopo errado
 - migration/schema inconsistente (EF Core + PostgreSQL) quando o PR exige
 - qualquer issue nova do SonarCloud na PR (independente de severity, impact, effort ou Quality Gate) — ver Etapa 8
+- corpo da PR sem `Closes #<issue-number>` da issue corrente
+- evidência de execução de `dotnet` no host (deve ser via container Docker SDK 10.0)
 
 ## ⚠️ NEEDS IMPROVEMENT
 - melhoria de código


### PR DESCRIPTION
## 📌 Contexto

Comparação dos prompts deste repo com `lfc-admin-gui` (mais maduro, com 13 lições reais acumuladas até PR #112) revelou cinco disciplinas que ainda não tínhamos aqui. Esta PR importa todas em um único pacote.

## 🎯 Objetivo

Nivelar a maturidade do contrato dos agents (programmer / reviewer / maestro) entre `lfc-authenticator` e `lfc-admin-gui`, mantendo o espelhamento `.cursor/agents/` ↔ `.claude/agents/` 100% idêntico (sem mais exceção de path).

## ⚙️ O que foi feito

### 1. Path portável do `programmer-lessons.md`
- **Antes**: cada cópia hardcoded com seu próprio prefixo (`.claude/agents/programmer-lessons.md` na cópia de `.claude/`, `.cursor/agents/programmer-lessons.md` na cópia de `.cursor/`)
- **Depois**: `programmer-lessons.md` no mesmo diretório do agente em execução
- **Bônus**: arquivos de `.cursor/agents/` e `.claude/agents/` agora ficam **100% idênticos**, eliminando a "única diferença permitida" da regra de espelhamento

### 2. Seção de espelhamento em todos os 3 agents
- Antes só em `programmer.md` (PR #139)
- Agora também em `reviewer.md` e `maestro.md`, garantindo que qualquer agente carregado primeiro veja a obrigação

### 3. Container-only como BLOCKER explícito
- Nova seção `🐳 Ambiente de Execução — CONTAINER ONLY` em `programmer.md` (proíbe `dotnet` no host)
- Nova seção em `reviewer.md` (verificação + classifica evidência de execução no host como **BLOCKER**)
- Bullet correspondente em Classificação BLOCKER do reviewer

### 4. `Closes #<issue-number>` obrigatório no body da PR
- Adicionado em `programmer.md` (seção "Comentários e base de PR")
- Adicionado em `reviewer.md` Etapa 2 (validação) + bullet em Classificação BLOCKER
- Auto-fecha issue no merge — elimina o passo manual de fechar issue (que já causou hassle no PR #140 onde o reviewer token nem tinha escopo `issues:write`)

### 5. Mapeamento multi-repo em todos os 3 agents
- Tabela de serviços (`lfc-authenticator`, `lfc-admin-gui`, `lfc-kurtto-admin-gui`) com responsabilidades e relações
- Caminhos locais de cada projeto
- Regra de carregamento de contexto cross-repo
- Útil para issues que afetam contrato de API consumido pelos admin-guis (ex.: a pendência do `permissionCodes` no `admin-gui` que ficou de #138)

## 📁 Arquivos impactados

- `M .claude/agents/programmer.md` — +60/-9 linhas
- `M .claude/agents/reviewer.md` — +68/-1 linhas
- `M .claude/agents/maestro.md` — +47 linhas
- `M .cursor/agents/programmer.md` — espelho idêntico
- `M .cursor/agents/reviewer.md` — espelho idêntico
- `M .cursor/agents/maestro.md` — espelho idêntico

(6 arquivos, 348 inserções, 10 deleções)

## 🧪 Testes

N/A — alteração apenas em arquivos de configuração de agents (markdown).

Validado:
\`\`\`bash
diff -r .cursor/agents .claude/agents
# (vazio — pastas 100% idênticas)
\`\`\`

## 🛡️ Segurança

Nenhum impacto. Sem código executável, sem credenciais, sem mudança de runtime.

## ⚠️ Riscos

- **Conflito potencial com PR #141** (`chore(agents): treat any new SonarCloud issue as BLOCKER in reviewer`, ainda em vôo): ambos editam a seção `Classificação BLOCKER` do reviewer, mas em bullets distintos e não sobrepostos. Se #141 mergear primeiro, esta PR vai precisar de rebase trivial; se esta mergear primeiro, #141 precisa de rebase trivial. Sem conflito semântico.
- **Aperto adicional de gate**: novas regras BLOCKER (Closes # missing, dotnet no host) podem capturar PRs que antes passariam. Aceitável e desejado.

## 🔗 Issue relacionada

N/A — chore de tooling (port de disciplinas do `lfc-admin-gui`).