### PR TITLE
feat(auth): exigir systemId no login e verify-token (#142)

### DIFF
--- a/.claude/agents/programmer-lessons.md
+++ b/.claude/agents/programmer-lessons.md
@@ -8,3 +8,5 @@ Erros que geraram BLOCKER em reviews anteriores. **Nunca repita esses padrões.*
 ---
 
 <!-- Novas lições devem ser adicionadas abaixo desta linha -->
+- [PR #146] Não ler `Request.Headers["X-Header-Name"]` direto em actions de controller (S6932) — usar binding via parâmetro `[FromHeader(Name = "X-Header-Name")] string? value` para que o ASP.NET Core trate parsing/validação e o OpenAPI gere o parâmetro automaticamente.
+- [PR #146] Marcar como `static` métodos privados/internos de helpers de teste que não acessam estado de instância (CA1822) — evita warning Roslyn e deixa explícito que o helper é puro.

--- a/.cursor/agents/programmer-lessons.md
+++ b/.cursor/agents/programmer-lessons.md
@@ -8,3 +8,5 @@ Erros que geraram BLOCKER em reviews anteriores. **Nunca repita esses padrões.*
 ---
 
 <!-- Novas lições devem ser adicionadas abaixo desta linha -->
+- [PR #146] Não ler `Request.Headers["X-Header-Name"]` direto em actions de controller (S6932) — usar binding via parâmetro `[FromHeader(Name = "X-Header-Name")] string? value` para que o ASP.NET Core trate parsing/validação e o OpenAPI gere o parâmetro automaticamente.
+- [PR #146] Marcar como `static` métodos privados/internos de helpers de teste que não acessam estado de instância (CA1822) — evita warning Roslyn e deixa explícito que o helper é puro.

--- a/AuthService.Tests/AuthApiTests.cs
+++ b/AuthService.Tests/AuthApiTests.cs
@@ -43,7 +43,7 @@ public class AuthApiTests : IAsyncLifetime
 
     private object LoginBody(string email, string password) => new { email, password, systemId = _kurttoSystemId };
 
-    private object LoginBodyForSystem(string email, string password, Guid systemId) =>
+    private static object LoginBodyForSystem(string email, string password, Guid systemId) =>
         new { email, password, systemId };
 
     private sealed class LoginResponseDto

--- a/AuthService.Tests/AuthApiTests.cs
+++ b/AuthService.Tests/AuthApiTests.cs
@@ -4,7 +4,9 @@ using System.Net.Http.Json;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using AuthService.Controllers.Auth;
 using AuthService.Data;
+using AuthService.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,12 +21,16 @@ public class AuthApiTests : IAsyncLifetime
     private WebAppFactory _factory = null!;
     private HttpClient _admin = null!;
     private HttpClient _anon = null!;
+    private Guid _kurttoSystemId;
+    private Guid _authenticatorSystemId;
 
     public async Task InitializeAsync()
     {
         _factory = new WebAppFactory();
         _admin = await TestApiClient.CreateAuthenticatedAsync(_factory);
         _anon = _factory.CreateApiClient();
+        _kurttoSystemId = await TestApiClient.GetSystemIdAsync(_factory, "kurtto");
+        _authenticatorSystemId = await TestApiClient.GetSystemIdAsync(_factory, "authenticator");
     }
 
     public Task DisposeAsync()
@@ -35,7 +41,10 @@ public class AuthApiTests : IAsyncLifetime
         return Task.CompletedTask;
     }
 
-    private static object LoginBody(string email, string password) => new { email, password };
+    private object LoginBody(string email, string password) => new { email, password, systemId = _kurttoSystemId };
+
+    private object LoginBodyForSystem(string email, string password, Guid systemId) =>
+        new { email, password, systemId };
 
     private sealed class LoginResponseDto
     {
@@ -135,8 +144,9 @@ public class AuthApiTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task VerifyToken_WithoutHeader_ReturnsUnauthorized()
+    public async Task VerifyToken_WithoutBearer_ReturnsUnauthorized()
     {
+        // Sem Authorization e sem X-System-Id: o pipeline de autenticação roda primeiro e devolve 401.
         var response = await _anon.GetAsync("/api/v1/auth/verify-token");
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -155,6 +165,7 @@ public class AuthApiTests : IAsyncLifetime
 
         using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        req.Headers.Add(AuthController.SystemIdHeader, _kurttoSystemId.ToString("D"));
         var response = await _anon.SendAsync(req);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -234,6 +245,7 @@ public class AuthApiTests : IAsyncLifetime
 
         using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        req.Headers.Add(AuthController.SystemIdHeader, _kurttoSystemId.ToString("D"));
         var response = await _anon.SendAsync(req);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -283,6 +295,7 @@ public class AuthApiTests : IAsyncLifetime
 
         using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        req.Headers.Add(AuthController.SystemIdHeader, _kurttoSystemId.ToString("D"));
         var response = await _anon.SendAsync(req);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -317,6 +330,7 @@ public class AuthApiTests : IAsyncLifetime
         using (var verifyReq = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token"))
         {
             verifyReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            verifyReq.Headers.Add(AuthController.SystemIdHeader, _kurttoSystemId.ToString("D"));
             var verifyRes = await _anon.SendAsync(verifyReq);
             Assert.Equal(HttpStatusCode.Unauthorized, verifyRes.StatusCode);
         }
@@ -385,11 +399,13 @@ public class AuthApiTests : IAsyncLifetime
             {
                 ["sub"] = Guid.NewGuid().ToString("D"),
                 ["tv"] = 0,
+                ["sys"] = _kurttoSystemId.ToString("D"),
                 ["exp"] = DateTimeOffset.UtcNow.AddMinutes(-5).ToUnixTimeSeconds()
             });
 
         using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        req.Headers.Add(AuthController.SystemIdHeader, _kurttoSystemId.ToString("D"));
         var response = await _anon.SendAsync(req);
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -403,11 +419,13 @@ public class AuthApiTests : IAsyncLifetime
             {
                 ["sub"] = Guid.NewGuid().ToString("D"),
                 ["tv"] = 0,
+                ["sys"] = _kurttoSystemId.ToString("D"),
                 ["exp"] = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds()
             });
 
         using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        req.Headers.Add(AuthController.SystemIdHeader, _kurttoSystemId.ToString("D"));
         var response = await _anon.SendAsync(req);
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -420,11 +438,13 @@ public class AuthApiTests : IAsyncLifetime
             new Dictionary<string, object>
             {
                 ["tv"] = 0,
+                ["sys"] = _kurttoSystemId.ToString("D"),
                 ["exp"] = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds()
             });
 
         using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        req.Headers.Add(AuthController.SystemIdHeader, _kurttoSystemId.ToString("D"));
         var response = await _anon.SendAsync(req);
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -437,11 +457,13 @@ public class AuthApiTests : IAsyncLifetime
             new Dictionary<string, object>
             {
                 ["sub"] = Guid.NewGuid().ToString("D"),
+                ["sys"] = _kurttoSystemId.ToString("D"),
                 ["exp"] = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds()
             });
 
         using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        req.Headers.Add(AuthController.SystemIdHeader, _kurttoSystemId.ToString("D"));
         var response = await _anon.SendAsync(req);
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -472,6 +494,289 @@ public class AuthApiTests : IAsyncLifetime
         var response = await _anon.SendAsync(req);
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WithoutSystemId_ReturnsBadRequest()
+    {
+        // Cria usuário válido para garantir que o 400 vem do systemId, não do email/senha.
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "NoSys User", email = "nosys@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        var response = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            new { email = "nosys@example.com", password = "SenhaSegura1!" },
+            TestApiClient.JsonOptions);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WithEmptySystemId_ReturnsBadRequest()
+    {
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "EmptySys User", email = "emptysys@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        var response = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            new { email = "emptysys@example.com", password = "SenhaSegura1!", systemId = Guid.Empty },
+            TestApiClient.JsonOptions);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WithUnknownSystemId_ReturnsBadRequest()
+    {
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "Unknown User", email = "unknown.sys@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        var response = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            new { email = "unknown.sys@example.com", password = "SenhaSegura1!", systemId = Guid.NewGuid() },
+            TestApiClient.JsonOptions);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WithDeletedSystemId_ReturnsBadRequest()
+    {
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "Del Sys User", email = "del.sys@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        // Cria sistema novo e marca como deletado (soft-delete = inativo).
+        Guid deletedSystemId;
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var now = DateTime.UtcNow;
+            var system = new AppSystem
+            {
+                Name = "Sistema Inativo",
+                Code = "sistema-inativo-test",
+                CreatedAt = now,
+                UpdatedAt = now,
+                DeletedAt = now
+            };
+            db.Systems.Add(system);
+            await db.SaveChangesAsync();
+            deletedSystemId = system.Id;
+        }
+
+        var response = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            new { email = "del.sys@example.com", password = "SenhaSegura1!", systemId = deletedSystemId },
+            TestApiClient.JsonOptions);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WithValidSystemId_ReturnsToken_AndJwtCarriesSysClaim()
+    {
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "Sys OK User", email = "sys.ok@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        var response = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            new { email = "sys.ok@example.com", password = "SenhaSegura1!", systemId = _kurttoSystemId },
+            TestApiClient.JsonOptions);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var dto = await response.Content.ReadFromJsonAsync<LoginResponseDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto);
+
+        var payload = ReadJwtPayload(dto.Token);
+        Assert.Equal(_kurttoSystemId.ToString("D"), payload.GetProperty("sys").GetString());
+    }
+
+    [Fact]
+    public async Task VerifyToken_WithoutXSystemIdHeader_ReturnsBadRequest()
+    {
+        // Token válido (claim sys preenchida) mas sem header X-System-Id.
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "VTok NoHdr", email = "vtok.nohdr@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        var login = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            LoginBody("vtok.nohdr@example.com", "SenhaSegura1!"), TestApiClient.JsonOptions);
+        var loginDto = await login.Content.ReadFromJsonAsync<LoginResponseDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(loginDto);
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        var response = await _anon.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task VerifyToken_WithMalformedXSystemIdHeader_ReturnsBadRequest()
+    {
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "VTok Bad Hdr", email = "vtok.badhdr@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        var login = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            LoginBody("vtok.badhdr@example.com", "SenhaSegura1!"), TestApiClient.JsonOptions);
+        var loginDto = await login.Content.ReadFromJsonAsync<LoginResponseDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(loginDto);
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        req.Headers.Add(AuthController.SystemIdHeader, "not-a-guid");
+        var response = await _anon.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task VerifyToken_WithUnknownSystemIdHeader_ReturnsBadRequest()
+    {
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "VTok Unk", email = "vtok.unk@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        var login = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            LoginBody("vtok.unk@example.com", "SenhaSegura1!"), TestApiClient.JsonOptions);
+        var loginDto = await login.Content.ReadFromJsonAsync<LoginResponseDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(loginDto);
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        req.Headers.Add(AuthController.SystemIdHeader, Guid.NewGuid().ToString("D"));
+        var response = await _anon.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task VerifyToken_WithDeletedSystemIdHeader_ReturnsBadRequest()
+    {
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "VTok Del", email = "vtok.del@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        var login = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            LoginBody("vtok.del@example.com", "SenhaSegura1!"), TestApiClient.JsonOptions);
+        var loginDto = await login.Content.ReadFromJsonAsync<LoginResponseDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(loginDto);
+
+        // Cria e marca como deletado um sistema cujo Id será usado no header.
+        Guid deletedSystemId;
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var now = DateTime.UtcNow;
+            var system = new AppSystem
+            {
+                Name = "Inativo VTok",
+                Code = "inativo-vtok",
+                CreatedAt = now,
+                UpdatedAt = now,
+                DeletedAt = now
+            };
+            db.Systems.Add(system);
+            await db.SaveChangesAsync();
+            deletedSystemId = system.Id;
+        }
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        req.Headers.Add(AuthController.SystemIdHeader, deletedSystemId.ToString("D"));
+        var response = await _anon.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task VerifyToken_CrossSystemToken_ReturnsUnauthorized()
+    {
+        // Login no sistema kurtto e tenta verify com header X-System-Id apontando pro sistema authenticator.
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "Cross Sys User", email = "cross.sys@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        var login = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            LoginBodyForSystem("cross.sys@example.com", "SenhaSegura1!", _kurttoSystemId), TestApiClient.JsonOptions);
+        var loginDto = await login.Content.ReadFromJsonAsync<LoginResponseDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(loginDto);
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        req.Headers.Add(AuthController.SystemIdHeader, _authenticatorSystemId.ToString("D"));
+        var response = await _anon.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task VerifyToken_AuthenticatorSystem_ReturnsEmptyRouteCodes_NotKurttoCodes()
+    {
+        // Root user tem todas as permissões (incluindo authenticator e kurtto).
+        // Quando faz login em authenticator, verify-token deve devolver routeCodes vazio
+        // (authenticator não declara rotas seedadas), em vez das rotas do kurtto.
+        var login = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            LoginBodyForSystem(DefaultSystemUserSeeder.RootEmail, DefaultSystemUserSeeder.ResolveCredential(), _authenticatorSystemId),
+            TestApiClient.JsonOptions);
+        var loginDto = await login.Content.ReadFromJsonAsync<LoginResponseDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(loginDto);
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        req.Headers.Add(AuthController.SystemIdHeader, _authenticatorSystemId.ToString("D"));
+        var response = await _anon.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<VerifyDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(body);
+        Assert.NotNull(body.RouteCodes);
+        Assert.Empty(body.RouteCodes);
+        // Codes do kurtto NÃO devem aparecer quando o sistema solicitado é authenticator.
+        Assert.DoesNotContain("KURTTO_V1_URLS_LIST_INCLUDE_DELETED", body.RouteCodes);
+        Assert.DoesNotContain("KURTTO_V1_URLS_GET_BY_CODE_INCLUDE_DELETED", body.RouteCodes);
+        Assert.DoesNotContain("KURTTO_V1_URLS_PATCH_RESTORE", body.RouteCodes);
+    }
+
+    [Fact]
+    public async Task VerifyToken_TokenWithoutSysClaim_ReturnsUnauthorized()
+    {
+        // Token forjado sem claim sys deve falhar na autenticação (handler exige sys).
+        var token = CreateHs256Token(
+            TestJwtSecret,
+            new Dictionary<string, object>
+            {
+                ["sub"] = Guid.NewGuid().ToString("D"),
+                ["tv"] = 0,
+                ["exp"] = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds()
+            });
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        req.Headers.Add(AuthController.SystemIdHeader, _kurttoSystemId.ToString("D"));
+        var response = await _anon.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    private static JsonElement ReadJwtPayload(string token)
+    {
+        var parts = token.Split('.');
+        Assert.Equal(3, parts.Length);
+        var jsonBytes = Base64UrlDecode(parts[1]);
+        using var doc = JsonDocument.Parse(jsonBytes);
+        return doc.RootElement.Clone();
+    }
+
+    private static byte[] Base64UrlDecode(string input)
+    {
+        var base64 = input.Replace('-', '+').Replace('_', '/');
+        var pad = 4 - (base64.Length % 4);
+        if (pad is > 0 and < 4)
+            base64 += new string('=', pad);
+
+        return Convert.FromBase64String(base64);
     }
 
     private static string CreateHs256Token(string secret, IDictionary<string, object> payload)

--- a/AuthService.Tests/DefaultSystemUserSeederTests.cs
+++ b/AuthService.Tests/DefaultSystemUserSeederTests.cs
@@ -40,6 +40,8 @@ public class DefaultSystemUserSeederTests : IAsyncLifetime
     [Fact]
     public async Task SystemUsers_ExistAfterBootstrap_CanLoginWithSeededCredentials()
     {
+        var systemId = await TestApiClient.GetSystemIdAsync(_factory, TestApiClient.DefaultSystemCode);
+
         var cases = new[]
         {
             new { Email = DefaultSystemUserSeeder.RootEmail, Password = DefaultSystemUserSeeder.ResolveCredential() },
@@ -50,7 +52,7 @@ public class DefaultSystemUserSeederTests : IAsyncLifetime
         foreach (var c in cases)
         {
             var response = await _client.PostAsJsonAsync("/api/v1/auth/login",
-                new { email = c.Email, password = c.Password },
+                new { email = c.Email, password = c.Password, systemId },
                 TestApiClient.JsonOptions);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/AuthService.Tests/JwtTokenServiceUnitTests.cs
+++ b/AuthService.Tests/JwtTokenServiceUnitTests.cs
@@ -19,7 +19,7 @@ public class JwtTokenServiceUnitTests
 
         Assert.Throws<InvalidOperationException>(() =>
         {
-            service.CreateAccessToken(Guid.NewGuid(), 1, out _);
+            service.CreateAccessToken(Guid.NewGuid(), 1, Guid.NewGuid(), out _);
         });
     }
 
@@ -34,7 +34,7 @@ public class JwtTokenServiceUnitTests
         var service = new JwtTokenService(options);
         var now = DateTimeOffset.UtcNow;
 
-        _ = service.CreateAccessToken(Guid.NewGuid(), 3, out var expiresAt);
+        _ = service.CreateAccessToken(Guid.NewGuid(), 3, Guid.NewGuid(), out var expiresAt);
 
         var minutes = (expiresAt - now).TotalMinutes;
         Assert.InRange(minutes, 59, 61);
@@ -44,6 +44,7 @@ public class JwtTokenServiceUnitTests
     public void CreateAccessToken_EmbedsExpectedClaims()
     {
         var userId = Guid.NewGuid();
+        var systemId = Guid.NewGuid();
         const int tokenVersion = 7;
         var options = Options.Create(new JwtOptions
         {
@@ -52,11 +53,12 @@ public class JwtTokenServiceUnitTests
         });
         var service = new JwtTokenService(options);
 
-        var token = service.CreateAccessToken(userId, tokenVersion, out _);
+        var token = service.CreateAccessToken(userId, tokenVersion, systemId, out _);
         var payload = ReadJwtPayload(token);
 
         Assert.Equal(userId.ToString("D"), payload.GetProperty("sub").GetString());
         Assert.Equal(tokenVersion, payload.GetProperty("tv").GetInt32());
+        Assert.Equal(systemId.ToString("D"), payload.GetProperty("sys").GetString());
         Assert.True(payload.GetProperty("exp").GetInt64() > 0);
         Assert.True(payload.GetProperty("iat").GetInt64() > 0);
     }

--- a/AuthService.Tests/TestApiClient.cs
+++ b/AuthService.Tests/TestApiClient.cs
@@ -1,13 +1,19 @@
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
+using AuthService.Controllers.Auth;
 using AuthService.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace AuthService.Tests;
 
 internal static class TestApiClient
 {
+    /// <summary>Code do sistema usado por padrão nos testes de Auth (catálogo oficial seeda kurtto).</summary>
+    internal const string DefaultSystemCode = "kurtto";
+
     internal static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -19,17 +25,41 @@ internal static class TestApiClient
         public string Token { get; set; } = string.Empty;
     }
 
-    /// <summary>Cliente HTTP com JWT do usuário root seedado (todas as permissões oficiais).</summary>
-    internal static async Task<HttpClient> CreateAuthenticatedAsync(WebAppFactory factory)
+    /// <summary>
+    /// Recupera o systemId de um sistema do catálogo oficial pelo Code (lança se não existir).
+    /// </summary>
+    internal static async Task<Guid> GetSystemIdAsync(WebAppFactory factory, string systemCode)
     {
+        await using var scope = factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        return await db.Systems.AsNoTracking()
+            .Where(s => s.Code == systemCode)
+            .Select(s => s.Id)
+            .SingleAsync();
+    }
+
+    /// <summary>Cliente HTTP com JWT do usuário root seedado (todas as permissões oficiais), atrelado ao sistema kurtto e com header X-System-Id já configurado.</summary>
+    internal static async Task<HttpClient> CreateAuthenticatedAsync(WebAppFactory factory)
+        => await CreateAuthenticatedAsync(factory, DefaultSystemCode);
+
+    /// <summary>Cliente HTTP com JWT do usuário root seedado, atrelado ao sistema indicado por <paramref name="systemCode"/> e com header X-System-Id já configurado.</summary>
+    internal static async Task<HttpClient> CreateAuthenticatedAsync(WebAppFactory factory, string systemCode)
+    {
+        var systemId = await GetSystemIdAsync(factory, systemCode);
         var client = factory.CreateApiClient();
         var login = await client.PostAsJsonAsync("/api/v1/auth/login",
-            new { email = DefaultSystemUserSeeder.RootEmail, password = DefaultSystemUserSeeder.ResolveCredential() },
+            new
+            {
+                email = DefaultSystemUserSeeder.RootEmail,
+                password = DefaultSystemUserSeeder.ResolveCredential(),
+                systemId
+            },
             JsonOptions);
         login.EnsureSuccessStatusCode();
         var dto = await login.Content.ReadFromJsonAsync<LoginDto>(JsonOptions);
         Assert.NotNull(dto);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", dto.Token);
+        client.DefaultRequestHeaders.Add(AuthController.SystemIdHeader, systemId.ToString("D"));
         return client;
     }
 }

--- a/AuthService.Tests/UsersApiTests.cs
+++ b/AuthService.Tests/UsersApiTests.cs
@@ -303,13 +303,14 @@ public class UsersApiTests : IAsyncLifetime
             new { password = "NovaSenhaSegura2!" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.OK, putPwd.StatusCode);
 
+        var systemId = await TestApiClient.GetSystemIdAsync(_factory, TestApiClient.DefaultSystemCode);
         var anon = _factory.CreateApiClient();
         var oldLogin = await anon.PostAsJsonAsync("/api/v1/auth/login",
-            new { email = "pwd.change@example.com", password = "SenhaSegura1!" }, TestApiClient.JsonOptions);
+            new { email = "pwd.change@example.com", password = "SenhaSegura1!", systemId }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Unauthorized, oldLogin.StatusCode);
 
         var newLogin = await anon.PostAsJsonAsync("/api/v1/auth/login",
-            new { email = "pwd.change@example.com", password = "NovaSenhaSegura2!" }, TestApiClient.JsonOptions);
+            new { email = "pwd.change@example.com", password = "NovaSenhaSegura2!", systemId }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.OK, newLogin.StatusCode);
     }
 

--- a/AuthService/Auth/IJwtTokenService.cs
+++ b/AuthService/Auth/IJwtTokenService.cs
@@ -2,6 +2,9 @@ namespace AuthService.Auth;
 
 public interface IJwtTokenService
 {
-    /// <summary>Emite JWT com claims <c>sub</c> (user id) e <c>tv</c> (token version).</summary>
-    string CreateAccessToken(Guid userId, int tokenVersion, out DateTimeOffset expiresAt);
+    /// <summary>
+    /// Emite JWT com claims <c>sub</c> (user id), <c>tv</c> (token version) e
+    /// <c>sys</c> (system id de quem fez login — usado para amarrar o token a um sistema específico).
+    /// </summary>
+    string CreateAccessToken(Guid userId, int tokenVersion, Guid systemId, out DateTimeOffset expiresAt);
 }

--- a/AuthService/Auth/JwtBearerAuthenticationHandler.cs
+++ b/AuthService/Auth/JwtBearerAuthenticationHandler.cs
@@ -34,7 +34,11 @@ public sealed class JwtBearerAuthenticationHandler(
         if (payloadResult.Error is not null)
             return payloadResult.Error;
 
-        var claimExtraction = TryExtractIdentityClaims(payloadResult.Payload!, out var userId, out var tokenVersionClaim);
+        var claimExtraction = TryExtractIdentityClaims(
+            payloadResult.Payload!,
+            out var userId,
+            out var tokenVersionClaim,
+            out var systemIdClaim);
         if (claimExtraction is not null)
             return claimExtraction;
 
@@ -54,12 +58,19 @@ public sealed class JwtBearerAuthenticationHandler(
         {
             new(ClaimTypes.NameIdentifier, userId.ToString("D")),
             new(ClaimTypes.Email, user.Email),
-            new(ClaimTypes.Name, user.Name)
+            new(ClaimTypes.Name, user.Name),
+            new(SystemIdClaimType, systemIdClaim.ToString("D"))
         };
         var identity = new ClaimsIdentity(claims, Scheme.Name);
         var principal = new ClaimsPrincipal(identity);
         return AuthenticateResult.Success(new AuthenticationTicket(principal, Scheme.Name));
     }
+
+    /// <summary>
+    /// Tipo de claim que carrega o <c>systemId</c> do sistema que emitiu o token (claim <c>sys</c>).
+    /// Usado pelo verify-token para evitar uso cruzado de tokens entre sistemas distintos.
+    /// </summary>
+    public const string SystemIdClaimType = "sys";
 
     private AuthenticateResult? TryReadBearerToken(out string token)
     {
@@ -113,10 +124,12 @@ public sealed class JwtBearerAuthenticationHandler(
     private static AuthenticateResult? TryExtractIdentityClaims(
         IDictionary<string, object> payload,
         out Guid userId,
-        out int tokenVersionClaim)
+        out int tokenVersionClaim,
+        out Guid systemIdClaim)
     {
         userId = Guid.Empty;
         tokenVersionClaim = 0;
+        systemIdClaim = Guid.Empty;
 
         if (!payload.TryGetValue("sub", out var subObj) || subObj?.ToString() is not { } subStr
             || !Guid.TryParse(subStr, out userId))
@@ -124,6 +137,10 @@ public sealed class JwtBearerAuthenticationHandler(
 
         if (!payload.TryGetValue("tv", out var tvObj) || !TryGetInt32(tvObj, out tokenVersionClaim))
             return AuthenticateResult.Fail("Token sem versão de sessão válida.");
+
+        if (!payload.TryGetValue("sys", out var sysObj) || sysObj?.ToString() is not { } sysStr
+            || !Guid.TryParse(sysStr, out systemIdClaim))
+            return AuthenticateResult.Fail("Token sem identificador de sistema válido.");
 
         return null;
     }

--- a/AuthService/Auth/JwtTokenService.cs
+++ b/AuthService/Auth/JwtTokenService.cs
@@ -8,7 +8,7 @@ public sealed class JwtTokenService(IOptions<JwtOptions> options) : IJwtTokenSer
 {
     private readonly JwtOptions _options = options.Value;
 
-    public string CreateAccessToken(Guid userId, int tokenVersion, out DateTimeOffset expiresAt)
+    public string CreateAccessToken(Guid userId, int tokenVersion, Guid systemId, out DateTimeOffset expiresAt)
     {
         if (string.IsNullOrWhiteSpace(_options.Secret) || _options.Secret.Length < 32)
             throw new InvalidOperationException("Auth:Jwt:Secret deve ter pelo menos 32 caracteres.");
@@ -22,6 +22,7 @@ public sealed class JwtTokenService(IOptions<JwtOptions> options) : IJwtTokenSer
             .WithSecret(_options.Secret)
             .AddClaim("sub", userId.ToString("D"))
             .AddClaim("tv", tokenVersion)
+            .AddClaim("sys", systemId.ToString("D"))
             .AddClaim("exp", exp)
             .AddClaim("iat", DateTimeOffset.UtcNow.ToUnixTimeSeconds())
             .Encode();

--- a/AuthService/Controllers/Auth/AuthController.cs
+++ b/AuthService/Controllers/Auth/AuthController.cs
@@ -119,13 +119,13 @@ public partial class AuthController : ControllerBase
 
     [HttpGet("verify-token")]
     [Authorize(AuthenticationSchemes = BearerAuthenticationDefaults.AuthenticationScheme)]
-    public async Task<IActionResult> VerifyToken()
+    public async Task<IActionResult> VerifyToken(
+        [FromHeader(Name = SystemIdHeader)] string? systemIdHeader)
     {
-        if (!Request.Headers.TryGetValue(SystemIdHeader, out var headerValues)
-            || string.IsNullOrWhiteSpace(headerValues.ToString()))
+        if (string.IsNullOrWhiteSpace(systemIdHeader))
             return BadRequest(new { message = SystemIdHeaderRequiredMessage });
 
-        if (!Guid.TryParse(headerValues.ToString(), out var headerSystemId) || headerSystemId == Guid.Empty)
+        if (!Guid.TryParse(systemIdHeader, out var headerSystemId) || headerSystemId == Guid.Empty)
             return BadRequest(new { message = InvalidSystemIdMessage });
 
         var systemExists = await _db.Systems.AsNoTracking()

--- a/AuthService/Controllers/Auth/AuthController.cs
+++ b/AuthService/Controllers/Auth/AuthController.cs
@@ -16,6 +16,13 @@ public partial class AuthController : ControllerBase
     private const string InvalidCredentialsMessage = "Credenciais inválidas.";
     private const string InvalidTokenMessage = "Token inválido.";
     private const string UserNotFoundMessage = "Usuário não encontrado.";
+    private const string SystemIdRequiredMessage = "SystemId é obrigatório.";
+    private const string SystemIdHeaderRequiredMessage = "Header X-System-Id é obrigatório.";
+    private const string InvalidSystemIdMessage = "Sistema inválido ou inativo.";
+    private const string CrossSystemTokenMessage = "Token não é válido para este sistema.";
+
+    /// <summary>Header HTTP que identifica o sistema cliente em <c>GET /auth/verify-token</c>.</summary>
+    public const string SystemIdHeader = "X-System-Id";
 
     private readonly AppDbContext _db;
     private readonly IJwtTokenService _jwt;
@@ -38,6 +45,9 @@ public partial class AuthController : ControllerBase
         [Required(ErrorMessage = "Password é obrigatório.")]
         [MaxLength(60)]
         public string Password { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "SystemId é obrigatório.")]
+        public Guid? SystemId { get; set; }
     }
 
     public record LoginResponse(string Token);
@@ -57,6 +67,18 @@ public partial class AuthController : ControllerBase
     {
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);
+
+        if (request.SystemId is not { } systemId || systemId == Guid.Empty)
+            return BadRequest(new { message = SystemIdRequiredMessage });
+
+        // Query filter global remove sistemas com DeletedAt != null (soft-delete = inativo).
+        var systemExists = await _db.Systems.AsNoTracking()
+            .AnyAsync(s => s.Id == systemId, HttpContext.RequestAborted);
+        if (!systemExists)
+        {
+            _logger.LogWarning("Tentativa de login com sistema inválido/inativo {SystemId}.", systemId);
+            return BadRequest(new { message = InvalidSystemIdMessage });
+        }
 
         var email = request.Email.Trim().ToLowerInvariant();
         var password = request.Password.Trim();
@@ -91,7 +113,7 @@ public partial class AuthController : ControllerBase
             return Unauthorized(new { message = InvalidCredentialsMessage });
         }
 
-        var token = _jwt.CreateAccessToken(user.Id, user.TokenVersion, out _);
+        var token = _jwt.CreateAccessToken(user.Id, user.TokenVersion, systemId, out _);
         return Ok(new LoginResponse(token));
     }
 
@@ -99,9 +121,34 @@ public partial class AuthController : ControllerBase
     [Authorize(AuthenticationSchemes = BearerAuthenticationDefaults.AuthenticationScheme)]
     public async Task<IActionResult> VerifyToken()
     {
+        if (!Request.Headers.TryGetValue(SystemIdHeader, out var headerValues)
+            || string.IsNullOrWhiteSpace(headerValues.ToString()))
+            return BadRequest(new { message = SystemIdHeaderRequiredMessage });
+
+        if (!Guid.TryParse(headerValues.ToString(), out var headerSystemId) || headerSystemId == Guid.Empty)
+            return BadRequest(new { message = InvalidSystemIdMessage });
+
+        var systemExists = await _db.Systems.AsNoTracking()
+            .AnyAsync(s => s.Id == headerSystemId, HttpContext.RequestAborted);
+        if (!systemExists)
+            return BadRequest(new { message = InvalidSystemIdMessage });
+
         var sub = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (string.IsNullOrEmpty(sub) || !Guid.TryParse(sub, out var userId))
             return Unauthorized(new { message = InvalidTokenMessage });
+
+        var sysClaim = User.FindFirstValue(JwtBearerAuthenticationHandler.SystemIdClaimType);
+        if (string.IsNullOrEmpty(sysClaim) || !Guid.TryParse(sysClaim, out var tokenSystemId))
+            return Unauthorized(new { message = InvalidTokenMessage });
+
+        if (tokenSystemId != headerSystemId)
+        {
+            _logger.LogWarning(
+                "Token cruzado detectado: claim sys={TokenSystemId} difere do header X-System-Id={HeaderSystemId}.",
+                tokenSystemId,
+                headerSystemId);
+            return Unauthorized(new { message = CrossSystemTokenMessage });
+        }
 
         var user = await _db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == userId);
         if (user is null)
@@ -111,7 +158,7 @@ public partial class AuthController : ControllerBase
             .OrderBy(x => x)
             .ToList();
         var permissionCodes = await ResolvePermissionCodesAsync(permissionIds, HttpContext.RequestAborted);
-        var routeCodes = await ResolveRouteCodesAsync(permissionIds, HttpContext.RequestAborted);
+        var routeCodes = await ResolveRouteCodesAsync(permissionIds, headerSystemId, HttpContext.RequestAborted);
         return Ok(new VerifyTokenResponse(
             user.Id,
             user.Name,
@@ -187,28 +234,37 @@ public partial class AuthController : ControllerBase
 
     private async Task<IReadOnlyList<string>> ResolveRouteCodesAsync(
         IReadOnlyCollection<Guid> permissionIds,
+        Guid systemId,
         CancellationToken cancellationToken)
     {
         if (permissionIds.Count == 0)
             return Array.Empty<string>();
 
-        var kurttoPermissionTypes = await _db.Permissions.AsNoTracking()
-            .Where(p => permissionIds.Contains(p.Id))
-            .Join(
-                _db.Systems.AsNoTracking(),
-                p => p.SystemId,
-                s => s.Id,
-                (p, s) => new { p.PermissionTypeId, SystemCode = s.Code })
-            .Where(x => x.SystemCode == "kurtto")
+        // Tipos de permissão (create/read/update/delete/restore) que o usuário possui no sistema indicado.
+        var permissionTypeCodes = await _db.Permissions.AsNoTracking()
+            .Where(p => permissionIds.Contains(p.Id) && p.SystemId == systemId)
             .Join(
                 _db.PermissionTypes.AsNoTracking(),
-                x => x.PermissionTypeId,
+                p => p.PermissionTypeId,
                 t => t.Id,
                 (_, t) => t.Code)
             .Distinct()
             .ToListAsync(cancellationToken);
 
-        var allowedPolicies = kurttoPermissionTypes
+        if (permissionTypeCodes.Count == 0)
+            return Array.Empty<string>();
+
+        // Códigos de rota declarados no DB para o sistema-alvo (limita rotas reais a este sistema).
+        var systemRouteCodes = (await _db.Routes.AsNoTracking()
+                .Where(r => r.SystemId == systemId)
+                .Select(r => r.Code)
+                .ToListAsync(cancellationToken))
+            .ToHashSet(StringComparer.Ordinal);
+
+        if (systemRouteCodes.Count == 0)
+            return Array.Empty<string>();
+
+        var allowedPolicies = permissionTypeCodes
             .Select(MapKurttoPermissionTypeToPolicy)
             .Where(policy => policy is not null)
             .Cast<string>()
@@ -217,8 +273,11 @@ public partial class AuthController : ControllerBase
         if (allowedPolicies.Count == 0)
             return Array.Empty<string>();
 
+        // O mapeamento estático route→policy hoje cobre apenas o sistema kurtto. Se o systemId
+        // não corresponde a kurtto, o filtro por systemRouteCodes garante que nada é vazado.
         return KurttoAccessSeeder.KurttoAdminRoutes
-            .Where(route => allowedPolicies.Contains(route.TargetPermissionPolicy))
+            .Where(route => allowedPolicies.Contains(route.TargetPermissionPolicy)
+                && systemRouteCodes.Contains(route.Code))
             .Select(route => route.Code)
             .OrderBy(code => code)
             .ToArray();

--- a/AuthService/OpenApi/ContractExamplesOperationFilter.cs
+++ b/AuthService/OpenApi/ContractExamplesOperationFilter.cs
@@ -145,19 +145,38 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
 
     private static void EnsureSystemIdHeaderParameter(OpenApiOperation operation)
     {
+        // O parâmetro X-System-Id é gerado automaticamente pelo ASP.NET Core a partir do
+        // [FromHeader] no controller. Aqui só ajustamos metadados (required, description)
+        // para garantir uma documentação consistente no Swagger.
+        const string headerDescription =
+            "UUID do sistema cliente. Deve corresponder ao systemId usado em POST /auth/login.";
+
         operation.Parameters ??= [];
-        var alreadyPresent = operation.Parameters.Any(p =>
+        var existing = operation.Parameters.FirstOrDefault(p =>
             p.In == ParameterLocation.Header
             && string.Equals(p.Name, AuthController.SystemIdHeader, StringComparison.OrdinalIgnoreCase));
-        if (alreadyPresent)
+
+        if (existing is OpenApiParameter mutable)
+        {
+            mutable.Required = true;
+            if (string.IsNullOrWhiteSpace(mutable.Description))
+                mutable.Description = headerDescription;
             return;
+        }
+
+        if (existing is not null)
+        {
+            // Parâmetro presente como referência imutável; deixamos o auto-gerado prevalecer
+            // sem duplicar a entrada na operação.
+            return;
+        }
 
         operation.Parameters.Add(new OpenApiParameter
         {
             Name = AuthController.SystemIdHeader,
             In = ParameterLocation.Header,
             Required = true,
-            Description = "UUID do sistema cliente. Deve corresponder ao systemId usado em POST /auth/login."
+            Description = headerDescription
         });
     }
 }

--- a/AuthService/OpenApi/ContractExamplesOperationFilter.cs
+++ b/AuthService/OpenApi/ContractExamplesOperationFilter.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using AuthService.Controllers.Auth;
 using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -31,12 +32,14 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
         if (normalized == "/auth/login" && method == "POST")
         {
             AddJsonResponse(operation, "200", "Login realizado.", new { token = "<jwt-token>" });
+            AddErrorResponse(operation, "400", "SystemId ausente ou sistema invalido/inativo.", new { message = "SystemId é obrigatório." });
             AddErrorResponse(operation, "401", "Credenciais invalidas.", new { message = "Credenciais inválidas." });
             return;
         }
 
         if (normalized == "/auth/verify-token" && method == "GET")
         {
+            EnsureSystemIdHeaderParameter(operation);
             AddJsonResponse(operation, "200", "Token valido.", new
             {
                 id = "00000000-0000-0000-0000-000000000000",
@@ -47,6 +50,7 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
                 permissionCodes = ExamplePermissionCodes,
                 routeCodes = ExampleRouteCodes
             });
+            AddErrorResponse(operation, "400", "Header X-System-Id ausente ou sistema invalido/inativo.", new { message = "Header X-System-Id é obrigatório." });
             return;
         }
 
@@ -137,5 +141,23 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
                 }
             }
         };
+    }
+
+    private static void EnsureSystemIdHeaderParameter(OpenApiOperation operation)
+    {
+        operation.Parameters ??= [];
+        var alreadyPresent = operation.Parameters.Any(p =>
+            p.In == ParameterLocation.Header
+            && string.Equals(p.Name, AuthController.SystemIdHeader, StringComparison.OrdinalIgnoreCase));
+        if (alreadyPresent)
+            return;
+
+        operation.Parameters.Add(new OpenApiParameter
+        {
+            Name = AuthController.SystemIdHeader,
+            In = ParameterLocation.Header,
+            Required = true,
+            Description = "UUID do sistema cliente. Deve corresponder ao systemId usado em POST /auth/login."
+        });
     }
 }


### PR DESCRIPTION
## 📌 Contexto

Hoje `POST /auth/login` não recebe nenhuma identificação do sistema cliente, e `GET /auth/verify-token` filtra `routeCodes` com hard-code `SystemCode == "kurtto"`. Como consequência, qualquer cliente do ecossistema (atual ou futuro) que validar token recebe as rotas do Kurtto — bug latente assim que mais de um sistema consumir a API. A issue #142 pede tornar a identificação de sistema obrigatória no login, no verify-token, e refatorar `ResolveRouteCodesAsync` para usar o `systemId` parametrizado.

## 🎯 Objetivo

Tornar o `auth-service` multi-tenant em relação a sistemas: cada login é amarrado a um `systemId`, e cada `verify-token` recebe o sistema cliente via header — devolvendo apenas rotas pertinentes ao sistema indicado e impedindo o uso cruzado de tokens entre sistemas.

## ⚙️ O que foi feito

- `LoginRequest` ganhou campo `SystemId: Guid?` obrigatório (`[Required]`); valor `Guid.Empty` é rejeitado.
- `POST /auth/login` valida 400 se `systemId` está ausente, é vazio, não existe ou está soft-deleted (query filter global do `AppSystem` cobre o "inativo").
- `IJwtTokenService.CreateAccessToken` recebe `systemId`; `JwtTokenService` adiciona claim `sys` ao JWT (Decisão A — ver abaixo).
- `JwtBearerAuthenticationHandler` exige claim `sys`, parseia para `Guid` e injeta no `ClaimsIdentity` (constante pública `SystemIdClaimType = "sys"`).
- `GET /auth/verify-token` exige header `X-System-Id`; valida formato/UUID, existência do sistema (não-deletado), e compara com a claim `sys` do token. Divergência → 401 (cross-system protection).
- `ResolveRouteCodesAsync` passou a ser parametrizado por `systemId`; filtra permissões pelo systemId e cruza com rotas declaradas no DB para o mesmo systemId. Comportamento regrede sozinho para `[]` quando o sistema solicitado não tem rotas seedadas (ex.: `authenticator`).
- `ContractExamplesOperationFilter` registra o header `X-System-Id` no Swagger e adiciona o exemplo 400 para login e verify-token.
- `TestApiClient.CreateAuthenticatedAsync` passa a configurar tanto o body do login (com `systemId` do kurtto) quanto o header `X-System-Id` por padrão; expõe helper `GetSystemIdAsync(factory, code)`.
- Testes existentes ajustados para o novo contrato; novos cenários cobrem ausência, formato inválido, sistema desconhecido, sistema soft-deleted, login válido (com inspeção da claim `sys`), cross-system token e o caso authenticator.

### Decisão A (claim `sys` no JWT) — adotada

A issue oferece duas alternativas:

- **A** (escolhida): JWT inclui claim `sys` com o systemId; verify-token valida que `X-System-Id` bate com a claim. Token de sistema A é rejeitado como sistema B.
- **B**: JWT não carrega `sys`; verify-token confia apenas no header. Vulnerável a tokens cruzados.

Optei por **A** porque é uma fronteira de segurança crítica entre tenants e o custo é mínimo (uma claim e uma comparação de Guid). Vide teste `VerifyToken_CrossSystemToken_ReturnsUnauthorized`.

## 📁 Arquivos impactados

- `AuthService/Controllers/Auth/AuthController.cs`
- `AuthService/Auth/IJwtTokenService.cs`
- `AuthService/Auth/JwtTokenService.cs`
- `AuthService/Auth/JwtBearerAuthenticationHandler.cs`
- `AuthService/OpenApi/ContractExamplesOperationFilter.cs`
- `AuthService.Tests/AuthApiTests.cs`
- `AuthService.Tests/DefaultSystemUserSeederTests.cs`
- `AuthService.Tests/UsersApiTests.cs`
- `AuthService.Tests/TestApiClient.cs`
- `AuthService.Tests/JwtTokenServiceUnitTests.cs`

## 🧪 Testes

- `docker compose --profile test run --rm test` → **200 passados / 0 falhos**.
- `dotnet format --verify-no-changes` (Docker SDK 10.0) → exit 0.
- `dotnet build` (Docker SDK 10.0) → 0 warnings, 0 errors.

Cobertura nova:

- `Login_WithoutSystemId_ReturnsBadRequest`
- `Login_WithEmptySystemId_ReturnsBadRequest`
- `Login_WithUnknownSystemId_ReturnsBadRequest`
- `Login_WithDeletedSystemId_ReturnsBadRequest`
- `Login_WithValidSystemId_ReturnsToken_AndJwtCarriesSysClaim`
- `VerifyToken_WithoutXSystemIdHeader_ReturnsBadRequest`
- `VerifyToken_WithMalformedXSystemIdHeader_ReturnsBadRequest`
- `VerifyToken_WithUnknownSystemIdHeader_ReturnsBadRequest`
- `VerifyToken_WithDeletedSystemIdHeader_ReturnsBadRequest`
- `VerifyToken_CrossSystemToken_ReturnsUnauthorized`
- `VerifyToken_AuthenticatorSystem_ReturnsEmptyRouteCodes_NotKurttoCodes`
- `VerifyToken_TokenWithoutSysClaim_ReturnsUnauthorized`
- `JwtTokenServiceUnitTests.CreateAccessToken_EmbedsExpectedClaims` (atualizado para validar `sys`)

## 🛡️ Segurança

- **Cross-system protection** via claim `sys` (Opção A) impede que um token emitido para o sistema A seja aceito como sistema B.
- Sistema soft-deleted (`DeletedAt != null`) é tratado como inativo (já há global query filter no `AppSystem`); não há novo vetor.
- Logs com `_logger.LogWarning` para tentativas com sistema inválido e tokens cruzados — sem expor tokens, secrets ou PII além do já presente.
- Contrato dos endpoints expandido sem reduzir validação existente.

## ⚠️ Riscos

- **Breaking change cross-repo**: clientes existentes que chamam `/auth/login` ou `/auth/verify-token` quebram até serem atualizados. A issue cita as issues-espelho:
  - `lfc-admin-gui` precisa enviar `VITE_SYSTEM_ID` (UUID do `authenticator`: `dc9e6357-4a98-4058-865e-a41e474c45b7`).
  - `lfc-kurtto-admin-gui` precisa enviar `VITE_SYSTEM_ID` (UUID do `kurtto`: `44839717-3e55-4d6d-8d4b-46b599305209`).
  - Ambas as issues foram (ou serão) abertas separadamente nos respectivos repositórios.
- **Mapeamento route→policy ainda kurtto-específico**: `MapKurttoPermissionTypeToPolicy` cobre apenas `perm:Kurtto.*`. Para futuros sistemas com rotas próprias, será necessário estender este mapeamento OU mover o mapping para o DB. Hoje, sistemas sem rotas seedadas devolvem `[]` corretamente — não há vazamento de rotas alheias. Foi mantido o escopo mínimo da issue.
- **Property-based testing**: não aplicado — os fluxos novos são pequenos (validações booleanas e match exato de Guid), o espaço de entrada é trivial. Justificativa registrada aqui conforme contrato.
- **Detector N+1**: as duas queries adicionadas (`Systems.AnyAsync(...)` por requisição) e o ajuste em `ResolveRouteCodesAsync` (que agora consulta `Routes` por systemId) são lookups por chave indexada, sem laços. Sem risco N+1.

## 🔗 Issue relacionada

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)