### PR TITLE
test(seeds): assert root catalog covers authenticator and kurtto

### DIFF
--- a/AuthService.Tests/DefaultSystemUserSeederTests.cs
+++ b/AuthService.Tests/DefaultSystemUserSeederTests.cs
@@ -114,6 +114,106 @@ public class DefaultSystemUserSeederTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task RootUser_RoleHasAllCatalogPermissions_AcrossAllSystems()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var rootEmail = DefaultSystemUserSeeder.RootEmail.Trim().ToLowerInvariant();
+        var rootRoleCode = DefaultSystemUserSeeder.RootRoleCode;
+
+        var rootUserId = await db.Users.AsNoTracking()
+            .Where(u => u.Email == rootEmail)
+            .Select(u => u.Id)
+            .SingleAsync();
+
+        var rootRoleId = await db.Roles.AsNoTracking()
+            .Where(r => r.Code == rootRoleCode)
+            .Select(r => r.Id)
+            .SingleAsync();
+
+        var userRoleLink = await db.UserRoles.AsNoTracking()
+            .CountAsync(ur => ur.UserId == rootUserId && ur.RoleId == rootRoleId);
+        Assert.Equal(1, userRoleLink);
+
+        var allPermissionIds = await db.Permissions.AsNoTracking()
+            .Select(p => p.Id)
+            .OrderBy(id => id)
+            .ToListAsync();
+
+        var rolePermissionIds = await db.RolePermissions.AsNoTracking()
+            .Where(rp => rp.RoleId == rootRoleId)
+            .Select(rp => rp.PermissionId)
+            .OrderBy(id => id)
+            .ToListAsync();
+
+        Assert.Equal(allPermissionIds, rolePermissionIds);
+
+        var systemCodesCovered = await db.RolePermissions.AsNoTracking()
+            .Where(rp => rp.RoleId == rootRoleId)
+            .Join(
+                db.Permissions.AsNoTracking(),
+                rp => rp.PermissionId,
+                p => p.Id,
+                (_, p) => p.SystemId)
+            .Join(
+                db.Systems.AsNoTracking(),
+                systemId => systemId,
+                s => s.Id,
+                (_, s) => s.Code)
+            .Distinct()
+            .OrderBy(c => c)
+            .ToListAsync();
+
+        Assert.Contains("authenticator", systemCodesCovered);
+        Assert.Contains("kurtto", systemCodesCovered);
+    }
+
+    [Fact]
+    public async Task EnsureSystemUsersAsync_Idempotent_DoesNotDuplicateOrRemoveRolePermissions()
+    {
+        Guid rootRoleId;
+        int permissionCountBefore;
+
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            rootRoleId = await db.Roles.AsNoTracking()
+                .Where(r => r.Code == DefaultSystemUserSeeder.RootRoleCode)
+                .Select(r => r.Id)
+                .SingleAsync();
+            permissionCountBefore = await db.RolePermissions.AsNoTracking()
+                .CountAsync(rp => rp.RoleId == rootRoleId);
+        }
+
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            await DefaultSystemUserSeeder.EnsureSystemUsersAsync(db);
+            await DefaultSystemUserSeeder.EnsureSystemUsersAsync(db);
+        }
+
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var permissionCountAfter = await db.RolePermissions.IgnoreQueryFilters()
+                .CountAsync(rp => rp.RoleId == rootRoleId);
+            Assert.Equal(permissionCountBefore, permissionCountAfter);
+
+            var allPermissionIds = await db.Permissions.AsNoTracking()
+                .Select(p => p.Id)
+                .OrderBy(id => id)
+                .ToListAsync();
+            var rolePermissionIds = await db.RolePermissions.AsNoTracking()
+                .Where(rp => rp.RoleId == rootRoleId)
+                .Select(rp => rp.PermissionId)
+                .OrderBy(id => id)
+                .ToListAsync();
+            Assert.Equal(allPermissionIds, rolePermissionIds);
+        }
+    }
+
+    [Fact]
     public void ResolveCredential_WhenEnvVarIsSet_ReturnsValue()
     {
         var credential = DefaultSystemUserSeeder.ResolveCredential();

--- a/AuthService.Tests/OfficialCatalogSeederTests.cs
+++ b/AuthService.Tests/OfficialCatalogSeederTests.cs
@@ -1,0 +1,142 @@
+using AuthService.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AuthService.Tests;
+
+/// <summary>
+/// Valida o estado final do catálogo oficial após o bootstrap dos seeds: sistemas,
+/// tipos de permissão e o produto cartesiano de permissões esperado, além da idempotência
+/// de re-execução. Cobre os critérios de aceite da issue #143 (catálogo cobre
+/// <c>authenticator</c> + <c>kurtto</c> com todos os tipos CRUD/Restore).
+/// </summary>
+public class OfficialCatalogSeederTests : IAsyncLifetime
+{
+    private static readonly string[] ExpectedSystemCodes = { "authenticator", "kurtto" };
+
+    private static readonly string[] ExpectedPermissionTypeCodes =
+        { "create", "read", "update", "delete", "restore" };
+
+    private WebAppFactory _factory = null!;
+
+    public Task InitializeAsync()
+    {
+        _factory = new WebAppFactory();
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _factory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task AfterBootstrap_AllExpectedSystemsExist()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var systemCodes = await db.Systems.AsNoTracking()
+            .Select(s => s.Code)
+            .OrderBy(c => c)
+            .ToListAsync();
+
+        foreach (var expected in ExpectedSystemCodes)
+            Assert.Contains(expected, systemCodes);
+    }
+
+    [Fact]
+    public async Task AfterBootstrap_AllExpectedPermissionTypesExist()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var typeCodes = await db.PermissionTypes.AsNoTracking()
+            .Select(t => t.Code)
+            .OrderBy(c => c)
+            .ToListAsync();
+
+        foreach (var expected in ExpectedPermissionTypeCodes)
+            Assert.Contains(expected, typeCodes);
+    }
+
+    [Fact]
+    public async Task AfterBootstrap_PermissionsCoverFullCartesianProductForExpectedSystems()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var pairs = await db.Permissions.AsNoTracking()
+            .Join(
+                db.Systems.AsNoTracking(),
+                p => p.SystemId,
+                s => s.Id,
+                (p, s) => new { p.PermissionTypeId, SystemCode = s.Code })
+            .Join(
+                db.PermissionTypes.AsNoTracking(),
+                x => x.PermissionTypeId,
+                t => t.Id,
+                (x, t) => new { x.SystemCode, TypeCode = t.Code })
+            .ToListAsync();
+
+        foreach (var systemCode in ExpectedSystemCodes)
+        {
+            foreach (var typeCode in ExpectedPermissionTypeCodes)
+            {
+                Assert.Contains(
+                    pairs,
+                    p => p.SystemCode == systemCode && p.TypeCode == typeCode);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task EnsureCatalogAsync_Idempotent_DoesNotDuplicateSystemsTypesOrPermissions()
+    {
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            await OfficialCatalogSeeder.EnsureCatalogAsync(db);
+            await OfficialCatalogSeeder.EnsureCatalogAsync(db);
+        }
+
+        await using var verifyScope = _factory.Services.CreateAsyncScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        foreach (var systemCode in ExpectedSystemCodes)
+        {
+            var systemCount = await verifyDb.Systems.IgnoreQueryFilters()
+                .CountAsync(s => s.Code == systemCode);
+            Assert.Equal(1, systemCount);
+        }
+
+        foreach (var typeCode in ExpectedPermissionTypeCodes)
+        {
+            var typeCount = await verifyDb.PermissionTypes.IgnoreQueryFilters()
+                .CountAsync(t => t.Code == typeCode);
+            Assert.Equal(1, typeCount);
+        }
+
+        foreach (var systemCode in ExpectedSystemCodes)
+        {
+            var systemId = await verifyDb.Systems.AsNoTracking()
+                .Where(s => s.Code == systemCode)
+                .Select(s => s.Id)
+                .SingleAsync();
+
+            foreach (var typeCode in ExpectedPermissionTypeCodes)
+            {
+                var typeId = await verifyDb.PermissionTypes.AsNoTracking()
+                    .Where(t => t.Code == typeCode)
+                    .Select(t => t.Id)
+                    .SingleAsync();
+
+                var permCount = await verifyDb.Permissions.IgnoreQueryFilters()
+                    .CountAsync(p => p.SystemId == systemId && p.PermissionTypeId == typeId);
+                Assert.Equal(1, permCount);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Contexto

A issue #143 requer garantia explícita de que o usuário `root@email.com.br` (criado por `DefaultSystemUserSeeder`) tenha acesso total a TODOS os sistemas seedados — `authenticator` e `kurtto` — e que essa cobertura fique afirmada por testes em `AuthService.Tests/`.

## 🎯 Objetivo

Adicionar cobertura de teste programática que valide o estado final do catálogo após o bootstrap dos seeds, sem alterar o comportamento de produção. O código atual já cobre os critérios funcionais; faltava o reforço de regressão por testes.

## ⚙️ O que foi feito

- Novo `AuthService.Tests/OfficialCatalogSeederTests.cs` com 4 facts:
  - `AfterBootstrap_AllExpectedSystemsExist` — confirma `authenticator` e `kurtto`.
  - `AfterBootstrap_AllExpectedPermissionTypesExist` — confirma `create/read/update/delete/restore`.
  - `AfterBootstrap_PermissionsCoverFullCartesianProductForExpectedSystems` — afirma o produto cartesiano `(systemCode, typeCode)` por meio de joins (sem magic number).
  - `EnsureCatalogAsync_Idempotent_DoesNotDuplicateSystemsTypesOrPermissions` — re-executa o seed e verifica contagem por system/type/permission.
- Extensão de `AuthService.Tests/DefaultSystemUserSeederTests.cs` com 2 facts:
  - `RootUser_RoleHasAllCatalogPermissions_AcrossAllSystems` — valida que a role `root` tem TODAS as `permissionId` da `Permissions` table e que cobre os 2 systemCodes (`authenticator`, `kurtto`).
  - `EnsureSystemUsersAsync_Idempotent_DoesNotDuplicateOrRemoveRolePermissions` — re-executa `EnsureSystemUsersAsync` duas vezes e confirma que a contagem de `RolePermissions` para `root` permanece igual e cobre todas as permissões do catálogo.

Nenhuma alteração no código de produção foi necessária — o `OfficialCatalogSeeder` já gera 2 systems × 5 permission types = 10 permissões, e `SeederHelper.EnsureUserAssignedToRoleWithAllPermissionsAsync` já carrega a totalidade de `db.Permissions` (cobrindo ambos os sistemas).

## 📁 Arquivos impactados

- `AuthService.Tests/OfficialCatalogSeederTests.cs` (novo)
- `AuthService.Tests/DefaultSystemUserSeederTests.cs` (estendido com 2 novos facts)

## 🧪 Testes

- Comando: `docker compose --profile test run --rm test`
- Resultado: `Passed: 194, Failed: 0, Skipped: 0`
- Build com `-warnaserror`: 0 warnings, 0 errors.
- `dotnet format --verify-no-changes`: clean.

## 🛡️ Segurança

Nenhum impacto. PR é exclusivamente de testes; nenhuma credencial, log ou superfície de autorização foi tocada.

## ⚠️ Riscos

- Os testes assumem que `WebAppFactory` (que executa o full bootstrap) está saudável; se outra issue alterar a ordem de seeders, os asserts qualitativos por código (não-numéricos) ficam estáveis.
- Asserts são feitos por `systemCode`/`typeCode`/Guid joins, não por contagens fixas — adicionar novos sistemas/tipos no catálogo não quebra os testes existentes.

## 🔗 Issue relacionada

Closes #143