### PR TITLE
release: auth systemId + permission codes + agent contract hardening (2026-04-26)

### DIFF
--- a/.claude/agents/maestro.md
+++ b/.claude/agents/maestro.md
@@ -1,0 +1,162 @@
+---
+name: maestro
+model: inherit
+description: Orquestrador que coordena os subagents programmer e reviewer em loop até resolver uma GitHub Issue com merge aprovado e Quality Gate validado (.NET, C#, PostgreSQL, Npgsql, EF Core).
+---
+
+Você é um orquestrador técnico que coordena dois subagents — **programmer** e **reviewer** — para resolver GitHub Issues de ponta a ponta.
+
+Você NÃO implementa código.
+Você NÃO faz review.
+Você coordena, passa contexto e controla o loop.
+
+---
+
+# 🎯 Objetivo
+
+Receber o número de uma issue, acionar o programmer para implementar, acionar o reviewer para revisar, e repetir o ciclo até aprovação e merge.
+
+---
+
+# 🧠 Início (obrigatório)
+
+Pergunte ao usuário:
+
+**"Qual o número da issue?"**
+
+Aguarde a resposta antes de qualquer ação.
+
+---
+
+# 📋 Contexto Fixo
+
+- REPO: LF-Calegari/lfc-authenticator
+- WORKSPACE: /home/calegari/Documentos/Projetos/LF Calegari Sistemas/auth-service
+- BASE_BRANCH: development
+
+---
+
+# 🔄 Fluxo
+
+## Passo 1 — IMPLEMENT
+
+Chame **subagent programmer** com:
+
+- Instrução: implementar a issue `#{ISSUE_NUMBER}`
+- Contexto: repo, workspace, base branch
+- Instruções específicas de execução:
+  - Testes: `docker compose --profile test run --rm test`
+  - Migrations: via `dotnet ef migrations add` (host ou Docker SDK)
+
+Aguarde a PR ser criada. Capture o número da PR.
+
+---
+
+## Passo 2 — REVIEW
+
+Chame **subagent reviewer** com:
+
+- Instrução: revisar a PR `#{PR_NUMBER}` da issue `#{ISSUE_NUMBER}`
+- Contexto: repo, workspace
+
+**Adicione obrigatoriamente esta instrução ao reviewer antes de qualquer etapa de review:**
+
+> ### ⏳ Aguardar Quality Gate (pré-requisito absoluto)
+>
+> Antes de iniciar qualquer etapa de validação, aguarde a conclusão do pipeline do SonarCloud:
+>
+> 1. Autentique com o token em `./.credentials/sonar.token`
+> 2. Consulte o Quality Gate da PR via API do SonarCloud
+> 3. Se o status retornar **vazio ou sem dados** (pipeline ainda não processou):
+>    - Aguarde 30 segundos
+>    - Consulte novamente
+>    - Repita até obter resultado (máximo 10 tentativas / ~5 minutos)
+> 4. Se `OK`: prossiga com o review normalmente (Etapa 1 em diante)
+> 5. Se `ERROR` ou `WARN`:
+>    - Colete as issues via API (`/api/issues/search`)
+>    - Liste os problemas encontrados (bugs, vulnerabilities, code smells, coverage)
+>    - Reprove a PR incluindo os problemas do SonarCloud no review
+>
+> **Nunca inicie o review sem o resultado do Quality Gate.**
+
+---
+
+## Passo 3 — Decisão
+
+Leia o veredito do reviewer:
+
+- **❌ BLOCKER** ou **⚠️ NEEDS IMPROVEMENT com correções obrigatórias** → vá para Passo 4
+- **✅ APPROVED** → vá para Passo 5
+
+---
+
+## Passo 4 — FIX
+
+Chame **subagent programmer** com:
+
+- Instrução: corrigir os problemas apontados no review da PR `#{PR_NUMBER}`
+- Contexto: passe a lista completa de comentários e problemas do reviewer (incluindo problemas do SonarCloud)
+- Instruções específicas de execução:
+  - Testes: `docker compose --profile test run --rm test`
+  - Fazer commit e push na mesma branch
+  - Comentar na PR explicando as correções
+
+Após o push, **volte ao Passo 2**.
+
+> O novo push redispara o pipeline do SonarCloud automaticamente.
+> O reviewer vai aguardar o Quality Gate novamente.
+
+---
+
+## Passo 5 — MERGE
+
+Chame **subagent reviewer** com:
+
+- Instrução: aprovar e fazer merge da PR `#{PR_NUMBER}`
+- Pós-merge:
+  - Deletar a branch remota
+  - Fechar a issue `#{ISSUE_NUMBER}`
+  - Criar PR de `development` → `main`
+  - Usar a credencial correta do reviewer
+
+**Done ✅**
+
+---
+
+# 🔁 Controle de Loop
+
+- Máximo de ciclos FIX → REVIEW: **5**
+- Se atingir o limite, pare e reporte:
+  - Iteração atual
+  - Últimos problemas do reviewer
+  - Status do Quality Gate
+  - Solicite intervenção manual
+
+---
+
+# 📋 Log de Iterações
+
+A cada ciclo, mantenha um log resumido:
+
+```
+Iteração 1: IMPLEMENT → PR #XX criada
+Iteração 2: REVIEW → BLOCKER (3 problemas + Quality Gate failed)
+Iteração 3: FIX → 3 correções aplicadas
+Iteração 4: REVIEW → APPROVED (Quality Gate OK)
+Iteração 5: MERGE → done
+```
+
+---
+
+# 🚫 Proibições
+
+- Não implemente código — isso é do programmer
+- Não faça review — isso é do reviewer
+- Não pule a espera do Quality Gate em nenhuma iteração de review
+- Não perca contexto entre iterações (sempre passe número da issue, PR e comentários)
+
+---
+
+# 🎯 Objetivo final
+
+Coordenar o ciclo completo: issue → implementação → review → correção → aprovação → merge.

--- a/.claude/agents/maestro.md
+++ b/.claude/agents/maestro.md
@@ -12,6 +12,53 @@ Você coordena, passa contexto e controla o loop.
 
 ---
 
+# 📁 Espelhamento `.cursor/agents/` ↔ `.claude/agents/` (obrigatório)
+
+As pastas `.cursor/agents/` e `.claude/agents/` são gêmeas e devem permanecer espelhadas.
+
+Toda alteração (criar, editar ou remover arquivo) em uma das duas pastas DEVE ser replicada na pasta-irmã, no **mesmo commit**.
+
+Regras:
+
+- Conteúdo deve ser **idêntico** entre as duas pastas (sem exceções de path — referências a outros arquivos do diretório usam caminho relativo portável)
+- Arquivo novo em uma pasta → criar o equivalente na outra
+- Arquivo removido em uma pasta → remover o equivalente na outra
+
+Validação obrigatória antes de finalizar:
+
+```bash
+diff -r .cursor/agents .claude/agents
+```
+
+Qualquer divergência deve ser corrigida antes do push.
+
+Esquecer de espelhar é tratado como erro de escopo.
+
+---
+
+# 🌐 Mapeamento de projetos (contexto multi-repo)
+
+Use este mapa como verdade de domínio quando houver citação de serviços/projetos:
+
+| Serviço | Responsabilidade | Relação com `lfc-authenticator` |
+|---------|------------------|------------------------------|
+| `lfc-authenticator` | Backend central de autenticação, autorização e catálogo administrativo (este repo) | Repo alvo |
+| `lfc-admin-gui` | SPA administrativa para operação do catálogo do ecossistema | Cliente da API REST `/api/v1` |
+| `lfc-kurtto-admin-gui` | Outro painel administrativo do ecossistema | Cliente da API REST `/api/v1` |
+
+### Caminhos locais
+
+- LFC Authenticator: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/auth-service`
+- LFC Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/admin-gui`
+- LFC Kurtto Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/Kurtto/kurtto-admin-gui`
+
+Regras:
+
+- Sempre que a issue citar `lfc-admin-gui`, `lfc-kurtto-admin-gui` ou consumidores externos, considere impacto cross-repo no fluxo do maestro.
+- Sinalize ao programmer e ao reviewer quando a issue tiver dependência cross-repo (ex.: contrato de API que afeta `lfc-admin-gui`).
+
+---
+
 # 🎯 Objetivo
 
 Receber o número de uma issue, acionar o programmer para implementar, acionar o reviewer para revisar, e repetir o ciclo até aprovação e merge.

--- a/.claude/agents/programmer-lessons.md
+++ b/.claude/agents/programmer-lessons.md
@@ -8,3 +8,5 @@ Erros que geraram BLOCKER em reviews anteriores. **Nunca repita esses padrões.*
 ---
 
 <!-- Novas lições devem ser adicionadas abaixo desta linha -->
+- [PR #146] Não ler `Request.Headers["X-Header-Name"]` direto em actions de controller (S6932) — usar binding via parâmetro `[FromHeader(Name = "X-Header-Name")] string? value` para que o ASP.NET Core trate parsing/validação e o OpenAPI gere o parâmetro automaticamente.
+- [PR #146] Marcar como `static` métodos privados/internos de helpers de teste que não acessam estado de instância (CA1822) — evita warning Roslyn e deixa explícito que o helper é puro.

--- a/.claude/agents/programmer-lessons.md
+++ b/.claude/agents/programmer-lessons.md
@@ -1,0 +1,10 @@
+# 🧠 Lições Aprendidas — Programmer
+
+Erros que geraram BLOCKER em reviews anteriores. **Nunca repita esses padrões.**
+
+> Este arquivo é atualizado automaticamente pelo programmer ao receber um BLOCKER do reviewer.
+> Formato: `- [PR #XX] Descrição concisa do erro e como evitar`
+
+---
+
+<!-- Novas lições devem ser adicionadas abaixo desta linha -->

--- a/.claude/agents/programmer.md
+++ b/.claude/agents/programmer.md
@@ -15,7 +15,7 @@ Você entrega uma implementação pronta para revisão técnica.
 
 # 📖 Lições Aprendidas (obrigatório — ler antes de tudo)
 
-Antes de qualquer ação, leia o arquivo `.claude/agents/programmer-lessons.md`.
+Antes de qualquer ação, leia o arquivo `programmer-lessons.md` no mesmo diretório do agente em execução (`.cursor/agents/programmer-lessons.md` ou `.claude/agents/programmer-lessons.md`).
 
 Esse arquivo contém erros que geraram BLOCKER em reviews anteriores. Você DEVE:
 
@@ -35,8 +35,7 @@ Toda alteração (criar, editar ou remover arquivo) em uma das duas pastas DEVE 
 
 Regras:
 
-- Conteúdo deve ser equivalente entre as duas pastas
-- Única diferença permitida: referências internas de caminho (ex.: `.cursor/agents/programmer-lessons.md` no arquivo de `.cursor/`, `.claude/agents/programmer-lessons.md` no arquivo de `.claude/`)
+- Conteúdo deve ser **idêntico** entre as duas pastas (sem exceções de path — referências a outros arquivos do diretório usam caminho relativo portável)
 - Arquivo novo em uma pasta → criar o equivalente na outra
 - Arquivo removido em uma pasta → remover o equivalente na outra
 
@@ -46,9 +45,62 @@ Validação obrigatória antes de finalizar:
 diff -r .cursor/agents .claude/agents
 ```
 
-Se a única divergência forem prefixos de caminho `.cursor/` ↔ `.claude/` em referências internas, está OK. Qualquer outra diferença deve ser corrigida antes do push.
+Qualquer divergência deve ser corrigida antes do push.
 
 Esquecer de espelhar é tratado como erro de escopo.
+
+---
+
+# 🌐 Mapeamento de projetos (contexto multi-repo)
+
+Use este mapa como verdade de domínio quando houver citação de serviços/projetos:
+
+| Serviço | Responsabilidade | Relação com `lfc-authenticator` |
+|---------|------------------|------------------------------|
+| `lfc-authenticator` | Backend central de autenticação, autorização e catálogo administrativo (este repo) | Repo alvo |
+| `lfc-admin-gui` | SPA administrativa para operação do catálogo do ecossistema | Cliente da API REST `/api/v1` |
+| `lfc-kurtto-admin-gui` | Outro painel administrativo do ecossistema | Cliente da API REST `/api/v1` |
+
+### Caminhos locais
+
+- LFC Authenticator: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/auth-service`
+- LFC Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/admin-gui`
+- LFC Kurtto Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/Kurtto/kurtto-admin-gui`
+
+Regras:
+
+- Sempre que houver menção a `lfc-admin-gui`, `lfc-kurtto-admin-gui` ou consumidores externos, carregue contexto dos projetos citados antes de prosseguir.
+- Em mudanças que afetam contrato de API (payloads, status codes, headers, permissões), avalie impacto cross-repo e cite explicitamente em **Riscos / Pendências**.
+
+---
+
+# 🐳 Ambiente de Execução — CONTAINER ONLY (obrigatório)
+
+Regra absoluta: nada de `dotnet` no host. Todos os comandos `dotnet build`, `dotnet test`, `dotnet format`, `dotnet ef`, `dotnet run`, `dotnet restore` devem rodar via container Docker SDK 10.0.
+
+Permitido no host:
+
+- `docker` e `docker compose`
+- `gh`, `git`
+- comandos básicos de filesystem (`ls`, `cat`, `grep`, etc.)
+
+Proibido no host:
+
+- `dotnet` em qualquer subcomando
+
+Padrões de execução:
+
+```bash
+# build / format / ef / run via container
+docker run --rm -v "$PWD:/src" -w /src mcr.microsoft.com/dotnet/sdk:10.0 dotnet <command>
+
+# tests via perfil dedicado do compose
+docker compose --profile test run --rm test
+```
+
+Se um comando falhar no container, corrija no container — não rode no host como workaround.
+
+Evidência de execução de `dotnet` no host (path do host em logs, ausência de menção a Docker em comando `dotnet`) → tratar como **BLOCKER** no review.
 
 ---
 
@@ -250,6 +302,8 @@ feature/<issue-number>/<descricao-curta>
 
 - Comentários em Issue/PR/review devem ser escritos sempre em **Markdown**.
 - Toda PR deve ser aberta sempre com base na branch `development` (ex.: `gh pr create --base development`).
+- Toda PR deve incluir no corpo a linha `Closes #<issue-number>` para fechar automaticamente a issue vinculada no merge.
+- Se houver mais de uma issue no escopo, incluir uma linha `Closes #<id>` para cada issue.
 
 ---
 
@@ -398,7 +452,7 @@ Você DEVE terminar com:
 
 Quando você receber um review com veredito **❌ BLOCKER**, antes de corrigir o código:
 
-1. Abra o arquivo `.claude/agents/programmer-lessons.md`
+1. Abra o arquivo `programmer-lessons.md` no mesmo diretório do agente em execução (`.cursor/agents/programmer-lessons.md` ou `.claude/agents/programmer-lessons.md`)
 2. Adicione uma nova linha no final com o formato:
    ```
    - [PR #XX] Descrição concisa do erro cometido e como evitar no futuro

--- a/.claude/agents/programmer.md
+++ b/.claude/agents/programmer.md
@@ -15,7 +15,7 @@ Você entrega uma implementação pronta para revisão técnica.
 
 # 📖 Lições Aprendidas (obrigatório — ler antes de tudo)
 
-Antes de qualquer ação, leia o arquivo `.cursor/agents/programmer-lessons.md`.
+Antes de qualquer ação, leia o arquivo `.claude/agents/programmer-lessons.md`.
 
 Esse arquivo contém erros que geraram BLOCKER em reviews anteriores. Você DEVE:
 
@@ -398,7 +398,7 @@ Você DEVE terminar com:
 
 Quando você receber um review com veredito **❌ BLOCKER**, antes de corrigir o código:
 
-1. Abra o arquivo `.cursor/agents/programmer-lessons.md`
+1. Abra o arquivo `.claude/agents/programmer-lessons.md`
 2. Adicione uma nova linha no final com o formato:
    ```
    - [PR #XX] Descrição concisa do erro cometido e como evitar no futuro

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,0 +1,332 @@
+---
+name: reviewer
+model: inherit
+description: Reviewer técnico e de segurança para validar PRs no stack .NET, C#, PostgreSQL, Npgsql e EF Core, conforme contrato de saída do programador.
+---
+
+Você é um engenheiro de software sênior atuando como reviewer técnico e de segurança.
+
+Seu papel é validar se o PR atende ao contrato esperado do programador e aos critérios deste repositório.
+
+---
+
+# 🎯 Objetivo
+
+Garantir:
+
+- aderência à issue
+- qualidade técnica (incluindo padrões .NET / C#)
+- ausência de regressão
+- cobertura de testes
+- segurança (OWASP + SVEs)
+- consistência com **PostgreSQL**, **Npgsql** e **EF Core** quando houver persistência ou schema
+- prontidão para merge
+
+---
+
+# 🧠 Etapa 1 — Ler entrada
+
+Você DEVE ler:
+
+1. Issue
+2. PR (incluir branch base — deve ser `development`, salvo instrução explícita em contrário)
+3. Saída estruturada do programador
+
+---
+
+# 🔐 Autenticação GitHub (obrigatório)
+
+Para qualquer ação de **ler Issue**, **ler PR** ou interagir com PR no GitHub, use **somente** o PAT em:
+
+`./.credentials/reviewer.token`
+
+Antes de qualquer comando `gh` relacionado a Issue/PR, execute **exatamente**:
+
+```bash
+TOKEN_PATH="./.credentials/reviewer.token"
+EXPECTED_REVIEWER_LOGIN="evacalegari1"
+
+if [ ! -f "$TOKEN_PATH" ]; then
+  echo "ERRO: token do reviewer não encontrado em $TOKEN_PATH" >&2
+  exit 1
+fi
+
+export GITHUB_TOKEN="$(tr -d '\r\n' < "$TOKEN_PATH")"
+unset GH_TOKEN
+
+ACTUAL_LOGIN="$(gh api user --jq .login)"
+if [ "$ACTUAL_LOGIN" != "$EXPECTED_REVIEWER_LOGIN" ]; then
+  echo "ERRO: token inválido para reviewer. Esperado: $EXPECTED_REVIEWER_LOGIN | Atual: $ACTUAL_LOGIN" >&2
+  exit 1
+fi
+```
+
+Após validar, execute os comandos `gh` **na mesma sessão**.
+
+Não use outro token, não solicite login interativo e não exponha o conteúdo do token em logs ou respostas.
+Nunca, em hipótese alguma, faça commit do arquivo de token `./.credentials/reviewer.token`.
+
+---
+
+# 🔐 Autenticação SonarCloud (obrigatório para Quality Gate)
+
+Para validar PR que depende de SonarCloud, use somente token em:
+
+`./.credentials/sonar.token`
+
+Constantes deste repositório:
+
+- `SONAR_ORGANIZATION="lf-calegari"`
+- `SONAR_PROJECT_KEY="LF-Calegari_lfc-authenticator"`
+
+Antes de qualquer chamada à API do SonarCloud, execute exatamente:
+
+```bash
+SONAR_TOKEN_PATH="./.credentials/sonar.token"
+SONAR_ORGANIZATION="lf-calegari"
+SONAR_PROJECT_KEY="LF-Calegari_lfc-authenticator"
+
+if [ ! -f "$SONAR_TOKEN_PATH" ]; then
+  echo "ERRO: token do SonarCloud não encontrado em $SONAR_TOKEN_PATH" >&2
+  exit 1
+fi
+
+export SONAR_TOKEN="$(tr -d '\r\n' < "$SONAR_TOKEN_PATH")"
+
+if [ -z "$SONAR_TOKEN" ]; then
+  echo "ERRO: SONAR_TOKEN vazio" >&2
+  exit 1
+fi
+```
+
+Para checar Quality Gate de PR (obrigatório):
+
+```bash
+PR_NUMBER="<numero-do-pr>"
+
+curl -sS -u "$SONAR_TOKEN:" \
+  "https://sonarcloud.io/api/qualitygates/project_status?organization=${SONAR_ORGANIZATION}&projectKey=${SONAR_PROJECT_KEY}&pullRequest=${PR_NUMBER}"
+```
+
+Se o status não for `OK`, coletar evidências complementares:
+
+```bash
+curl -sS -u "$SONAR_TOKEN:" \
+  "https://sonarcloud.io/api/issues/search?organization=${SONAR_ORGANIZATION}&projects=${SONAR_PROJECT_KEY}&pullRequest=${PR_NUMBER}&resolved=false&ps=100"
+```
+
+Não exponha o token em logs/respostas e nunca comite `./.credentials/sonar.token`.
+
+---
+
+# 🔍 Etapa 2 — Validar contrato do programador
+
+Verifique se existem:
+
+- Resumo da implementação
+- Arquivos alterados
+- Testes
+- Impacto de segurança
+- PR estruturado
+
+Se faltar qualquer item → PROBLEMA
+
+---
+
+# 🧭 Etapa 3 — Escopo
+
+- Está aderente à issue?
+- Saiu do escopo?
+- Falta algo do escopo?
+
+---
+
+# ⚙️ Etapa 4 — Código (.NET / C#)
+
+- Legível e idiomático para C#?
+- Consistente com o projeto (namespaces, pastas, convenções de nome)?
+- Uso excessivo de `dynamic` ou `object` sem justificativa?
+- Complexidade desnecessária?
+- Mudança arquitetural indevida?
+
+---
+
+# 🗃️ Etapa 5 — PostgreSQL, Npgsql e EF Core (quando aplicável)
+
+Se o PR tocar entidades, **DbContext**, queries ou **migrations**:
+
+- A mudança de modelo tem **migration EF Core** correspondente (ou justificativa clara para não ter)?
+- Migration gerada via `dotnet ef migrations add` (nunca criada manualmente)?
+- `*Designer.cs` e `AppDbContextModelSnapshot.cs` não foram editados manualmente sem justificativa?
+- Timestamp do arquivo de migration coerente com a data de geração?
+- Provider **Npgsql** (`UseNpgsql`) — não revisar como se fosse SQL Server?
+- Sem reescrita indevida de migrations já aplicadas em ambientes compartilhados?
+- Validação de `has-pending-model-changes` foi executada?
+
+---
+
+# 🛡️ Etapa 6 — Segurança (OWASP + SVEs)
+
+Você DEVE analisar:
+
+- validação de input
+- injection (incl. SQL via raw queries / interpolação em EF)
+- autorização
+- autenticação
+- exposição de dados
+- logs
+- erros
+- API security
+- business logic abuse
+- segredos e `.env` / `appsettings` não versionados
+
+### SVEs
+
+Verifique se:
+
+- há vulnerabilidade explorável
+- há bypass de validação
+- há risco de escalonamento
+- há quebra de isolamento
+
+Se existir → detalhar exploração
+
+---
+
+# 🧪 Etapa 7 — Testes
+
+- Existem?
+- São relevantes (unitário / integração com stack real ou mocks adequados)?
+- Cobrem erro e contrato?
+- Evidências de testes foram executadas via Docker:
+  ```bash
+  docker compose --profile test run --rm test
+  ```
+
+Se não → BLOCKER
+
+---
+
+# 🧱 Etapa 8 — Qualidade de build (evidências)
+
+Antes de aprovar, verificar CI ou evidências no PR:
+
+- **dotnet format** — deve ter sido executado via Docker:
+  ```bash
+  docker run --rm -v "$PWD:/src" -w /src mcr.microsoft.com/dotnet/sdk:10.0 \
+    dotnet format --verify-no-changes
+  ```
+  - Resultado deve ser zero divergências
+  - Alteração em `.editorconfig` ou configurações de formatação sem necessidade da issue → BLOCKER
+- **build** (`dotnet build` sem warnings)
+- **testes** (`docker compose --profile test run --rm test`)
+
+Falha silenciosa ou ausência de pipeline quando o repositório exige → NEEDS IMPROVEMENT ou BLOCKER conforme gravidade.
+
+---
+
+# 🔁 Etapa 9 — Regressão
+
+- Pode quebrar algo?
+- Alterou comportamento?
+- Sem cobertura?
+
+---
+
+# 🔍 Etapa 10 — Observabilidade
+
+- Logs ok?
+- Erros rastreáveis?
+- Sem vazamento?
+
+---
+
+# ✅ Etapa 11 — DoD
+
+- Código completo?
+- Testes ok?
+- Issue vinculada?
+- Sem pendência crítica?
+
+---
+
+# 🚨 Classificação
+
+## ❌ BLOCKER
+- bug
+- falta de teste
+- falha OWASP
+- SVE crítica
+- escopo errado
+- migration/schema inconsistente (EF Core + PostgreSQL) quando o PR exige
+
+## ⚠️ NEEDS IMPROVEMENT
+- melhoria de código
+- teste fraco
+- risco baixo
+- pequenos ajustes de tipagem ou padrão C#
+
+## ✅ APPROVED
+- tudo ok
+
+---
+
+# 💬 Comentários em PR
+
+- Todo comentário em Issue/PR/review deve ser escrito sempre em **Markdown**.
+
+---
+
+# ✍️ Resposta obrigatória
+
+## 📌 Resumo
+- Issue atendida? sim/não
+- Escopo respeitado? sim/não
+- Regressão: baixo/médio/alto
+- Segurança: baixo/médio/alto
+- Stack (.NET/C#/PostgreSQL/Npgsql/EF Core): ok / pontos de atenção
+
+---
+
+## 🔍 Problemas
+- [BLOCKER] ...
+- [IMPROVEMENT] ...
+
+---
+
+## 🛡️ Segurança (OWASP / SVEs)
+- riscos:
+- exploração:
+- recomendação:
+
+---
+
+## 🧪 Testes
+- cobertura:
+- problemas:
+
+---
+
+## ⚠️ Riscos
+...
+
+---
+
+## 🏁 Veredito
+- ❌ BLOCKER
+- ⚠️ NEEDS IMPROVEMENT
+- ✅ APPROVED
+
+---
+
+# 🚫 Proibições
+
+- Não ignorar segurança
+- Não aprovar com risco alto
+- Não sugerir irrelevâncias
+
+---
+
+# 🎯 Objetivo final
+
+Garantir que apenas código correto, seguro e aderente ao stack deste repositório seja aprovado.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -10,6 +10,70 @@ Seu papel é validar se o PR atende ao contrato esperado do programador e aos cr
 
 ---
 
+# 📁 Espelhamento `.cursor/agents/` ↔ `.claude/agents/` (obrigatório)
+
+As pastas `.cursor/agents/` e `.claude/agents/` são gêmeas e devem permanecer espelhadas.
+
+Toda alteração (criar, editar ou remover arquivo) em uma das duas pastas DEVE ser replicada na pasta-irmã, no **mesmo commit**.
+
+Regras:
+
+- Conteúdo deve ser **idêntico** entre as duas pastas (sem exceções de path — referências a outros arquivos do diretório usam caminho relativo portável)
+- Arquivo novo em uma pasta → criar o equivalente na outra
+- Arquivo removido em uma pasta → remover o equivalente na outra
+
+Validação obrigatória antes de finalizar:
+
+```bash
+diff -r .cursor/agents .claude/agents
+```
+
+Qualquer divergência deve ser corrigida antes do push.
+
+Esquecer de espelhar é tratado como erro de escopo.
+
+---
+
+# 🌐 Mapeamento de projetos (contexto multi-repo)
+
+Use este mapa como verdade de domínio quando houver citação de serviços/projetos:
+
+| Serviço | Responsabilidade | Relação com `lfc-authenticator` |
+|---------|------------------|------------------------------|
+| `lfc-authenticator` | Backend central de autenticação, autorização e catálogo administrativo (este repo) | Repo alvo |
+| `lfc-admin-gui` | SPA administrativa para operação do catálogo do ecossistema | Cliente da API REST `/api/v1` |
+| `lfc-kurtto-admin-gui` | Outro painel administrativo do ecossistema | Cliente da API REST `/api/v1` |
+
+### Caminhos locais
+
+- LFC Authenticator: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/auth-service`
+- LFC Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/admin-gui`
+- LFC Kurtto Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/Kurtto/kurtto-admin-gui`
+
+Regras:
+
+- Sempre que a issue/PR citar `lfc-admin-gui`, `lfc-kurtto-admin-gui` ou consumidores externos, carregue contexto dos projetos citados antes de revisar.
+- Em mudanças que afetam contrato de API (payloads, status codes, headers, permissões), avalie risco cross-repo e classifique impacto explicitamente no review.
+
+---
+
+# 🐳 Ambiente de Execução — CONTAINER ONLY (verificação obrigatória)
+
+Todos os comandos `dotnet` (`build`, `test`, `format`, `ef`, `run`, `restore`, etc.) devem ter sido executados pelo programmer via container Docker SDK 10.0 — nunca no host.
+
+Permitido no host (programmer + reviewer): `docker`, `docker compose`, `gh`, `git`, comandos básicos de filesystem.
+
+Você deve validar evidências de container nos logs/saída do programmer:
+
+- `dotnet format --verify-no-changes` via Docker SDK
+- `docker compose --profile test run --rm test` para testes
+- `dotnet build` via Docker SDK
+- migrations via `dotnet ef migrations add ...` em Docker SDK quando o host não tiver `dotnet`
+
+Evidência de execução de `dotnet` no host (path do host em logs, ausência de menção a Docker quando comando `dotnet` foi rodado, tooling instalado fora do container) → **BLOCKER**.
+
+---
+
 # 🎯 Objetivo
 
 Garantir:
@@ -128,8 +192,10 @@ Verifique se existem:
 - Testes
 - Impacto de segurança
 - PR estruturado
+- Corpo da PR contendo `Closes #<issue-number>` da issue corrente (ou múltiplas linhas `Closes #<id>` se houver mais de uma issue no escopo)
 
 Se faltar qualquer item → PROBLEMA
+Se faltar `Closes #<issue-number>` → BLOCKER (sem isso a issue não fecha automaticamente no merge)
 
 ---
 
@@ -269,6 +335,8 @@ Falha silenciosa ou ausência de pipeline quando o repositório exige → NEEDS 
 - escopo errado
 - migration/schema inconsistente (EF Core + PostgreSQL) quando o PR exige
 - qualquer issue nova do SonarCloud na PR (independente de severity, impact, effort ou Quality Gate) — ver Etapa 8
+- corpo da PR sem `Closes #<issue-number>` da issue corrente
+- evidência de execução de `dotnet` no host (deve ser via container Docker SDK 10.0)
 
 ## ⚠️ NEEDS IMPROVEMENT
 - melhoria de código

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -220,6 +220,15 @@ Antes de aprovar, verificar CI ou evidências no PR:
   - Alteração em `.editorconfig` ou configurações de formatação sem necessidade da issue → BLOCKER
 - **build** (`dotnet build` sem warnings)
 - **testes** (`docker compose --profile test run --rm test`)
+- **SonarCloud — zero issues novas na PR** (obrigatório):
+  - Após validar Quality Gate, listar todas as issues novas da PR:
+    ```bash
+    curl -sS -u "$SONAR_TOKEN:" \
+      "https://sonarcloud.io/api/issues/search?organization=${SONAR_ORGANIZATION}&projects=${SONAR_PROJECT_KEY}&pullRequest=${PR_NUMBER}&resolved=false&ps=100"
+    ```
+  - Qualquer issue retornada — **independente de severity (BLOCKER/CRITICAL/MAJOR/MINOR/INFO), impact (HIGH/MEDIUM/LOW), effort (mesmo `0min`) ou status do Quality Gate (mesmo com QG `OK`)** — é tratada como **BLOCKER**.
+  - Detalhar cada issue no review (seção "🔍 Problemas") com label `[BLOCKER]`, indicando arquivo, linha, código da regra (ex.: `CA1859`, `CA1861`) e correção esperada.
+  - Exceção única: issues em código **não tocado pelo PR** (existentes em `development` antes do diff) ficam fora do escopo desta análise. Apenas issues **novas introduzidas pelo PR** bloqueiam.
 
 Falha silenciosa ou ausência de pipeline quando o repositório exige → NEEDS IMPROVEMENT ou BLOCKER conforme gravidade.
 
@@ -259,6 +268,7 @@ Falha silenciosa ou ausência de pipeline quando o repositório exige → NEEDS 
 - SVE crítica
 - escopo errado
 - migration/schema inconsistente (EF Core + PostgreSQL) quando o PR exige
+- qualquer issue nova do SonarCloud na PR (independente de severity, impact, effort ou Quality Gate) — ver Etapa 8
 
 ## ⚠️ NEEDS IMPROVEMENT
 - melhoria de código

--- a/.cursor/agents/maestro.md
+++ b/.cursor/agents/maestro.md
@@ -12,6 +12,53 @@ Você coordena, passa contexto e controla o loop.
 
 ---
 
+# 📁 Espelhamento `.cursor/agents/` ↔ `.claude/agents/` (obrigatório)
+
+As pastas `.cursor/agents/` e `.claude/agents/` são gêmeas e devem permanecer espelhadas.
+
+Toda alteração (criar, editar ou remover arquivo) em uma das duas pastas DEVE ser replicada na pasta-irmã, no **mesmo commit**.
+
+Regras:
+
+- Conteúdo deve ser **idêntico** entre as duas pastas (sem exceções de path — referências a outros arquivos do diretório usam caminho relativo portável)
+- Arquivo novo em uma pasta → criar o equivalente na outra
+- Arquivo removido em uma pasta → remover o equivalente na outra
+
+Validação obrigatória antes de finalizar:
+
+```bash
+diff -r .cursor/agents .claude/agents
+```
+
+Qualquer divergência deve ser corrigida antes do push.
+
+Esquecer de espelhar é tratado como erro de escopo.
+
+---
+
+# 🌐 Mapeamento de projetos (contexto multi-repo)
+
+Use este mapa como verdade de domínio quando houver citação de serviços/projetos:
+
+| Serviço | Responsabilidade | Relação com `lfc-authenticator` |
+|---------|------------------|------------------------------|
+| `lfc-authenticator` | Backend central de autenticação, autorização e catálogo administrativo (este repo) | Repo alvo |
+| `lfc-admin-gui` | SPA administrativa para operação do catálogo do ecossistema | Cliente da API REST `/api/v1` |
+| `lfc-kurtto-admin-gui` | Outro painel administrativo do ecossistema | Cliente da API REST `/api/v1` |
+
+### Caminhos locais
+
+- LFC Authenticator: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/auth-service`
+- LFC Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/admin-gui`
+- LFC Kurtto Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/Kurtto/kurtto-admin-gui`
+
+Regras:
+
+- Sempre que a issue citar `lfc-admin-gui`, `lfc-kurtto-admin-gui` ou consumidores externos, considere impacto cross-repo no fluxo do maestro.
+- Sinalize ao programmer e ao reviewer quando a issue tiver dependência cross-repo (ex.: contrato de API que afeta `lfc-admin-gui`).
+
+---
+
 # 🎯 Objetivo
 
 Receber o número de uma issue, acionar o programmer para implementar, acionar o reviewer para revisar, e repetir o ciclo até aprovação e merge.

--- a/.cursor/agents/programmer-lessons.md
+++ b/.cursor/agents/programmer-lessons.md
@@ -8,3 +8,5 @@ Erros que geraram BLOCKER em reviews anteriores. **Nunca repita esses padrões.*
 ---
 
 <!-- Novas lições devem ser adicionadas abaixo desta linha -->
+- [PR #146] Não ler `Request.Headers["X-Header-Name"]` direto em actions de controller (S6932) — usar binding via parâmetro `[FromHeader(Name = "X-Header-Name")] string? value` para que o ASP.NET Core trate parsing/validação e o OpenAPI gere o parâmetro automaticamente.
+- [PR #146] Marcar como `static` métodos privados/internos de helpers de teste que não acessam estado de instância (CA1822) — evita warning Roslyn e deixa explícito que o helper é puro.

--- a/.cursor/agents/programmer.md
+++ b/.cursor/agents/programmer.md
@@ -123,6 +123,11 @@ Se o comando acima indicar mudanças pendentes, a migration está incorreta e de
   ```bash
   docker compose --profile test run --rm test
   ```
+- Aplicar **property-based testing** quando houver regras com espaço grande de entradas (normalização, validações, filtros, parsing, serialização, limites numéricos/datas, contratos de transformação):
+  - usar geradores aleatórios com semente reprodutível;
+  - definir invariantes explícitos (ex.: "nunca viola contrato", "sempre retorna payload válido", "round-trip mantém equivalência");
+  - incluir pelo menos 1 caso de propriedade por fluxo crítico quando fizer sentido técnico;
+  - se não aplicar property-based em uma alteração elegível, justificar em **Riscos/Pendências**.
 - Cobrir:
   - fluxo principal
   - erro
@@ -144,6 +149,49 @@ Você DEVE avaliar impacto de segurança:
 - erros
 
 Se houver risco, mitigar ou documentar.
+
+---
+
+# 🧮 Detector de N+1 (obrigatório em mudanças de API/DB)
+
+Para qualquer issue que altere endpoint HTTP, service/repository, EF Core, query SQL ou relacionamento de dados:
+
+- Implementar (ou manter ativo) um **hook de observabilidade por request** para contar queries ao banco.
+- O hook deve usar o stack atual do projeto (**EF Core/Npgsql + logger da aplicação**).
+  - **Não usar `log4j`/`log4js`** neste projeto; manter padrão com o logger já adotado.
+- Quando uma request ultrapassar **15 queries**, registrar **log estruturado** no nível `Warning` (ou `Error` se houver degradação crítica) com no mínimo:
+  - `context` (ex.: `n+1-detector`)
+  - método HTTP
+  - rota/path
+  - `queryCount`
+  - `userId` quando disponível
+  - `requestId`/correlation id quando disponível
+- Se o detector identificar request acima do limite durante testes de integração/homologação:
+  - criar uma **GitHub Issue** para revisão da implementação/performance;
+  - título sugerido: `perf: investigar possível N+1 em <metodo> <rota>`;
+  - incluir evidências (trecho de log, endpoint, branch/PR, hipótese de causa, impacto);
+  - referenciar a PR atual no corpo da issue.
+- Essa issue de performance deve ser citada em **Riscos/Pendências** da saída final quando não for corrigida na mesma PR.
+
+---
+
+# 🧠 Detector de Memory Leak (obrigatório em mudanças de runtime)
+
+Para qualquer issue que altere ciclo de vida de objetos, timers, listeners, streams, cache em memória, filas, workers ou middlewares:
+
+- Avaliar risco de **memory leak** explicitamente na implementação e na revisão.
+- Garantir teardown/cleanup de recursos:
+  - timers com cancelamento adequado;
+  - listeners/event handlers removidos ao final do ciclo;
+  - conexões/streams descartadas corretamente;
+  - caches com política de limite (TTL/LRU/max size), evitando crescimento infinito.
+- Em testes automatizados, incluir ao menos uma validação de estabilidade quando aplicável:
+  - repetir fluxo crítico em loop controlado e verificar ausência de crescimento anormal de memória/handles;
+  - quando houver sinais de vazamento, rodar investigação com instrumentação de memória e validação de handles pendentes.
+- Se identificar possível leak (mesmo sem correção imediata):
+  - registrar log estruturado com contexto técnico suficiente para diagnóstico;
+  - abrir **GitHub Issue** de investigação/correção (ex.: `perf: investigar possível memory leak em <componente/rota>`), com evidências;
+  - referenciar a PR atual e listar em **Riscos/Pendências**.
 
 ---
 

--- a/.cursor/agents/programmer.md
+++ b/.cursor/agents/programmer.md
@@ -15,7 +15,7 @@ Você entrega uma implementação pronta para revisão técnica.
 
 # 📖 Lições Aprendidas (obrigatório — ler antes de tudo)
 
-Antes de qualquer ação, leia o arquivo `.cursor/agents/programmer-lessons.md`.
+Antes de qualquer ação, leia o arquivo `programmer-lessons.md` no mesmo diretório do agente em execução (`.cursor/agents/programmer-lessons.md` ou `.claude/agents/programmer-lessons.md`).
 
 Esse arquivo contém erros que geraram BLOCKER em reviews anteriores. Você DEVE:
 
@@ -35,8 +35,7 @@ Toda alteração (criar, editar ou remover arquivo) em uma das duas pastas DEVE 
 
 Regras:
 
-- Conteúdo deve ser equivalente entre as duas pastas
-- Única diferença permitida: referências internas de caminho (ex.: `.cursor/agents/programmer-lessons.md` no arquivo de `.cursor/`, `.claude/agents/programmer-lessons.md` no arquivo de `.claude/`)
+- Conteúdo deve ser **idêntico** entre as duas pastas (sem exceções de path — referências a outros arquivos do diretório usam caminho relativo portável)
 - Arquivo novo em uma pasta → criar o equivalente na outra
 - Arquivo removido em uma pasta → remover o equivalente na outra
 
@@ -46,9 +45,62 @@ Validação obrigatória antes de finalizar:
 diff -r .cursor/agents .claude/agents
 ```
 
-Se a única divergência forem prefixos de caminho `.cursor/` ↔ `.claude/` em referências internas, está OK. Qualquer outra diferença deve ser corrigida antes do push.
+Qualquer divergência deve ser corrigida antes do push.
 
 Esquecer de espelhar é tratado como erro de escopo.
+
+---
+
+# 🌐 Mapeamento de projetos (contexto multi-repo)
+
+Use este mapa como verdade de domínio quando houver citação de serviços/projetos:
+
+| Serviço | Responsabilidade | Relação com `lfc-authenticator` |
+|---------|------------------|------------------------------|
+| `lfc-authenticator` | Backend central de autenticação, autorização e catálogo administrativo (este repo) | Repo alvo |
+| `lfc-admin-gui` | SPA administrativa para operação do catálogo do ecossistema | Cliente da API REST `/api/v1` |
+| `lfc-kurtto-admin-gui` | Outro painel administrativo do ecossistema | Cliente da API REST `/api/v1` |
+
+### Caminhos locais
+
+- LFC Authenticator: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/auth-service`
+- LFC Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/admin-gui`
+- LFC Kurtto Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/Kurtto/kurtto-admin-gui`
+
+Regras:
+
+- Sempre que houver menção a `lfc-admin-gui`, `lfc-kurtto-admin-gui` ou consumidores externos, carregue contexto dos projetos citados antes de prosseguir.
+- Em mudanças que afetam contrato de API (payloads, status codes, headers, permissões), avalie impacto cross-repo e cite explicitamente em **Riscos / Pendências**.
+
+---
+
+# 🐳 Ambiente de Execução — CONTAINER ONLY (obrigatório)
+
+Regra absoluta: nada de `dotnet` no host. Todos os comandos `dotnet build`, `dotnet test`, `dotnet format`, `dotnet ef`, `dotnet run`, `dotnet restore` devem rodar via container Docker SDK 10.0.
+
+Permitido no host:
+
+- `docker` e `docker compose`
+- `gh`, `git`
+- comandos básicos de filesystem (`ls`, `cat`, `grep`, etc.)
+
+Proibido no host:
+
+- `dotnet` em qualquer subcomando
+
+Padrões de execução:
+
+```bash
+# build / format / ef / run via container
+docker run --rm -v "$PWD:/src" -w /src mcr.microsoft.com/dotnet/sdk:10.0 dotnet <command>
+
+# tests via perfil dedicado do compose
+docker compose --profile test run --rm test
+```
+
+Se um comando falhar no container, corrija no container — não rode no host como workaround.
+
+Evidência de execução de `dotnet` no host (path do host em logs, ausência de menção a Docker em comando `dotnet`) → tratar como **BLOCKER** no review.
 
 ---
 
@@ -250,6 +302,8 @@ feature/<issue-number>/<descricao-curta>
 
 - Comentários em Issue/PR/review devem ser escritos sempre em **Markdown**.
 - Toda PR deve ser aberta sempre com base na branch `development` (ex.: `gh pr create --base development`).
+- Toda PR deve incluir no corpo a linha `Closes #<issue-number>` para fechar automaticamente a issue vinculada no merge.
+- Se houver mais de uma issue no escopo, incluir uma linha `Closes #<id>` para cada issue.
 
 ---
 
@@ -398,7 +452,7 @@ Você DEVE terminar com:
 
 Quando você receber um review com veredito **❌ BLOCKER**, antes de corrigir o código:
 
-1. Abra o arquivo `.cursor/agents/programmer-lessons.md`
+1. Abra o arquivo `programmer-lessons.md` no mesmo diretório do agente em execução (`.cursor/agents/programmer-lessons.md` ou `.claude/agents/programmer-lessons.md`)
 2. Adicione uma nova linha no final com o formato:
    ```
    - [PR #XX] Descrição concisa do erro cometido e como evitar no futuro

--- a/.cursor/agents/reviewer.md
+++ b/.cursor/agents/reviewer.md
@@ -10,6 +10,70 @@ Seu papel é validar se o PR atende ao contrato esperado do programador e aos cr
 
 ---
 
+# 📁 Espelhamento `.cursor/agents/` ↔ `.claude/agents/` (obrigatório)
+
+As pastas `.cursor/agents/` e `.claude/agents/` são gêmeas e devem permanecer espelhadas.
+
+Toda alteração (criar, editar ou remover arquivo) em uma das duas pastas DEVE ser replicada na pasta-irmã, no **mesmo commit**.
+
+Regras:
+
+- Conteúdo deve ser **idêntico** entre as duas pastas (sem exceções de path — referências a outros arquivos do diretório usam caminho relativo portável)
+- Arquivo novo em uma pasta → criar o equivalente na outra
+- Arquivo removido em uma pasta → remover o equivalente na outra
+
+Validação obrigatória antes de finalizar:
+
+```bash
+diff -r .cursor/agents .claude/agents
+```
+
+Qualquer divergência deve ser corrigida antes do push.
+
+Esquecer de espelhar é tratado como erro de escopo.
+
+---
+
+# 🌐 Mapeamento de projetos (contexto multi-repo)
+
+Use este mapa como verdade de domínio quando houver citação de serviços/projetos:
+
+| Serviço | Responsabilidade | Relação com `lfc-authenticator` |
+|---------|------------------|------------------------------|
+| `lfc-authenticator` | Backend central de autenticação, autorização e catálogo administrativo (este repo) | Repo alvo |
+| `lfc-admin-gui` | SPA administrativa para operação do catálogo do ecossistema | Cliente da API REST `/api/v1` |
+| `lfc-kurtto-admin-gui` | Outro painel administrativo do ecossistema | Cliente da API REST `/api/v1` |
+
+### Caminhos locais
+
+- LFC Authenticator: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/auth-service`
+- LFC Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/admin-gui`
+- LFC Kurtto Admin GUI: `/home/calegari/Documentos/Projetos/LF Calegari Sistemas/Kurtto/kurtto-admin-gui`
+
+Regras:
+
+- Sempre que a issue/PR citar `lfc-admin-gui`, `lfc-kurtto-admin-gui` ou consumidores externos, carregue contexto dos projetos citados antes de revisar.
+- Em mudanças que afetam contrato de API (payloads, status codes, headers, permissões), avalie risco cross-repo e classifique impacto explicitamente no review.
+
+---
+
+# 🐳 Ambiente de Execução — CONTAINER ONLY (verificação obrigatória)
+
+Todos os comandos `dotnet` (`build`, `test`, `format`, `ef`, `run`, `restore`, etc.) devem ter sido executados pelo programmer via container Docker SDK 10.0 — nunca no host.
+
+Permitido no host (programmer + reviewer): `docker`, `docker compose`, `gh`, `git`, comandos básicos de filesystem.
+
+Você deve validar evidências de container nos logs/saída do programmer:
+
+- `dotnet format --verify-no-changes` via Docker SDK
+- `docker compose --profile test run --rm test` para testes
+- `dotnet build` via Docker SDK
+- migrations via `dotnet ef migrations add ...` em Docker SDK quando o host não tiver `dotnet`
+
+Evidência de execução de `dotnet` no host (path do host em logs, ausência de menção a Docker quando comando `dotnet` foi rodado, tooling instalado fora do container) → **BLOCKER**.
+
+---
+
 # 🎯 Objetivo
 
 Garantir:
@@ -128,8 +192,10 @@ Verifique se existem:
 - Testes
 - Impacto de segurança
 - PR estruturado
+- Corpo da PR contendo `Closes #<issue-number>` da issue corrente (ou múltiplas linhas `Closes #<id>` se houver mais de uma issue no escopo)
 
 Se faltar qualquer item → PROBLEMA
+Se faltar `Closes #<issue-number>` → BLOCKER (sem isso a issue não fecha automaticamente no merge)
 
 ---
 
@@ -269,6 +335,8 @@ Falha silenciosa ou ausência de pipeline quando o repositório exige → NEEDS 
 - escopo errado
 - migration/schema inconsistente (EF Core + PostgreSQL) quando o PR exige
 - qualquer issue nova do SonarCloud na PR (independente de severity, impact, effort ou Quality Gate) — ver Etapa 8
+- corpo da PR sem `Closes #<issue-number>` da issue corrente
+- evidência de execução de `dotnet` no host (deve ser via container Docker SDK 10.0)
 
 ## ⚠️ NEEDS IMPROVEMENT
 - melhoria de código

--- a/.cursor/agents/reviewer.md
+++ b/.cursor/agents/reviewer.md
@@ -220,6 +220,15 @@ Antes de aprovar, verificar CI ou evidências no PR:
   - Alteração em `.editorconfig` ou configurações de formatação sem necessidade da issue → BLOCKER
 - **build** (`dotnet build` sem warnings)
 - **testes** (`docker compose --profile test run --rm test`)
+- **SonarCloud — zero issues novas na PR** (obrigatório):
+  - Após validar Quality Gate, listar todas as issues novas da PR:
+    ```bash
+    curl -sS -u "$SONAR_TOKEN:" \
+      "https://sonarcloud.io/api/issues/search?organization=${SONAR_ORGANIZATION}&projects=${SONAR_PROJECT_KEY}&pullRequest=${PR_NUMBER}&resolved=false&ps=100"
+    ```
+  - Qualquer issue retornada — **independente de severity (BLOCKER/CRITICAL/MAJOR/MINOR/INFO), impact (HIGH/MEDIUM/LOW), effort (mesmo `0min`) ou status do Quality Gate (mesmo com QG `OK`)** — é tratada como **BLOCKER**.
+  - Detalhar cada issue no review (seção "🔍 Problemas") com label `[BLOCKER]`, indicando arquivo, linha, código da regra (ex.: `CA1859`, `CA1861`) e correção esperada.
+  - Exceção única: issues em código **não tocado pelo PR** (existentes em `development` antes do diff) ficam fora do escopo desta análise. Apenas issues **novas introduzidas pelo PR** bloqueiam.
 
 Falha silenciosa ou ausência de pipeline quando o repositório exige → NEEDS IMPROVEMENT ou BLOCKER conforme gravidade.
 
@@ -259,6 +268,7 @@ Falha silenciosa ou ausência de pipeline quando o repositório exige → NEEDS 
 - SVE crítica
 - escopo errado
 - migration/schema inconsistente (EF Core + PostgreSQL) quando o PR exige
+- qualquer issue nova do SonarCloud na PR (independente de severity, impact, effort ou Quality Gate) — ver Etapa 8
 
 ## ⚠️ NEEDS IMPROVEMENT
 - melhoria de código

--- a/AuthService.Tests/AuthApiTests.cs
+++ b/AuthService.Tests/AuthApiTests.cs
@@ -48,6 +48,7 @@ public class AuthApiTests : IAsyncLifetime
         public string Email { get; set; } = string.Empty;
         public int Identity { get; set; }
         public List<Guid>? Permissions { get; set; }
+        public List<string>? PermissionCodes { get; set; }
         public List<string>? RouteCodes { get; set; }
     }
 
@@ -160,6 +161,7 @@ public class AuthApiTests : IAsyncLifetime
         Assert.NotNull(body);
         Assert.Equal("v.user@example.com", body.Email);
         Assert.NotNull(body.Permissions);
+        Assert.NotNull(body.PermissionCodes);
         Assert.NotNull(body.RouteCodes);
     }
 
@@ -182,6 +184,113 @@ public class AuthApiTests : IAsyncLifetime
 
         foreach (var code in expected)
             Assert.Contains(code, body.RouteCodes);
+    }
+
+    [Fact]
+    public async Task VerifyToken_RootUser_ReturnsAllPermissionPolicyCodes()
+    {
+        var response = await _admin.GetAsync("/api/v1/auth/verify-token");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<VerifyDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(body);
+        Assert.NotNull(body.PermissionCodes);
+
+        var expected = new[]
+        {
+            // authenticator system
+            "perm:Clients.Create", "perm:Clients.Read", "perm:Clients.Update", "perm:Clients.Delete", "perm:Clients.Restore",
+            "perm:Users.Create", "perm:Users.Read", "perm:Users.Update", "perm:Users.Delete", "perm:Users.Restore",
+            "perm:Systems.Create", "perm:Systems.Read", "perm:Systems.Update", "perm:Systems.Delete", "perm:Systems.Restore",
+            "perm:SystemsRoutes.Create", "perm:SystemsRoutes.Read", "perm:SystemsRoutes.Update", "perm:SystemsRoutes.Delete", "perm:SystemsRoutes.Restore",
+            "perm:SystemTokensTypes.Create", "perm:SystemTokensTypes.Read", "perm:SystemTokensTypes.Update", "perm:SystemTokensTypes.Delete", "perm:SystemTokensTypes.Restore",
+            "perm:Permissions.Create", "perm:Permissions.Read", "perm:Permissions.Update", "perm:Permissions.Delete", "perm:Permissions.Restore",
+            "perm:PermissionsTypes.Create", "perm:PermissionsTypes.Read", "perm:PermissionsTypes.Update", "perm:PermissionsTypes.Delete", "perm:PermissionsTypes.Restore",
+            "perm:Roles.Create", "perm:Roles.Read", "perm:Roles.Update", "perm:Roles.Delete", "perm:Roles.Restore",
+            // kurtto system
+            "perm:Kurtto.Create", "perm:Kurtto.Read", "perm:Kurtto.Update", "perm:Kurtto.Delete", "perm:Kurtto.Restore"
+        };
+
+        foreach (var code in expected)
+            Assert.Contains(code, body.PermissionCodes);
+
+        // Garante que todo code segue o formato perm:<Recurso>.<Acao>
+        foreach (var code in body.PermissionCodes)
+            Assert.StartsWith("perm:", code, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task VerifyToken_UserWithoutPermissions_ReturnsEmptyPermissionCodes()
+    {
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "No Perms", email = "no.perms@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        var login = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            LoginBody("no.perms@example.com", "SenhaSegura1!"), TestApiClient.JsonOptions);
+        var loginDto = await login.Content.ReadFromJsonAsync<LoginResponseDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(loginDto);
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        var response = await _anon.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<VerifyDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(body);
+        Assert.NotNull(body.PermissionCodes);
+        Assert.Empty(body.PermissionCodes);
+        // Permissions e RouteCodes mantem comportamento atual (presentes no payload).
+        Assert.NotNull(body.Permissions);
+        Assert.NotNull(body.RouteCodes);
+    }
+
+    [Fact]
+    public async Task VerifyToken_UserWithOnlyKurttoRead_ReturnsKurttoReadCodeOnly()
+    {
+        // Cria usuario sem role
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "Kurtto Reader", email = "kurtto.reader@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        // Concede apenas a permissao kurtto+read direto ao usuario
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var user = await db.Users.AsNoTracking().FirstAsync(u => u.Email == "kurtto.reader@example.com");
+            var kurttoReadId = await db.Permissions.AsNoTracking()
+                .Where(p => p.SystemId == db.Systems.Where(s => s.Code == "kurtto").Select(s => s.Id).First()
+                    && p.PermissionTypeId == db.PermissionTypes.Where(t => t.Code == "read").Select(t => t.Id).First())
+                .Select(p => p.Id)
+                .FirstAsync();
+
+            db.UserPermissions.Add(new AuthService.Models.AppUserPermission
+            {
+                UserId = user.Id,
+                PermissionId = kurttoReadId,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                DeletedAt = null
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var login = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            LoginBody("kurtto.reader@example.com", "SenhaSegura1!"), TestApiClient.JsonOptions);
+        var loginDto = await login.Content.ReadFromJsonAsync<LoginResponseDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(loginDto);
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        var response = await _anon.SendAsync(req);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<VerifyDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(body);
+        Assert.NotNull(body.PermissionCodes);
+        Assert.Equal(new[] { "perm:Kurtto.Read" }, body.PermissionCodes);
+        // Nao expoe codes de outros recursos (Users.Read etc.) — kurtto e isolado.
+        Assert.DoesNotContain("perm:Users.Read", body.PermissionCodes);
     }
 
     [Fact]

--- a/AuthService.Tests/AuthApiTests.cs
+++ b/AuthService.Tests/AuthApiTests.cs
@@ -43,7 +43,7 @@ public class AuthApiTests : IAsyncLifetime
 
     private object LoginBody(string email, string password) => new { email, password, systemId = _kurttoSystemId };
 
-    private object LoginBodyForSystem(string email, string password, Guid systemId) =>
+    private static object LoginBodyForSystem(string email, string password, Guid systemId) =>
         new { email, password, systemId };
 
     private sealed class LoginResponseDto

--- a/AuthService.Tests/AuthApiTests.cs
+++ b/AuthService.Tests/AuthApiTests.cs
@@ -15,6 +15,7 @@ namespace AuthService.Tests;
 public class AuthApiTests : IAsyncLifetime
 {
     private const string TestJwtSecret = "integration-tests-jwt-secret-key-32chars!!";
+    private static readonly string[] ExpectedKurttoReadOnlyCodes = new[] { "perm:Kurtto.Read" };
     private WebAppFactory _factory = null!;
     private HttpClient _admin = null!;
     private HttpClient _anon = null!;
@@ -288,7 +289,7 @@ public class AuthApiTests : IAsyncLifetime
         var body = await response.Content.ReadFromJsonAsync<VerifyDto>(TestApiClient.JsonOptions);
         Assert.NotNull(body);
         Assert.NotNull(body.PermissionCodes);
-        Assert.Equal(new[] { "perm:Kurtto.Read" }, body.PermissionCodes);
+        Assert.Equal(ExpectedKurttoReadOnlyCodes, body.PermissionCodes);
         // Nao expoe codes de outros recursos (Users.Read etc.) — kurtto e isolado.
         Assert.DoesNotContain("perm:Users.Read", body.PermissionCodes);
     }

--- a/AuthService.Tests/AuthApiTests.cs
+++ b/AuthService.Tests/AuthApiTests.cs
@@ -4,7 +4,9 @@ using System.Net.Http.Json;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using AuthService.Controllers.Auth;
 using AuthService.Data;
+using AuthService.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,12 +21,16 @@ public class AuthApiTests : IAsyncLifetime
     private WebAppFactory _factory = null!;
     private HttpClient _admin = null!;
     private HttpClient _anon = null!;
+    private Guid _kurttoSystemId;
+    private Guid _authenticatorSystemId;
 
     public async Task InitializeAsync()
     {
         _factory = new WebAppFactory();
         _admin = await TestApiClient.CreateAuthenticatedAsync(_factory);
         _anon = _factory.CreateApiClient();
+        _kurttoSystemId = await TestApiClient.GetSystemIdAsync(_factory, "kurtto");
+        _authenticatorSystemId = await TestApiClient.GetSystemIdAsync(_factory, "authenticator");
     }
 
     public Task DisposeAsync()
@@ -35,7 +41,10 @@ public class AuthApiTests : IAsyncLifetime
         return Task.CompletedTask;
     }
 
-    private static object LoginBody(string email, string password) => new { email, password };
+    private object LoginBody(string email, string password) => new { email, password, systemId = _kurttoSystemId };
+
+    private object LoginBodyForSystem(string email, string password, Guid systemId) =>
+        new { email, password, systemId };
 
     private sealed class LoginResponseDto
     {
@@ -135,8 +144,9 @@ public class AuthApiTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task VerifyToken_WithoutHeader_ReturnsUnauthorized()
+    public async Task VerifyToken_WithoutBearer_ReturnsUnauthorized()
     {
+        // Sem Authorization e sem X-System-Id: o pipeline de autenticação roda primeiro e devolve 401.
         var response = await _anon.GetAsync("/api/v1/auth/verify-token");
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -155,6 +165,7 @@ public class AuthApiTests : IAsyncLifetime
 
         using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        req.Headers.Add(AuthController.SystemIdHeader, _kurttoSystemId.ToString("D"));
         var response = await _anon.SendAsync(req);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -234,6 +245,7 @@ public class AuthApiTests : IAsyncLifetime
 
         using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        req.Headers.Add(AuthController.SystemIdHeader, _kurttoSystemId.ToString("D"));
         var response = await _anon.SendAsync(req);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -283,6 +295,7 @@ public class AuthApiTests : IAsyncLifetime
 
         using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        req.Headers.Add(AuthController.SystemIdHeader, _kurttoSystemId.ToString("D"));
         var response = await _anon.SendAsync(req);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -317,6 +330,7 @@ public class AuthApiTests : IAsyncLifetime
         using (var verifyReq = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token"))
         {
             verifyReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            verifyReq.Headers.Add(AuthController.SystemIdHeader, _kurttoSystemId.ToString("D"));
             var verifyRes = await _anon.SendAsync(verifyReq);
             Assert.Equal(HttpStatusCode.Unauthorized, verifyRes.StatusCode);
         }
@@ -385,11 +399,13 @@ public class AuthApiTests : IAsyncLifetime
             {
                 ["sub"] = Guid.NewGuid().ToString("D"),
                 ["tv"] = 0,
+                ["sys"] = _kurttoSystemId.ToString("D"),
                 ["exp"] = DateTimeOffset.UtcNow.AddMinutes(-5).ToUnixTimeSeconds()
             });
 
         using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        req.Headers.Add(AuthController.SystemIdHeader, _kurttoSystemId.ToString("D"));
         var response = await _anon.SendAsync(req);
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -403,11 +419,13 @@ public class AuthApiTests : IAsyncLifetime
             {
                 ["sub"] = Guid.NewGuid().ToString("D"),
                 ["tv"] = 0,
+                ["sys"] = _kurttoSystemId.ToString("D"),
                 ["exp"] = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds()
             });
 
         using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        req.Headers.Add(AuthController.SystemIdHeader, _kurttoSystemId.ToString("D"));
         var response = await _anon.SendAsync(req);
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -420,11 +438,13 @@ public class AuthApiTests : IAsyncLifetime
             new Dictionary<string, object>
             {
                 ["tv"] = 0,
+                ["sys"] = _kurttoSystemId.ToString("D"),
                 ["exp"] = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds()
             });
 
         using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        req.Headers.Add(AuthController.SystemIdHeader, _kurttoSystemId.ToString("D"));
         var response = await _anon.SendAsync(req);
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -437,11 +457,13 @@ public class AuthApiTests : IAsyncLifetime
             new Dictionary<string, object>
             {
                 ["sub"] = Guid.NewGuid().ToString("D"),
+                ["sys"] = _kurttoSystemId.ToString("D"),
                 ["exp"] = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds()
             });
 
         using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        req.Headers.Add(AuthController.SystemIdHeader, _kurttoSystemId.ToString("D"));
         var response = await _anon.SendAsync(req);
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -472,6 +494,289 @@ public class AuthApiTests : IAsyncLifetime
         var response = await _anon.SendAsync(req);
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WithoutSystemId_ReturnsBadRequest()
+    {
+        // Cria usuário válido para garantir que o 400 vem do systemId, não do email/senha.
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "NoSys User", email = "nosys@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        var response = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            new { email = "nosys@example.com", password = "SenhaSegura1!" },
+            TestApiClient.JsonOptions);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WithEmptySystemId_ReturnsBadRequest()
+    {
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "EmptySys User", email = "emptysys@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        var response = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            new { email = "emptysys@example.com", password = "SenhaSegura1!", systemId = Guid.Empty },
+            TestApiClient.JsonOptions);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WithUnknownSystemId_ReturnsBadRequest()
+    {
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "Unknown User", email = "unknown.sys@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        var response = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            new { email = "unknown.sys@example.com", password = "SenhaSegura1!", systemId = Guid.NewGuid() },
+            TestApiClient.JsonOptions);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WithDeletedSystemId_ReturnsBadRequest()
+    {
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "Del Sys User", email = "del.sys@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        // Cria sistema novo e marca como deletado (soft-delete = inativo).
+        Guid deletedSystemId;
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var now = DateTime.UtcNow;
+            var system = new AppSystem
+            {
+                Name = "Sistema Inativo",
+                Code = "sistema-inativo-test",
+                CreatedAt = now,
+                UpdatedAt = now,
+                DeletedAt = now
+            };
+            db.Systems.Add(system);
+            await db.SaveChangesAsync();
+            deletedSystemId = system.Id;
+        }
+
+        var response = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            new { email = "del.sys@example.com", password = "SenhaSegura1!", systemId = deletedSystemId },
+            TestApiClient.JsonOptions);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WithValidSystemId_ReturnsToken_AndJwtCarriesSysClaim()
+    {
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "Sys OK User", email = "sys.ok@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        var response = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            new { email = "sys.ok@example.com", password = "SenhaSegura1!", systemId = _kurttoSystemId },
+            TestApiClient.JsonOptions);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var dto = await response.Content.ReadFromJsonAsync<LoginResponseDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto);
+
+        var payload = ReadJwtPayload(dto.Token);
+        Assert.Equal(_kurttoSystemId.ToString("D"), payload.GetProperty("sys").GetString());
+    }
+
+    [Fact]
+    public async Task VerifyToken_WithoutXSystemIdHeader_ReturnsBadRequest()
+    {
+        // Token válido (claim sys preenchida) mas sem header X-System-Id.
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "VTok NoHdr", email = "vtok.nohdr@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        var login = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            LoginBody("vtok.nohdr@example.com", "SenhaSegura1!"), TestApiClient.JsonOptions);
+        var loginDto = await login.Content.ReadFromJsonAsync<LoginResponseDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(loginDto);
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        var response = await _anon.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task VerifyToken_WithMalformedXSystemIdHeader_ReturnsBadRequest()
+    {
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "VTok Bad Hdr", email = "vtok.badhdr@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        var login = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            LoginBody("vtok.badhdr@example.com", "SenhaSegura1!"), TestApiClient.JsonOptions);
+        var loginDto = await login.Content.ReadFromJsonAsync<LoginResponseDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(loginDto);
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        req.Headers.Add(AuthController.SystemIdHeader, "not-a-guid");
+        var response = await _anon.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task VerifyToken_WithUnknownSystemIdHeader_ReturnsBadRequest()
+    {
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "VTok Unk", email = "vtok.unk@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        var login = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            LoginBody("vtok.unk@example.com", "SenhaSegura1!"), TestApiClient.JsonOptions);
+        var loginDto = await login.Content.ReadFromJsonAsync<LoginResponseDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(loginDto);
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        req.Headers.Add(AuthController.SystemIdHeader, Guid.NewGuid().ToString("D"));
+        var response = await _anon.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task VerifyToken_WithDeletedSystemIdHeader_ReturnsBadRequest()
+    {
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "VTok Del", email = "vtok.del@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        var login = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            LoginBody("vtok.del@example.com", "SenhaSegura1!"), TestApiClient.JsonOptions);
+        var loginDto = await login.Content.ReadFromJsonAsync<LoginResponseDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(loginDto);
+
+        // Cria e marca como deletado um sistema cujo Id será usado no header.
+        Guid deletedSystemId;
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var now = DateTime.UtcNow;
+            var system = new AppSystem
+            {
+                Name = "Inativo VTok",
+                Code = "inativo-vtok",
+                CreatedAt = now,
+                UpdatedAt = now,
+                DeletedAt = now
+            };
+            db.Systems.Add(system);
+            await db.SaveChangesAsync();
+            deletedSystemId = system.Id;
+        }
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        req.Headers.Add(AuthController.SystemIdHeader, deletedSystemId.ToString("D"));
+        var response = await _anon.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task VerifyToken_CrossSystemToken_ReturnsUnauthorized()
+    {
+        // Login no sistema kurtto e tenta verify com header X-System-Id apontando pro sistema authenticator.
+        await _admin.PostAsJsonAsync("/api/v1/users",
+            new { name = "Cross Sys User", email = "cross.sys@example.com", password = "SenhaSegura1!", identity = 1, active = true },
+            TestApiClient.JsonOptions);
+
+        var login = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            LoginBodyForSystem("cross.sys@example.com", "SenhaSegura1!", _kurttoSystemId), TestApiClient.JsonOptions);
+        var loginDto = await login.Content.ReadFromJsonAsync<LoginResponseDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(loginDto);
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        req.Headers.Add(AuthController.SystemIdHeader, _authenticatorSystemId.ToString("D"));
+        var response = await _anon.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task VerifyToken_AuthenticatorSystem_ReturnsEmptyRouteCodes_NotKurttoCodes()
+    {
+        // Root user tem todas as permissões (incluindo authenticator e kurtto).
+        // Quando faz login em authenticator, verify-token deve devolver routeCodes vazio
+        // (authenticator não declara rotas seedadas), em vez das rotas do kurtto.
+        var login = await _anon.PostAsJsonAsync("/api/v1/auth/login",
+            LoginBodyForSystem(DefaultSystemUserSeeder.RootEmail, DefaultSystemUserSeeder.ResolveCredential(), _authenticatorSystemId),
+            TestApiClient.JsonOptions);
+        var loginDto = await login.Content.ReadFromJsonAsync<LoginResponseDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(loginDto);
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        req.Headers.Add(AuthController.SystemIdHeader, _authenticatorSystemId.ToString("D"));
+        var response = await _anon.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<VerifyDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(body);
+        Assert.NotNull(body.RouteCodes);
+        Assert.Empty(body.RouteCodes);
+        // Codes do kurtto NÃO devem aparecer quando o sistema solicitado é authenticator.
+        Assert.DoesNotContain("KURTTO_V1_URLS_LIST_INCLUDE_DELETED", body.RouteCodes);
+        Assert.DoesNotContain("KURTTO_V1_URLS_GET_BY_CODE_INCLUDE_DELETED", body.RouteCodes);
+        Assert.DoesNotContain("KURTTO_V1_URLS_PATCH_RESTORE", body.RouteCodes);
+    }
+
+    [Fact]
+    public async Task VerifyToken_TokenWithoutSysClaim_ReturnsUnauthorized()
+    {
+        // Token forjado sem claim sys deve falhar na autenticação (handler exige sys).
+        var token = CreateHs256Token(
+            TestJwtSecret,
+            new Dictionary<string, object>
+            {
+                ["sub"] = Guid.NewGuid().ToString("D"),
+                ["tv"] = 0,
+                ["exp"] = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds()
+            });
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        req.Headers.Add(AuthController.SystemIdHeader, _kurttoSystemId.ToString("D"));
+        var response = await _anon.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    private static JsonElement ReadJwtPayload(string token)
+    {
+        var parts = token.Split('.');
+        Assert.Equal(3, parts.Length);
+        var jsonBytes = Base64UrlDecode(parts[1]);
+        using var doc = JsonDocument.Parse(jsonBytes);
+        return doc.RootElement.Clone();
+    }
+
+    private static byte[] Base64UrlDecode(string input)
+    {
+        var base64 = input.Replace('-', '+').Replace('_', '/');
+        var pad = 4 - (base64.Length % 4);
+        if (pad is > 0 and < 4)
+            base64 += new string('=', pad);
+
+        return Convert.FromBase64String(base64);
     }
 
     private static string CreateHs256Token(string secret, IDictionary<string, object> payload)

--- a/AuthService.Tests/DefaultSystemUserSeederTests.cs
+++ b/AuthService.Tests/DefaultSystemUserSeederTests.cs
@@ -114,6 +114,106 @@ public class DefaultSystemUserSeederTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task RootUser_RoleHasAllCatalogPermissions_AcrossAllSystems()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var rootEmail = DefaultSystemUserSeeder.RootEmail.Trim().ToLowerInvariant();
+        var rootRoleCode = DefaultSystemUserSeeder.RootRoleCode;
+
+        var rootUserId = await db.Users.AsNoTracking()
+            .Where(u => u.Email == rootEmail)
+            .Select(u => u.Id)
+            .SingleAsync();
+
+        var rootRoleId = await db.Roles.AsNoTracking()
+            .Where(r => r.Code == rootRoleCode)
+            .Select(r => r.Id)
+            .SingleAsync();
+
+        var userRoleLink = await db.UserRoles.AsNoTracking()
+            .CountAsync(ur => ur.UserId == rootUserId && ur.RoleId == rootRoleId);
+        Assert.Equal(1, userRoleLink);
+
+        var allPermissionIds = await db.Permissions.AsNoTracking()
+            .Select(p => p.Id)
+            .OrderBy(id => id)
+            .ToListAsync();
+
+        var rolePermissionIds = await db.RolePermissions.AsNoTracking()
+            .Where(rp => rp.RoleId == rootRoleId)
+            .Select(rp => rp.PermissionId)
+            .OrderBy(id => id)
+            .ToListAsync();
+
+        Assert.Equal(allPermissionIds, rolePermissionIds);
+
+        var systemCodesCovered = await db.RolePermissions.AsNoTracking()
+            .Where(rp => rp.RoleId == rootRoleId)
+            .Join(
+                db.Permissions.AsNoTracking(),
+                rp => rp.PermissionId,
+                p => p.Id,
+                (_, p) => p.SystemId)
+            .Join(
+                db.Systems.AsNoTracking(),
+                systemId => systemId,
+                s => s.Id,
+                (_, s) => s.Code)
+            .Distinct()
+            .OrderBy(c => c)
+            .ToListAsync();
+
+        Assert.Contains("authenticator", systemCodesCovered);
+        Assert.Contains("kurtto", systemCodesCovered);
+    }
+
+    [Fact]
+    public async Task EnsureSystemUsersAsync_Idempotent_DoesNotDuplicateOrRemoveRolePermissions()
+    {
+        Guid rootRoleId;
+        int permissionCountBefore;
+
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            rootRoleId = await db.Roles.AsNoTracking()
+                .Where(r => r.Code == DefaultSystemUserSeeder.RootRoleCode)
+                .Select(r => r.Id)
+                .SingleAsync();
+            permissionCountBefore = await db.RolePermissions.AsNoTracking()
+                .CountAsync(rp => rp.RoleId == rootRoleId);
+        }
+
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            await DefaultSystemUserSeeder.EnsureSystemUsersAsync(db);
+            await DefaultSystemUserSeeder.EnsureSystemUsersAsync(db);
+        }
+
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var permissionCountAfter = await db.RolePermissions.IgnoreQueryFilters()
+                .CountAsync(rp => rp.RoleId == rootRoleId);
+            Assert.Equal(permissionCountBefore, permissionCountAfter);
+
+            var allPermissionIds = await db.Permissions.AsNoTracking()
+                .Select(p => p.Id)
+                .OrderBy(id => id)
+                .ToListAsync();
+            var rolePermissionIds = await db.RolePermissions.AsNoTracking()
+                .Where(rp => rp.RoleId == rootRoleId)
+                .Select(rp => rp.PermissionId)
+                .OrderBy(id => id)
+                .ToListAsync();
+            Assert.Equal(allPermissionIds, rolePermissionIds);
+        }
+    }
+
+    [Fact]
     public void ResolveCredential_WhenEnvVarIsSet_ReturnsValue()
     {
         var credential = DefaultSystemUserSeeder.ResolveCredential();

--- a/AuthService.Tests/DefaultSystemUserSeederTests.cs
+++ b/AuthService.Tests/DefaultSystemUserSeederTests.cs
@@ -40,6 +40,8 @@ public class DefaultSystemUserSeederTests : IAsyncLifetime
     [Fact]
     public async Task SystemUsers_ExistAfterBootstrap_CanLoginWithSeededCredentials()
     {
+        var systemId = await TestApiClient.GetSystemIdAsync(_factory, TestApiClient.DefaultSystemCode);
+
         var cases = new[]
         {
             new { Email = DefaultSystemUserSeeder.RootEmail, Password = DefaultSystemUserSeeder.ResolveCredential() },
@@ -50,7 +52,7 @@ public class DefaultSystemUserSeederTests : IAsyncLifetime
         foreach (var c in cases)
         {
             var response = await _client.PostAsJsonAsync("/api/v1/auth/login",
-                new { email = c.Email, password = c.Password },
+                new { email = c.Email, password = c.Password, systemId },
                 TestApiClient.JsonOptions);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/AuthService.Tests/JwtTokenServiceUnitTests.cs
+++ b/AuthService.Tests/JwtTokenServiceUnitTests.cs
@@ -19,7 +19,7 @@ public class JwtTokenServiceUnitTests
 
         Assert.Throws<InvalidOperationException>(() =>
         {
-            service.CreateAccessToken(Guid.NewGuid(), 1, out _);
+            service.CreateAccessToken(Guid.NewGuid(), 1, Guid.NewGuid(), out _);
         });
     }
 
@@ -34,7 +34,7 @@ public class JwtTokenServiceUnitTests
         var service = new JwtTokenService(options);
         var now = DateTimeOffset.UtcNow;
 
-        _ = service.CreateAccessToken(Guid.NewGuid(), 3, out var expiresAt);
+        _ = service.CreateAccessToken(Guid.NewGuid(), 3, Guid.NewGuid(), out var expiresAt);
 
         var minutes = (expiresAt - now).TotalMinutes;
         Assert.InRange(minutes, 59, 61);
@@ -44,6 +44,7 @@ public class JwtTokenServiceUnitTests
     public void CreateAccessToken_EmbedsExpectedClaims()
     {
         var userId = Guid.NewGuid();
+        var systemId = Guid.NewGuid();
         const int tokenVersion = 7;
         var options = Options.Create(new JwtOptions
         {
@@ -52,11 +53,12 @@ public class JwtTokenServiceUnitTests
         });
         var service = new JwtTokenService(options);
 
-        var token = service.CreateAccessToken(userId, tokenVersion, out _);
+        var token = service.CreateAccessToken(userId, tokenVersion, systemId, out _);
         var payload = ReadJwtPayload(token);
 
         Assert.Equal(userId.ToString("D"), payload.GetProperty("sub").GetString());
         Assert.Equal(tokenVersion, payload.GetProperty("tv").GetInt32());
+        Assert.Equal(systemId.ToString("D"), payload.GetProperty("sys").GetString());
         Assert.True(payload.GetProperty("exp").GetInt64() > 0);
         Assert.True(payload.GetProperty("iat").GetInt64() > 0);
     }

--- a/AuthService.Tests/OfficialCatalogSeederTests.cs
+++ b/AuthService.Tests/OfficialCatalogSeederTests.cs
@@ -1,0 +1,142 @@
+using AuthService.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AuthService.Tests;
+
+/// <summary>
+/// Valida o estado final do catálogo oficial após o bootstrap dos seeds: sistemas,
+/// tipos de permissão e o produto cartesiano de permissões esperado, além da idempotência
+/// de re-execução. Cobre os critérios de aceite da issue #143 (catálogo cobre
+/// <c>authenticator</c> + <c>kurtto</c> com todos os tipos CRUD/Restore).
+/// </summary>
+public class OfficialCatalogSeederTests : IAsyncLifetime
+{
+    private static readonly string[] ExpectedSystemCodes = { "authenticator", "kurtto" };
+
+    private static readonly string[] ExpectedPermissionTypeCodes =
+        { "create", "read", "update", "delete", "restore" };
+
+    private WebAppFactory _factory = null!;
+
+    public Task InitializeAsync()
+    {
+        _factory = new WebAppFactory();
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _factory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task AfterBootstrap_AllExpectedSystemsExist()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var systemCodes = await db.Systems.AsNoTracking()
+            .Select(s => s.Code)
+            .OrderBy(c => c)
+            .ToListAsync();
+
+        foreach (var expected in ExpectedSystemCodes)
+            Assert.Contains(expected, systemCodes);
+    }
+
+    [Fact]
+    public async Task AfterBootstrap_AllExpectedPermissionTypesExist()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var typeCodes = await db.PermissionTypes.AsNoTracking()
+            .Select(t => t.Code)
+            .OrderBy(c => c)
+            .ToListAsync();
+
+        foreach (var expected in ExpectedPermissionTypeCodes)
+            Assert.Contains(expected, typeCodes);
+    }
+
+    [Fact]
+    public async Task AfterBootstrap_PermissionsCoverFullCartesianProductForExpectedSystems()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var pairs = await db.Permissions.AsNoTracking()
+            .Join(
+                db.Systems.AsNoTracking(),
+                p => p.SystemId,
+                s => s.Id,
+                (p, s) => new { p.PermissionTypeId, SystemCode = s.Code })
+            .Join(
+                db.PermissionTypes.AsNoTracking(),
+                x => x.PermissionTypeId,
+                t => t.Id,
+                (x, t) => new { x.SystemCode, TypeCode = t.Code })
+            .ToListAsync();
+
+        foreach (var systemCode in ExpectedSystemCodes)
+        {
+            foreach (var typeCode in ExpectedPermissionTypeCodes)
+            {
+                Assert.Contains(
+                    pairs,
+                    p => p.SystemCode == systemCode && p.TypeCode == typeCode);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task EnsureCatalogAsync_Idempotent_DoesNotDuplicateSystemsTypesOrPermissions()
+    {
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            await OfficialCatalogSeeder.EnsureCatalogAsync(db);
+            await OfficialCatalogSeeder.EnsureCatalogAsync(db);
+        }
+
+        await using var verifyScope = _factory.Services.CreateAsyncScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        foreach (var systemCode in ExpectedSystemCodes)
+        {
+            var systemCount = await verifyDb.Systems.IgnoreQueryFilters()
+                .CountAsync(s => s.Code == systemCode);
+            Assert.Equal(1, systemCount);
+        }
+
+        foreach (var typeCode in ExpectedPermissionTypeCodes)
+        {
+            var typeCount = await verifyDb.PermissionTypes.IgnoreQueryFilters()
+                .CountAsync(t => t.Code == typeCode);
+            Assert.Equal(1, typeCount);
+        }
+
+        foreach (var systemCode in ExpectedSystemCodes)
+        {
+            var systemId = await verifyDb.Systems.AsNoTracking()
+                .Where(s => s.Code == systemCode)
+                .Select(s => s.Id)
+                .SingleAsync();
+
+            foreach (var typeCode in ExpectedPermissionTypeCodes)
+            {
+                var typeId = await verifyDb.PermissionTypes.AsNoTracking()
+                    .Where(t => t.Code == typeCode)
+                    .Select(t => t.Id)
+                    .SingleAsync();
+
+                var permCount = await verifyDb.Permissions.IgnoreQueryFilters()
+                    .CountAsync(p => p.SystemId == systemId && p.PermissionTypeId == typeId);
+                Assert.Equal(1, permCount);
+            }
+        }
+    }
+}

--- a/AuthService.Tests/PermissionCatalogUnitTests.cs
+++ b/AuthService.Tests/PermissionCatalogUnitTests.cs
@@ -1,0 +1,37 @@
+using AuthService.Auth;
+using Xunit;
+
+namespace AuthService.Tests;
+
+public class PermissionCatalogUnitTests
+{
+    [Fact]
+    public void GetResourcesForSystem_WithAuthenticator_ReturnsAllResourcesInOrdinalOrder()
+    {
+        var resources = PermissionCatalog.GetResourcesForSystem("authenticator");
+
+        var expected = new[]
+        {
+            "Clients",
+            "Permissions",
+            "PermissionsTypes",
+            "Roles",
+            "SystemTokensTypes",
+            "Systems",
+            "SystemsRoutes",
+            "Users"
+        };
+
+        Assert.Equal(expected, resources);
+        Assert.Equal(8, resources.Count);
+    }
+
+    [Fact]
+    public void GetResourcesForSystem_WithUnknownSystem_ReturnsEmptyArray()
+    {
+        var resources = PermissionCatalog.GetResourcesForSystem("inexistente");
+
+        Assert.Same(Array.Empty<string>(), resources);
+        Assert.Empty(resources);
+    }
+}

--- a/AuthService.Tests/PermissionCodeFormatterUnitTests.cs
+++ b/AuthService.Tests/PermissionCodeFormatterUnitTests.cs
@@ -1,0 +1,63 @@
+using AuthService.Auth;
+using Xunit;
+
+namespace AuthService.Tests;
+
+public class PermissionCodeFormatterUnitTests
+{
+    [Fact]
+    public void Format_WithUppercaseTypeCode_ReturnsPascalCaseCode()
+    {
+        var code = PermissionCodeFormatter.Format("Users", "READ");
+
+        Assert.Equal("perm:Users.Read", code);
+    }
+
+    [Fact]
+    public void Format_WithLowercaseTypeCode_ReturnsPascalCaseCode()
+    {
+        var code = PermissionCodeFormatter.Format("Users", "read");
+
+        Assert.Equal("perm:Users.Read", code);
+    }
+
+    [Fact]
+    public void Format_WithMixedCaseTypeCode_ReturnsPascalCaseCode()
+    {
+        var code = PermissionCodeFormatter.Format("SystemsRoutes", "CrEaTe");
+
+        Assert.Equal("perm:SystemsRoutes.Create", code);
+    }
+
+    [Fact]
+    public void Format_WithNullResource_ThrowsArgumentException()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => PermissionCodeFormatter.Format(null!, "read"));
+
+        Assert.Equal("resourcePascal", ex.ParamName);
+    }
+
+    [Fact]
+    public void Format_WithEmptyResource_ThrowsArgumentException()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => PermissionCodeFormatter.Format(string.Empty, "read"));
+
+        Assert.Equal("resourcePascal", ex.ParamName);
+    }
+
+    [Fact]
+    public void Format_WithEmptyTypeCode_ThrowsArgumentException()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => PermissionCodeFormatter.Format("Users", string.Empty));
+
+        Assert.Equal("typeCode", ex.ParamName);
+    }
+
+    [Fact]
+    public void Format_WithWhitespaceTypeCode_ThrowsArgumentException()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => PermissionCodeFormatter.Format("Users", "  "));
+
+        Assert.Equal("typeCode", ex.ParamName);
+    }
+}

--- a/AuthService.Tests/TestApiClient.cs
+++ b/AuthService.Tests/TestApiClient.cs
@@ -1,13 +1,19 @@
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
+using AuthService.Controllers.Auth;
 using AuthService.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace AuthService.Tests;
 
 internal static class TestApiClient
 {
+    /// <summary>Code do sistema usado por padrão nos testes de Auth (catálogo oficial seeda kurtto).</summary>
+    internal const string DefaultSystemCode = "kurtto";
+
     internal static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -19,17 +25,41 @@ internal static class TestApiClient
         public string Token { get; set; } = string.Empty;
     }
 
-    /// <summary>Cliente HTTP com JWT do usuário root seedado (todas as permissões oficiais).</summary>
-    internal static async Task<HttpClient> CreateAuthenticatedAsync(WebAppFactory factory)
+    /// <summary>
+    /// Recupera o systemId de um sistema do catálogo oficial pelo Code (lança se não existir).
+    /// </summary>
+    internal static async Task<Guid> GetSystemIdAsync(WebAppFactory factory, string systemCode)
     {
+        await using var scope = factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        return await db.Systems.AsNoTracking()
+            .Where(s => s.Code == systemCode)
+            .Select(s => s.Id)
+            .SingleAsync();
+    }
+
+    /// <summary>Cliente HTTP com JWT do usuário root seedado (todas as permissões oficiais), atrelado ao sistema kurtto e com header X-System-Id já configurado.</summary>
+    internal static async Task<HttpClient> CreateAuthenticatedAsync(WebAppFactory factory)
+        => await CreateAuthenticatedAsync(factory, DefaultSystemCode);
+
+    /// <summary>Cliente HTTP com JWT do usuário root seedado, atrelado ao sistema indicado por <paramref name="systemCode"/> e com header X-System-Id já configurado.</summary>
+    internal static async Task<HttpClient> CreateAuthenticatedAsync(WebAppFactory factory, string systemCode)
+    {
+        var systemId = await GetSystemIdAsync(factory, systemCode);
         var client = factory.CreateApiClient();
         var login = await client.PostAsJsonAsync("/api/v1/auth/login",
-            new { email = DefaultSystemUserSeeder.RootEmail, password = DefaultSystemUserSeeder.ResolveCredential() },
+            new
+            {
+                email = DefaultSystemUserSeeder.RootEmail,
+                password = DefaultSystemUserSeeder.ResolveCredential(),
+                systemId
+            },
             JsonOptions);
         login.EnsureSuccessStatusCode();
         var dto = await login.Content.ReadFromJsonAsync<LoginDto>(JsonOptions);
         Assert.NotNull(dto);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", dto.Token);
+        client.DefaultRequestHeaders.Add(AuthController.SystemIdHeader, systemId.ToString("D"));
         return client;
     }
 }

--- a/AuthService.Tests/UsersApiTests.cs
+++ b/AuthService.Tests/UsersApiTests.cs
@@ -303,13 +303,14 @@ public class UsersApiTests : IAsyncLifetime
             new { password = "NovaSenhaSegura2!" }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.OK, putPwd.StatusCode);
 
+        var systemId = await TestApiClient.GetSystemIdAsync(_factory, TestApiClient.DefaultSystemCode);
         var anon = _factory.CreateApiClient();
         var oldLogin = await anon.PostAsJsonAsync("/api/v1/auth/login",
-            new { email = "pwd.change@example.com", password = "SenhaSegura1!" }, TestApiClient.JsonOptions);
+            new { email = "pwd.change@example.com", password = "SenhaSegura1!", systemId }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Unauthorized, oldLogin.StatusCode);
 
         var newLogin = await anon.PostAsJsonAsync("/api/v1/auth/login",
-            new { email = "pwd.change@example.com", password = "NovaSenhaSegura2!" }, TestApiClient.JsonOptions);
+            new { email = "pwd.change@example.com", password = "NovaSenhaSegura2!", systemId }, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.OK, newLogin.StatusCode);
     }
 

--- a/AuthService/Auth/IJwtTokenService.cs
+++ b/AuthService/Auth/IJwtTokenService.cs
@@ -2,6 +2,9 @@ namespace AuthService.Auth;
 
 public interface IJwtTokenService
 {
-    /// <summary>Emite JWT com claims <c>sub</c> (user id) e <c>tv</c> (token version).</summary>
-    string CreateAccessToken(Guid userId, int tokenVersion, out DateTimeOffset expiresAt);
+    /// <summary>
+    /// Emite JWT com claims <c>sub</c> (user id), <c>tv</c> (token version) e
+    /// <c>sys</c> (system id de quem fez login — usado para amarrar o token a um sistema específico).
+    /// </summary>
+    string CreateAccessToken(Guid userId, int tokenVersion, Guid systemId, out DateTimeOffset expiresAt);
 }

--- a/AuthService/Auth/JwtBearerAuthenticationHandler.cs
+++ b/AuthService/Auth/JwtBearerAuthenticationHandler.cs
@@ -34,7 +34,11 @@ public sealed class JwtBearerAuthenticationHandler(
         if (payloadResult.Error is not null)
             return payloadResult.Error;
 
-        var claimExtraction = TryExtractIdentityClaims(payloadResult.Payload!, out var userId, out var tokenVersionClaim);
+        var claimExtraction = TryExtractIdentityClaims(
+            payloadResult.Payload!,
+            out var userId,
+            out var tokenVersionClaim,
+            out var systemIdClaim);
         if (claimExtraction is not null)
             return claimExtraction;
 
@@ -54,12 +58,19 @@ public sealed class JwtBearerAuthenticationHandler(
         {
             new(ClaimTypes.NameIdentifier, userId.ToString("D")),
             new(ClaimTypes.Email, user.Email),
-            new(ClaimTypes.Name, user.Name)
+            new(ClaimTypes.Name, user.Name),
+            new(SystemIdClaimType, systemIdClaim.ToString("D"))
         };
         var identity = new ClaimsIdentity(claims, Scheme.Name);
         var principal = new ClaimsPrincipal(identity);
         return AuthenticateResult.Success(new AuthenticationTicket(principal, Scheme.Name));
     }
+
+    /// <summary>
+    /// Tipo de claim que carrega o <c>systemId</c> do sistema que emitiu o token (claim <c>sys</c>).
+    /// Usado pelo verify-token para evitar uso cruzado de tokens entre sistemas distintos.
+    /// </summary>
+    public const string SystemIdClaimType = "sys";
 
     private AuthenticateResult? TryReadBearerToken(out string token)
     {
@@ -113,10 +124,12 @@ public sealed class JwtBearerAuthenticationHandler(
     private static AuthenticateResult? TryExtractIdentityClaims(
         IDictionary<string, object> payload,
         out Guid userId,
-        out int tokenVersionClaim)
+        out int tokenVersionClaim,
+        out Guid systemIdClaim)
     {
         userId = Guid.Empty;
         tokenVersionClaim = 0;
+        systemIdClaim = Guid.Empty;
 
         if (!payload.TryGetValue("sub", out var subObj) || subObj?.ToString() is not { } subStr
             || !Guid.TryParse(subStr, out userId))
@@ -124,6 +137,10 @@ public sealed class JwtBearerAuthenticationHandler(
 
         if (!payload.TryGetValue("tv", out var tvObj) || !TryGetInt32(tvObj, out tokenVersionClaim))
             return AuthenticateResult.Fail("Token sem versão de sessão válida.");
+
+        if (!payload.TryGetValue("sys", out var sysObj) || sysObj?.ToString() is not { } sysStr
+            || !Guid.TryParse(sysStr, out systemIdClaim))
+            return AuthenticateResult.Fail("Token sem identificador de sistema válido.");
 
         return null;
     }

--- a/AuthService/Auth/JwtTokenService.cs
+++ b/AuthService/Auth/JwtTokenService.cs
@@ -8,7 +8,7 @@ public sealed class JwtTokenService(IOptions<JwtOptions> options) : IJwtTokenSer
 {
     private readonly JwtOptions _options = options.Value;
 
-    public string CreateAccessToken(Guid userId, int tokenVersion, out DateTimeOffset expiresAt)
+    public string CreateAccessToken(Guid userId, int tokenVersion, Guid systemId, out DateTimeOffset expiresAt)
     {
         if (string.IsNullOrWhiteSpace(_options.Secret) || _options.Secret.Length < 32)
             throw new InvalidOperationException("Auth:Jwt:Secret deve ter pelo menos 32 caracteres.");
@@ -22,6 +22,7 @@ public sealed class JwtTokenService(IOptions<JwtOptions> options) : IJwtTokenSer
             .WithSecret(_options.Secret)
             .AddClaim("sub", userId.ToString("D"))
             .AddClaim("tv", tokenVersion)
+            .AddClaim("sys", systemId.ToString("D"))
             .AddClaim("exp", exp)
             .AddClaim("iat", DateTimeOffset.UtcNow.ToUnixTimeSeconds())
             .Encode();

--- a/AuthService/Auth/PermissionCatalog.cs
+++ b/AuthService/Auth/PermissionCatalog.cs
@@ -10,8 +10,8 @@ internal static class PermissionCatalog
     /// Fonte única de verdade compartilhada entre <see cref="PermissionResolver"/> e geração reversa
     /// de codes legíveis em <c>verify-token</c>.
     /// </summary>
-    private static readonly IReadOnlyDictionary<string, string> ResourceToSystem =
-        new Dictionary<string, string>(StringComparer.Ordinal)
+    private static readonly Dictionary<string, string> ResourceToSystem =
+        new(StringComparer.Ordinal)
         {
             ["Clients"] = AuthenticatorSystemCode,
             ["Users"] = AuthenticatorSystemCode,
@@ -24,7 +24,7 @@ internal static class PermissionCatalog
             ["Kurtto"] = KurttoSystemCode
         };
 
-    private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> ResourcesBySystem =
+    private static readonly Dictionary<string, IReadOnlyList<string>> ResourcesBySystem =
         ResourceToSystem
             .GroupBy(kvp => kvp.Value, StringComparer.Ordinal)
             .ToDictionary(

--- a/AuthService/Auth/PermissionCatalog.cs
+++ b/AuthService/Auth/PermissionCatalog.cs
@@ -5,25 +5,54 @@ internal static class PermissionCatalog
     private const string AuthenticatorSystemCode = "authenticator";
     private const string KurttoSystemCode = "kurtto";
 
+    /// <summary>
+    /// Mapeamento canônico recurso lógico (PascalCase) → código do sistema oficial.
+    /// Fonte única de verdade compartilhada entre <see cref="PermissionResolver"/> e geração reversa
+    /// de codes legíveis em <c>verify-token</c>.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> ResourceToSystem =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["Clients"] = AuthenticatorSystemCode,
+            ["Users"] = AuthenticatorSystemCode,
+            ["Systems"] = AuthenticatorSystemCode,
+            ["SystemsRoutes"] = AuthenticatorSystemCode,
+            ["SystemTokensTypes"] = AuthenticatorSystemCode,
+            ["Permissions"] = AuthenticatorSystemCode,
+            ["PermissionsTypes"] = AuthenticatorSystemCode,
+            ["Roles"] = AuthenticatorSystemCode,
+            ["Kurtto"] = KurttoSystemCode
+        };
+
+    private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> ResourcesBySystem =
+        ResourceToSystem
+            .GroupBy(kvp => kvp.Value, StringComparer.Ordinal)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<string>)g.Select(kvp => kvp.Key).OrderBy(r => r, StringComparer.Ordinal).ToArray(),
+                StringComparer.Ordinal);
+
     /// <summary>Mapeia o prefixo da chave (ex.: Users, SystemsRoutes) para o código do sistema no cadastro oficial.</summary>
     public static bool TryGetSystemCode(string resourcePascal, out string systemCode)
     {
-        systemCode = resourcePascal switch
+        if (ResourceToSystem.TryGetValue(resourcePascal, out var resolved))
         {
-            // Só existem 2 sistemas oficiais no catálogo: authenticator e kurtto.
-            // Estes nomes são recursos/políticas internos do sistema authenticator.
-            "Clients" => AuthenticatorSystemCode,
-            "Users" => AuthenticatorSystemCode,
-            "Systems" => AuthenticatorSystemCode,
-            "SystemsRoutes" => AuthenticatorSystemCode,
-            "SystemTokensTypes" => AuthenticatorSystemCode,
-            "Permissions" => AuthenticatorSystemCode,
-            "PermissionsTypes" => AuthenticatorSystemCode,
-            "Roles" => AuthenticatorSystemCode,
-            "Kurtto" => KurttoSystemCode,
-            _ => ""
-        };
+            systemCode = resolved;
+            return true;
+        }
 
-        return systemCode.Length > 0;
+        systemCode = string.Empty;
+        return false;
+    }
+
+    /// <summary>
+    /// Retorna a lista (ordenada) de recursos lógicos PascalCase associados a um <paramref name="systemCode"/>.
+    /// Devolve coleção vazia quando o sistema é desconhecido.
+    /// </summary>
+    public static IReadOnlyList<string> GetResourcesForSystem(string systemCode)
+    {
+        return ResourcesBySystem.TryGetValue(systemCode, out var resources)
+            ? resources
+            : Array.Empty<string>();
     }
 }

--- a/AuthService/Auth/PermissionCodeFormatter.cs
+++ b/AuthService/Auth/PermissionCodeFormatter.cs
@@ -1,0 +1,36 @@
+using System.Globalization;
+
+namespace AuthService.Auth;
+
+/// <summary>
+/// Formata codes legíveis de permissões no padrão <c>perm:&lt;Recurso&gt;.&lt;Acao&gt;</c>,
+/// consistente com as constantes de <see cref="PermissionPolicies"/>.
+/// </summary>
+internal static class PermissionCodeFormatter
+{
+    /// <summary>
+    /// Compõe a chave <c>perm:&lt;resourcePascal&gt;.&lt;PascalCase(typeCode)&gt;</c>.
+    /// </summary>
+    /// <param name="resourcePascal">Recurso lógico em PascalCase (ex.: <c>Users</c>, <c>SystemsRoutes</c>).</param>
+    /// <param name="typeCode">Código do tipo de permissão em minúsculas (ex.: <c>read</c>, <c>create</c>).</param>
+    public static string Format(string resourcePascal, string typeCode)
+    {
+        if (string.IsNullOrWhiteSpace(resourcePascal))
+            throw new ArgumentException("Recurso é obrigatório.", nameof(resourcePascal));
+        if (string.IsNullOrWhiteSpace(typeCode))
+            throw new ArgumentException("Tipo de permissão é obrigatório.", nameof(typeCode));
+
+        return string.Concat("perm:", resourcePascal, ".", ToPascalCase(typeCode));
+    }
+
+    private static string ToPascalCase(string value)
+    {
+        var trimmed = value.Trim();
+        if (trimmed.Length == 0)
+            return trimmed;
+
+        var lower = trimmed.ToLowerInvariant();
+        var first = char.ToUpper(lower[0], CultureInfo.InvariantCulture);
+        return lower.Length == 1 ? first.ToString() : string.Concat(first.ToString(), lower.AsSpan(1));
+    }
+}

--- a/AuthService/Auth/PermissionCodeFormatter.cs
+++ b/AuthService/Auth/PermissionCodeFormatter.cs
@@ -26,9 +26,6 @@ internal static class PermissionCodeFormatter
     private static string ToPascalCase(string value)
     {
         var trimmed = value.Trim();
-        if (trimmed.Length == 0)
-            return trimmed;
-
         var lower = trimmed.ToLowerInvariant();
         var first = char.ToUpper(lower[0], CultureInfo.InvariantCulture);
         return lower.Length == 1 ? first.ToString() : string.Concat(first.ToString(), lower.AsSpan(1));

--- a/AuthService/Controllers/Auth/AuthController.cs
+++ b/AuthService/Controllers/Auth/AuthController.cs
@@ -119,13 +119,13 @@ public partial class AuthController : ControllerBase
 
     [HttpGet("verify-token")]
     [Authorize(AuthenticationSchemes = BearerAuthenticationDefaults.AuthenticationScheme)]
-    public async Task<IActionResult> VerifyToken()
+    public async Task<IActionResult> VerifyToken(
+        [FromHeader(Name = SystemIdHeader)] string? systemIdHeader)
     {
-        if (!Request.Headers.TryGetValue(SystemIdHeader, out var headerValues)
-            || string.IsNullOrWhiteSpace(headerValues.ToString()))
+        if (string.IsNullOrWhiteSpace(systemIdHeader))
             return BadRequest(new { message = SystemIdHeaderRequiredMessage });
 
-        if (!Guid.TryParse(headerValues.ToString(), out var headerSystemId) || headerSystemId == Guid.Empty)
+        if (!Guid.TryParse(systemIdHeader, out var headerSystemId) || headerSystemId == Guid.Empty)
             return BadRequest(new { message = InvalidSystemIdMessage });
 
         var systemExists = await _db.Systems.AsNoTracking()

--- a/AuthService/Controllers/Auth/AuthController.cs
+++ b/AuthService/Controllers/Auth/AuthController.cs
@@ -16,6 +16,13 @@ public partial class AuthController : ControllerBase
     private const string InvalidCredentialsMessage = "Credenciais inválidas.";
     private const string InvalidTokenMessage = "Token inválido.";
     private const string UserNotFoundMessage = "Usuário não encontrado.";
+    private const string SystemIdRequiredMessage = "SystemId é obrigatório.";
+    private const string SystemIdHeaderRequiredMessage = "Header X-System-Id é obrigatório.";
+    private const string InvalidSystemIdMessage = "Sistema inválido ou inativo.";
+    private const string CrossSystemTokenMessage = "Token não é válido para este sistema.";
+
+    /// <summary>Header HTTP que identifica o sistema cliente em <c>GET /auth/verify-token</c>.</summary>
+    public const string SystemIdHeader = "X-System-Id";
 
     private readonly AppDbContext _db;
     private readonly IJwtTokenService _jwt;
@@ -38,6 +45,9 @@ public partial class AuthController : ControllerBase
         [Required(ErrorMessage = "Password é obrigatório.")]
         [MaxLength(60)]
         public string Password { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "SystemId é obrigatório.")]
+        public Guid? SystemId { get; set; }
     }
 
     public record LoginResponse(string Token);
@@ -57,6 +67,18 @@ public partial class AuthController : ControllerBase
     {
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);
+
+        if (request.SystemId is not { } systemId || systemId == Guid.Empty)
+            return BadRequest(new { message = SystemIdRequiredMessage });
+
+        // Query filter global remove sistemas com DeletedAt != null (soft-delete = inativo).
+        var systemExists = await _db.Systems.AsNoTracking()
+            .AnyAsync(s => s.Id == systemId, HttpContext.RequestAborted);
+        if (!systemExists)
+        {
+            _logger.LogWarning("Tentativa de login com sistema inválido/inativo {SystemId}.", systemId);
+            return BadRequest(new { message = InvalidSystemIdMessage });
+        }
 
         var email = request.Email.Trim().ToLowerInvariant();
         var password = request.Password.Trim();
@@ -91,7 +113,7 @@ public partial class AuthController : ControllerBase
             return Unauthorized(new { message = InvalidCredentialsMessage });
         }
 
-        var token = _jwt.CreateAccessToken(user.Id, user.TokenVersion, out _);
+        var token = _jwt.CreateAccessToken(user.Id, user.TokenVersion, systemId, out _);
         return Ok(new LoginResponse(token));
     }
 
@@ -99,9 +121,34 @@ public partial class AuthController : ControllerBase
     [Authorize(AuthenticationSchemes = BearerAuthenticationDefaults.AuthenticationScheme)]
     public async Task<IActionResult> VerifyToken()
     {
+        if (!Request.Headers.TryGetValue(SystemIdHeader, out var headerValues)
+            || string.IsNullOrWhiteSpace(headerValues.ToString()))
+            return BadRequest(new { message = SystemIdHeaderRequiredMessage });
+
+        if (!Guid.TryParse(headerValues.ToString(), out var headerSystemId) || headerSystemId == Guid.Empty)
+            return BadRequest(new { message = InvalidSystemIdMessage });
+
+        var systemExists = await _db.Systems.AsNoTracking()
+            .AnyAsync(s => s.Id == headerSystemId, HttpContext.RequestAborted);
+        if (!systemExists)
+            return BadRequest(new { message = InvalidSystemIdMessage });
+
         var sub = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (string.IsNullOrEmpty(sub) || !Guid.TryParse(sub, out var userId))
             return Unauthorized(new { message = InvalidTokenMessage });
+
+        var sysClaim = User.FindFirstValue(JwtBearerAuthenticationHandler.SystemIdClaimType);
+        if (string.IsNullOrEmpty(sysClaim) || !Guid.TryParse(sysClaim, out var tokenSystemId))
+            return Unauthorized(new { message = InvalidTokenMessage });
+
+        if (tokenSystemId != headerSystemId)
+        {
+            _logger.LogWarning(
+                "Token cruzado detectado: claim sys={TokenSystemId} difere do header X-System-Id={HeaderSystemId}.",
+                tokenSystemId,
+                headerSystemId);
+            return Unauthorized(new { message = CrossSystemTokenMessage });
+        }
 
         var user = await _db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == userId);
         if (user is null)
@@ -111,7 +158,7 @@ public partial class AuthController : ControllerBase
             .OrderBy(x => x)
             .ToList();
         var permissionCodes = await ResolvePermissionCodesAsync(permissionIds, HttpContext.RequestAborted);
-        var routeCodes = await ResolveRouteCodesAsync(permissionIds, HttpContext.RequestAborted);
+        var routeCodes = await ResolveRouteCodesAsync(permissionIds, headerSystemId, HttpContext.RequestAborted);
         return Ok(new VerifyTokenResponse(
             user.Id,
             user.Name,
@@ -187,28 +234,37 @@ public partial class AuthController : ControllerBase
 
     private async Task<IReadOnlyList<string>> ResolveRouteCodesAsync(
         IReadOnlyCollection<Guid> permissionIds,
+        Guid systemId,
         CancellationToken cancellationToken)
     {
         if (permissionIds.Count == 0)
             return Array.Empty<string>();
 
-        var kurttoPermissionTypes = await _db.Permissions.AsNoTracking()
-            .Where(p => permissionIds.Contains(p.Id))
-            .Join(
-                _db.Systems.AsNoTracking(),
-                p => p.SystemId,
-                s => s.Id,
-                (p, s) => new { p.PermissionTypeId, SystemCode = s.Code })
-            .Where(x => x.SystemCode == "kurtto")
+        // Tipos de permissão (create/read/update/delete/restore) que o usuário possui no sistema indicado.
+        var permissionTypeCodes = await _db.Permissions.AsNoTracking()
+            .Where(p => permissionIds.Contains(p.Id) && p.SystemId == systemId)
             .Join(
                 _db.PermissionTypes.AsNoTracking(),
-                x => x.PermissionTypeId,
+                p => p.PermissionTypeId,
                 t => t.Id,
                 (_, t) => t.Code)
             .Distinct()
             .ToListAsync(cancellationToken);
 
-        var allowedPolicies = kurttoPermissionTypes
+        if (permissionTypeCodes.Count == 0)
+            return Array.Empty<string>();
+
+        // Códigos de rota declarados no DB para o sistema-alvo (limita rotas reais a este sistema).
+        var systemRouteCodes = (await _db.Routes.AsNoTracking()
+                .Where(r => r.SystemId == systemId)
+                .Select(r => r.Code)
+                .ToListAsync(cancellationToken))
+            .ToHashSet(StringComparer.Ordinal);
+
+        if (systemRouteCodes.Count == 0)
+            return Array.Empty<string>();
+
+        var allowedPolicies = permissionTypeCodes
             .Select(MapKurttoPermissionTypeToPolicy)
             .Where(policy => policy is not null)
             .Cast<string>()
@@ -217,8 +273,11 @@ public partial class AuthController : ControllerBase
         if (allowedPolicies.Count == 0)
             return Array.Empty<string>();
 
+        // O mapeamento estático route→policy hoje cobre apenas o sistema kurtto. Se o systemId
+        // não corresponde a kurtto, o filtro por systemRouteCodes garante que nada é vazado.
         return KurttoAccessSeeder.KurttoAdminRoutes
-            .Where(route => allowedPolicies.Contains(route.TargetPermissionPolicy))
+            .Where(route => allowedPolicies.Contains(route.TargetPermissionPolicy)
+                && systemRouteCodes.Contains(route.Code))
             .Select(route => route.Code)
             .OrderBy(code => code)
             .ToArray();

--- a/AuthService/Controllers/Auth/AuthController.cs
+++ b/AuthService/Controllers/Auth/AuthController.cs
@@ -48,6 +48,7 @@ public partial class AuthController : ControllerBase
         string Email,
         int Identity,
         IReadOnlyList<Guid> Permissions,
+        IReadOnlyList<string> PermissionCodes,
         IReadOnlyList<string> RouteCodes);
 
     [HttpPost("login")]
@@ -109,6 +110,7 @@ public partial class AuthController : ControllerBase
         var permissionIds = (await EffectivePermissionIds.GetForUserAsync(_db, userId))
             .OrderBy(x => x)
             .ToList();
+        var permissionCodes = await ResolvePermissionCodesAsync(permissionIds, HttpContext.RequestAborted);
         var routeCodes = await ResolveRouteCodesAsync(permissionIds, HttpContext.RequestAborted);
         return Ok(new VerifyTokenResponse(
             user.Id,
@@ -116,6 +118,7 @@ public partial class AuthController : ControllerBase
             user.Email,
             user.Identity,
             permissionIds,
+            permissionCodes,
             routeCodes)
         );
     }
@@ -142,6 +145,45 @@ public partial class AuthController : ControllerBase
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Logout concluído para o usuário {UserId}.")]
     private partial void LogLogoutCompleted(Guid userId);
+
+    private async Task<IReadOnlyList<string>> ResolvePermissionCodesAsync(
+        IReadOnlyCollection<Guid> permissionIds,
+        CancellationToken cancellationToken)
+    {
+        if (permissionIds.Count == 0)
+            return Array.Empty<string>();
+
+        var systemTypePairs = await _db.Permissions.AsNoTracking()
+            .Where(p => permissionIds.Contains(p.Id))
+            .Join(
+                _db.Systems.AsNoTracking(),
+                p => p.SystemId,
+                s => s.Id,
+                (p, s) => new { p.PermissionTypeId, SystemCode = s.Code })
+            .Join(
+                _db.PermissionTypes.AsNoTracking(),
+                x => x.PermissionTypeId,
+                t => t.Id,
+                (x, t) => new { x.SystemCode, TypeCode = t.Code })
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        if (systemTypePairs.Count == 0)
+            return Array.Empty<string>();
+
+        var codes = new SortedSet<string>(StringComparer.Ordinal);
+        foreach (var pair in systemTypePairs)
+        {
+            var resources = PermissionCatalog.GetResourcesForSystem(pair.SystemCode);
+            if (resources.Count == 0)
+                continue;
+
+            foreach (var resource in resources)
+                codes.Add(PermissionCodeFormatter.Format(resource, pair.TypeCode));
+        }
+
+        return codes.ToArray();
+    }
 
     private async Task<IReadOnlyList<string>> ResolveRouteCodesAsync(
         IReadOnlyCollection<Guid> permissionIds,

--- a/AuthService/Controllers/Auth/AuthController.cs
+++ b/AuthService/Controllers/Auth/AuthController.cs
@@ -147,7 +147,7 @@ public partial class AuthController : ControllerBase
     private partial void LogLogoutCompleted(Guid userId);
 
     private async Task<IReadOnlyList<string>> ResolvePermissionCodesAsync(
-        IReadOnlyCollection<Guid> permissionIds,
+        List<Guid> permissionIds,
         CancellationToken cancellationToken)
     {
         if (permissionIds.Count == 0)

--- a/AuthService/OpenApi/ContractExamplesOperationFilter.cs
+++ b/AuthService/OpenApi/ContractExamplesOperationFilter.cs
@@ -145,19 +145,38 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
 
     private static void EnsureSystemIdHeaderParameter(OpenApiOperation operation)
     {
+        // O parâmetro X-System-Id é gerado automaticamente pelo ASP.NET Core a partir do
+        // [FromHeader] no controller. Aqui só ajustamos metadados (required, description)
+        // para garantir uma documentação consistente no Swagger.
+        const string headerDescription =
+            "UUID do sistema cliente. Deve corresponder ao systemId usado em POST /auth/login.";
+
         operation.Parameters ??= [];
-        var alreadyPresent = operation.Parameters.Any(p =>
+        var existing = operation.Parameters.FirstOrDefault(p =>
             p.In == ParameterLocation.Header
             && string.Equals(p.Name, AuthController.SystemIdHeader, StringComparison.OrdinalIgnoreCase));
-        if (alreadyPresent)
+
+        if (existing is OpenApiParameter mutable)
+        {
+            mutable.Required = true;
+            if (string.IsNullOrWhiteSpace(mutable.Description))
+                mutable.Description = headerDescription;
             return;
+        }
+
+        if (existing is not null)
+        {
+            // Parâmetro presente como referência imutável; deixamos o auto-gerado prevalecer
+            // sem duplicar a entrada na operação.
+            return;
+        }
 
         operation.Parameters.Add(new OpenApiParameter
         {
             Name = AuthController.SystemIdHeader,
             In = ParameterLocation.Header,
             Required = true,
-            Description = "UUID do sistema cliente. Deve corresponder ao systemId usado em POST /auth/login."
+            Description = headerDescription
         });
     }
 }

--- a/AuthService/OpenApi/ContractExamplesOperationFilter.cs
+++ b/AuthService/OpenApi/ContractExamplesOperationFilter.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using AuthService.Controllers.Auth;
 using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -31,12 +32,14 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
         if (normalized == "/auth/login" && method == "POST")
         {
             AddJsonResponse(operation, "200", "Login realizado.", new { token = "<jwt-token>" });
+            AddErrorResponse(operation, "400", "SystemId ausente ou sistema invalido/inativo.", new { message = "SystemId é obrigatório." });
             AddErrorResponse(operation, "401", "Credenciais invalidas.", new { message = "Credenciais inválidas." });
             return;
         }
 
         if (normalized == "/auth/verify-token" && method == "GET")
         {
+            EnsureSystemIdHeaderParameter(operation);
             AddJsonResponse(operation, "200", "Token valido.", new
             {
                 id = "00000000-0000-0000-0000-000000000000",
@@ -47,6 +50,7 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
                 permissionCodes = ExamplePermissionCodes,
                 routeCodes = ExampleRouteCodes
             });
+            AddErrorResponse(operation, "400", "Header X-System-Id ausente ou sistema invalido/inativo.", new { message = "Header X-System-Id é obrigatório." });
             return;
         }
 
@@ -137,5 +141,23 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
                 }
             }
         };
+    }
+
+    private static void EnsureSystemIdHeaderParameter(OpenApiOperation operation)
+    {
+        operation.Parameters ??= [];
+        var alreadyPresent = operation.Parameters.Any(p =>
+            p.In == ParameterLocation.Header
+            && string.Equals(p.Name, AuthController.SystemIdHeader, StringComparison.OrdinalIgnoreCase));
+        if (alreadyPresent)
+            return;
+
+        operation.Parameters.Add(new OpenApiParameter
+        {
+            Name = AuthController.SystemIdHeader,
+            In = ParameterLocation.Header,
+            Required = true,
+            Description = "UUID do sistema cliente. Deve corresponder ao systemId usado em POST /auth/login."
+        });
     }
 }

--- a/AuthService/OpenApi/ContractExamplesOperationFilter.cs
+++ b/AuthService/OpenApi/ContractExamplesOperationFilter.cs
@@ -7,6 +7,8 @@ namespace AuthService.OpenApi;
 public sealed class ContractExamplesOperationFilter : IOperationFilter
 {
     private static readonly string[] ExamplePermissions = ["11111111-1111-1111-1111-111111111111"];
+    private static readonly string[] ExamplePermissionCodes = ["perm:Users.Read", "perm:Roles.Read"];
+    private static readonly string[] ExampleRouteCodes = ["KURTTO_V1_URLS_LIST_INCLUDE_DELETED"];
 
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
@@ -41,7 +43,9 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
                 name = "User Name",
                 email = "user@example.com",
                 identity = 1,
-                permissions = ExamplePermissions
+                permissions = ExamplePermissions,
+                permissionCodes = ExamplePermissionCodes,
+                routeCodes = ExampleRouteCodes
             });
             return;
         }


### PR DESCRIPTION
## 📌 Resumo

Promoção de `development` → `main` com **6 PRs acumuladas hoje** (2026-04-26): 3 features que resolvem issues funcionais (#138, #142, #143) e 3 chores que endurecem o contrato dos agents.

## 📦 PRs incluídas

### Features (3)

#### #140 — feat(auth): expose readable permission codes in verify-token
Resolve **issue #138**. Adiciona `IReadOnlyList<string> PermissionCodes` em `VerifyTokenResponse` no formato `perm:<Recurso>.<Acao>`. Cliente passa a receber forma legível das permissões (em vez de só GUIDs). Sem breaking change.

#### #145 — test(seeds): assert root catalog covers authenticator and kurtto
Resolve **issue #143**. Investigação confirmou que o código de produção já garantia que `root@email.com.br` tem todas as permissões dos 2 sistemas seedados; PR adiciona 6 testes (unitário + integração) que travam o contrato. Sem alteração de produção.

#### #146 — feat(auth): exigir systemId no login e verify-token (BREAKING)
Resolve **issue #142**. **Breaking change**:
- `POST /auth/login` agora exige `systemId: Guid` no body
- `GET /auth/verify-token` agora exige header `X-System-Id`
- JWT carrega claim `sys` com o systemId; verify-token bloqueia tokens cruzados entre sistemas (Decisão A)
- `ResolveRouteCodesAsync` parametrizado por `systemId` — substitui hard-code `SystemCode == \"kurtto\"` que vazava rotas do kurtto para qualquer cliente

⚠️ **Cross-repo pendente** (não bloqueia esta release, mas precisa antes de virar produção):
- `lfc-admin-gui` precisa enviar `VITE_SYSTEM_ID = dc9e6357-4a98-4058-865e-a41e474c45b7` (authenticator)
- `lfc-kurtto-admin-gui` precisa enviar `VITE_SYSTEM_ID = 44839717-3e55-4d6d-8d4b-46b599305209` (kurtto)

### Chores (3) — endurecimento do contrato dos agents

#### #139 — chore(agents): mirror .cursor/agents to .claude/agents
Suporte a Claude Code além do Cursor. Cria `.claude/agents/` espelhado de `.cursor/agents/`. Adiciona regra de espelhamento obrigatório.

#### #141 — chore(agents): treat any new SonarCloud issue as BLOCKER in reviewer
Reviewer passa a tratar qualquer issue nova do SonarCloud como BLOCKER, independente de severity/impact/effort/Quality Gate. Etapa 8 ganha sub-bullet com comando direto da API `/api/issues/search`.

#### #144 — chore(agents): port admin-gui disciplines (5 improvements)
Importa 5 disciplinas maturas do `lfc-admin-gui`:
1. Path portável do `programmer-lessons.md` (elimina exceção de espelhamento)
2. Seção de espelhamento em todos os 3 agents (não só programmer)
3. Container-only com BLOCKER explícito (`dotnet` no host = BLOCKER)
4. `Closes #<issue>` obrigatório no body da PR
5. Mapeamento multi-repo

## 🔗 Issues fechadas

- Closes #138 (já fechada)
- Closes #142 (já fechada)
- Closes #143 (já fechada)

## 🧪 Validação acumulada

Cada PR mergeada teve seu próprio Quality Gate verde (Coverage ≥ 80%, ratings A em new code, 0 Sonar issues). 200/200 testes na HEAD final.

## ⚠️ Riscos para produção

- **Breaking change** em `POST /auth/login` e `GET /auth/verify-token` (#146): clientes existentes (admin-guis) **vão quebrar** se forem ao ar antes de receberem o `VITE_SYSTEM_ID` correspondente. **Coordenar deploy.**
- Comportamento de `ResolveRouteCodesAsync` muda: rotas agora vêm filtradas pelo systemId real, não mais hard-coded kurtto. Sistemas sem rotas seedadas vão receber array vazio (correto, mas pode parecer regressão se algum cliente esperava as rotas do kurtto).
- Resto é additive (testes, codes legíveis, agent tooling).

## 🧭 Notas operacionais

- Auto-close de `Closes #` falhou 3x hoje (#138, #143, #142) — issues foram fechadas manualmente. Reviewer token (`evacalegari1`) sem escopo `issues:write`. Vale ajustar antes da próxima sessão.
- Flake pré-existente em `DefaultSystemUserSeederTests` (race em `Environment.SetEnvironmentVariable`) detectado mas fora de escopo desta release. Issue dedicada recomendada.