### PR TITLE
feat(systems): GET /systems com busca, paginação server-side e includeDeleted (#151)

### DIFF
--- a/AuthService.Tests/SystemsApiTests.cs
+++ b/AuthService.Tests/SystemsApiTests.cs
@@ -132,11 +132,240 @@ public class SystemsApiTests : IAsyncLifetime
 
         var listResp = await _client.GetAsync("/api/v1/systems");
         listResp.EnsureSuccessStatusCode();
-        var list = await listResp.Content.ReadFromJsonAsync<List<SystemDto>>(TestApiClient.JsonOptions);
-        Assert.NotNull(list);
-        Assert.All(list, s => Assert.Null(s.DeletedAt));
-        Assert.Contains(list, s => s.Code == "ATIVO");
-        Assert.DoesNotContain(list, s => s.Code == "OUTRO");
+        var page = await listResp.Content.ReadFromJsonAsync<PagedSystemsDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(page);
+        Assert.Equal(1, page.Page);
+        Assert.Equal(20, page.PageSize);
+        Assert.All(page.Data, s => Assert.Null(s.DeletedAt));
+        Assert.Contains(page.Data, s => s.Code == "ATIVO");
+        Assert.DoesNotContain(page.Data, s => s.Code == "OUTRO");
+        Assert.Equal(page.Data.Count, page.Total);
+    }
+
+    [Fact]
+    public async Task GetAll_NoFilters_UsesDefaultEnvelope()
+    {
+        var page = await GetSystemsPageAsync("/api/v1/systems");
+        Assert.Equal(1, page.Page);
+        Assert.Equal(20, page.PageSize);
+        Assert.True(page.Total >= page.Data.Count);
+    }
+
+    [Fact]
+    public async Task GetAll_WithSearchQ_PartialMatchOnName()
+    {
+        await SeedSystemsAsync(("Admin GUI", "ADMIN_GUI"), ("Faturamento", "FAT_001"));
+
+        var page = await GetSystemsPageAsync("/api/v1/systems?q=adm");
+        Assert.Contains(page.Data, s => s.Code == "ADMIN_GUI");
+        Assert.DoesNotContain(page.Data, s => s.Code == "FAT_001");
+    }
+
+    [Fact]
+    public async Task GetAll_WithSearchQ_IsCaseInsensitive()
+    {
+        await SeedSystemsAsync(("Admin GUI", "ADMIN_GUI"));
+
+        var lower = await GetSystemsPageAsync("/api/v1/systems?q=admin");
+        var upper = await GetSystemsPageAsync("/api/v1/systems?q=ADMIN");
+        var mixed = await GetSystemsPageAsync("/api/v1/systems?q=AdMiN");
+
+        Assert.Contains(lower.Data, s => s.Code == "ADMIN_GUI");
+        Assert.Contains(upper.Data, s => s.Code == "ADMIN_GUI");
+        Assert.Contains(mixed.Data, s => s.Code == "ADMIN_GUI");
+    }
+
+    [Fact]
+    public async Task GetAll_WithSearchQ_MatchesNameOrCode()
+    {
+        await SeedSystemsAsync(
+            ("Sistema Alpha", "BETA_CODE"),
+            ("Outro Nome", "ALPHA_CODE"),
+            ("Sem relacao", "NEUTRO"));
+
+        var byName = await GetSystemsPageAsync("/api/v1/systems?q=Alpha");
+        Assert.Contains(byName.Data, s => s.Code == "BETA_CODE");
+        Assert.Contains(byName.Data, s => s.Code == "ALPHA_CODE");
+        Assert.DoesNotContain(byName.Data, s => s.Code == "NEUTRO");
+    }
+
+    [Fact]
+    public async Task GetAll_WithPagination_ReturnsCorrectSubset()
+    {
+        await SeedSystemsAsync(
+            ("AAA Sistema", "PAGE_AAA"),
+            ("BBB Sistema", "PAGE_BBB"),
+            ("CCC Sistema", "PAGE_CCC"),
+            ("DDD Sistema", "PAGE_DDD"),
+            ("EEE Sistema", "PAGE_EEE"));
+
+        var firstPage = await GetSystemsPageAsync("/api/v1/systems?q=Sistema&page=1&pageSize=2");
+        var secondPage = await GetSystemsPageAsync("/api/v1/systems?q=Sistema&page=2&pageSize=2");
+        var thirdPage = await GetSystemsPageAsync("/api/v1/systems?q=Sistema&page=3&pageSize=2");
+
+        Assert.Equal(2, firstPage.Data.Count);
+        Assert.Equal(2, secondPage.Data.Count);
+        Assert.Single(thirdPage.Data);
+        Assert.Equal(5, firstPage.Total);
+        Assert.Equal(5, secondPage.Total);
+        Assert.Equal(5, thirdPage.Total);
+
+        var firstCodes = firstPage.Data.Select(s => s.Code).ToList();
+        var secondCodes = secondPage.Data.Select(s => s.Code).ToList();
+        var thirdCodes = thirdPage.Data.Select(s => s.Code).ToList();
+        Assert.Empty(firstCodes.Intersect(secondCodes));
+        Assert.Empty(secondCodes.Intersect(thirdCodes));
+        Assert.Empty(firstCodes.Intersect(thirdCodes));
+    }
+
+    [Fact]
+    public async Task GetAll_WithPageSizeAboveLimit_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync("/api/v1/systems?pageSize=101");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_WithPageSizeZero_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync("/api/v1/systems?pageSize=0");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_WithPageSizeNegative_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync("/api/v1/systems?pageSize=-3");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_WithPageZero_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync("/api/v1/systems?page=0");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_WithPageNegative_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync("/api/v1/systems?page=-1");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_WithIncludeDeletedTrue_ReturnsActiveAndDeleted()
+    {
+        await SeedSystemsAsync(("Sis Ativo", "INC_ACTIVE"));
+        var deletedResp = await _client.PostAsJsonAsync(
+            "/api/v1/systems",
+            new { name = "Sis Deletado", code = "INC_DELETED" },
+            TestApiClient.JsonOptions);
+        var deleted = await deletedResp.Content.ReadFromJsonAsync<SystemDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(deleted);
+        await _client.DeleteAsync($"/api/v1/systems/{deleted.Id}");
+
+        var page = await GetSystemsPageAsync("/api/v1/systems?includeDeleted=true&q=Sis&pageSize=100");
+        Assert.Contains(page.Data, s => s.Code == "INC_ACTIVE");
+        Assert.Contains(page.Data, s => s.Code == "INC_DELETED" && s.DeletedAt != null);
+    }
+
+    [Fact]
+    public async Task GetAll_WithIncludeDeletedDefault_HidesSoftDeleted()
+    {
+        var resp = await _client.PostAsJsonAsync(
+            "/api/v1/systems",
+            new { name = "Sis Hidden", code = "HIDE_DELETED" },
+            TestApiClient.JsonOptions);
+        var dto = await resp.Content.ReadFromJsonAsync<SystemDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto);
+        await _client.DeleteAsync($"/api/v1/systems/{dto.Id}");
+
+        var page = await GetSystemsPageAsync("/api/v1/systems?q=Hidden&pageSize=100");
+        Assert.DoesNotContain(page.Data, s => s.Code == "HIDE_DELETED");
+    }
+
+    [Fact]
+    public async Task GetAll_TotalReflectsFilters_BeforePagination()
+    {
+        await SeedSystemsAsync(
+            ("Filtro UM", "FIL_TOTAL_1"),
+            ("Filtro DOIS", "FIL_TOTAL_2"),
+            ("Filtro TRES", "FIL_TOTAL_3"),
+            ("Outro", "OTHER_TOTAL"));
+
+        var page = await GetSystemsPageAsync("/api/v1/systems?q=Filtro&page=1&pageSize=2");
+        Assert.Equal(3, page.Total);
+        Assert.Equal(2, page.Data.Count);
+    }
+
+    [Fact]
+    public async Task GetAll_PageBeyondTotal_ReturnsEmptyDataAnd200()
+    {
+        await SeedSystemsAsync(("Empty page A", "EMPTY_A"));
+
+        var resp = await _client.GetAsync("/api/v1/systems?q=Empty&page=99&pageSize=10");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var page = await resp.Content.ReadFromJsonAsync<PagedSystemsDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(page);
+        Assert.Empty(page.Data);
+        Assert.Equal(1, page.Total);
+    }
+
+    [Fact]
+    public async Task GetAll_OrderingIsStable_NoDuplicatesAcrossPages()
+    {
+        var seeds = Enumerable.Range(0, 7)
+            .Select(i => ($"Ordem {i:D2}", $"ORDER_{i:D2}"))
+            .ToArray();
+        await SeedSystemsAsync(seeds);
+
+        var first = await GetSystemsPageAsync("/api/v1/systems?q=Ordem&page=1&pageSize=3");
+        var second = await GetSystemsPageAsync("/api/v1/systems?q=Ordem&page=2&pageSize=3");
+        var third = await GetSystemsPageAsync("/api/v1/systems?q=Ordem&page=3&pageSize=3");
+
+        var collected = first.Data.Concat(second.Data).Concat(third.Data)
+            .Select(s => s.Code)
+            .ToList();
+        Assert.Equal(collected.Count, collected.Distinct().Count());
+        Assert.Equal(seeds.Length, collected.Count);
+    }
+
+    [Fact]
+    public async Task GetAll_OrderedByName_Ascending()
+    {
+        await SeedSystemsAsync(
+            ("ZZZ Order", "ORD_ZZZ"),
+            ("AAA Order", "ORD_AAA"),
+            ("MMM Order", "ORD_MMM"));
+
+        var page = await GetSystemsPageAsync("/api/v1/systems?q=Order&pageSize=10");
+        var names = page.Data.Where(s => s.Code.StartsWith("ORD_", StringComparison.Ordinal))
+            .Select(s => s.Name)
+            .ToList();
+        var sorted = names.OrderBy(n => n, StringComparer.Ordinal).ToList();
+        Assert.Equal(sorted, names);
+    }
+
+    private async Task<PagedSystemsDto> GetSystemsPageAsync(string url)
+    {
+        var resp = await _client.GetAsync(url);
+        resp.EnsureSuccessStatusCode();
+        var page = await resp.Content.ReadFromJsonAsync<PagedSystemsDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(page);
+        return page;
+    }
+
+    private async Task SeedSystemsAsync(params (string Name, string Code)[] systems)
+    {
+        foreach (var (name, code) in systems)
+        {
+            var resp = await _client.PostAsJsonAsync(
+                "/api/v1/systems",
+                new { name, code },
+                TestApiClient.JsonOptions);
+            resp.EnsureSuccessStatusCode();
+        }
     }
 
     [Fact]
@@ -222,4 +451,10 @@ public class SystemsApiTests : IAsyncLifetime
         DateTime CreatedAt,
         DateTime UpdatedAt,
         DateTime? DeletedAt);
+
+    private sealed record PagedSystemsDto(
+        List<SystemDto> Data,
+        int Page,
+        int PageSize,
+        int Total);
 }

--- a/AuthService/Controllers/Common/PagedResponse.cs
+++ b/AuthService/Controllers/Common/PagedResponse.cs
@@ -1,0 +1,15 @@
+namespace AuthService.Controllers.Common;
+
+/// <summary>
+/// Envelope de resposta paginada usado por endpoints de listagem com busca/paginação server-side.
+/// </summary>
+/// <typeparam name="T">Tipo dos itens listados na página corrente.</typeparam>
+/// <param name="Data">Itens da página corrente (após filtros e <c>Skip</c>/<c>Take</c>).</param>
+/// <param name="Page">Número da página retornada (1-based) após defaults/validação.</param>
+/// <param name="PageSize">Tamanho da página efetivamente aplicado após defaults/validação.</param>
+/// <param name="Total">Total de registros que casam com os filtros aplicados, antes da paginação.</param>
+public sealed record PagedResponse<T>(
+    IReadOnlyList<T> Data,
+    int Page,
+    int PageSize,
+    int Total);

--- a/AuthService/Controllers/Systems/SystemsController.cs
+++ b/AuthService/Controllers/Systems/SystemsController.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using AuthService.Auth;
+using AuthService.Controllers.Common;
 using AuthService.Data;
 using AuthService.Models;
 using Microsoft.AspNetCore.Authorization;
@@ -129,12 +130,47 @@ public class SystemsController : ControllerBase
         return CreatedAtAction(nameof(GetById), new { id = entity.Id }, ToResponse(entity));
     }
 
+    /// <summary>Tamanho de página default quando o cliente não envia <c>pageSize</c>.</summary>
+    public const int DefaultPageSize = 20;
+
+    /// <summary>Limite superior para <c>pageSize</c>; valores acima retornam 400.</summary>
+    public const int MaxPageSize = 100;
+
     [HttpGet]
     [Authorize(Policy = PermissionPolicies.SystemsRead)]
-    public async Task<IActionResult> GetAll()
+    public async Task<IActionResult> GetAll(
+        [FromQuery] string? q = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = DefaultPageSize,
+        [FromQuery] bool includeDeleted = false)
     {
-        var list = await _db.Systems
-            .OrderBy(s => s.CreatedAt)
+        if (page <= 0)
+            ModelState.AddModelError(nameof(page), "page deve ser maior ou igual a 1.");
+
+        if (pageSize <= 0 || pageSize > MaxPageSize)
+            ModelState.AddModelError(nameof(pageSize), $"pageSize deve estar entre 1 e {MaxPageSize}.");
+
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        IQueryable<AppSystem> query = _db.Systems;
+        if (includeDeleted)
+            query = query.IgnoreQueryFilters();
+
+        if (!string.IsNullOrWhiteSpace(q))
+        {
+            var pattern = $"%{EscapeLikePattern(q.Trim())}%";
+            query = query.Where(s =>
+                EF.Functions.ILike(s.Name, pattern) || EF.Functions.ILike(s.Code, pattern));
+        }
+
+        var total = await query.CountAsync();
+
+        var data = await query
+            .OrderBy(s => s.Name)
+            .ThenBy(s => s.Id)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
             .Select(s => new SystemResponse(
                 s.Id,
                 s.Name,
@@ -144,7 +180,20 @@ public class SystemsController : ControllerBase
                 s.UpdatedAt,
                 s.DeletedAt))
             .ToListAsync();
-        return Ok(list);
+
+        return Ok(new PagedResponse<SystemResponse>(data, page, pageSize, total));
+    }
+
+    /// <summary>
+    /// Escapa caracteres curinga (<c>%</c>, <c>_</c>) e o caractere de escape (<c>\</c>) na entrada do usuário
+    /// para evitar que sejam interpretados como wildcards no <c>ILIKE</c>. Mantém o termo como busca literal parcial.
+    /// </summary>
+    private static string EscapeLikePattern(string value)
+    {
+        return value
+            .Replace("\\", "\\\\")
+            .Replace("%", "\\%")
+            .Replace("_", "\\_");
     }
 
     [HttpGet("{id:guid}")]

--- a/AuthService/OpenApi/ContractExamplesOperationFilter.cs
+++ b/AuthService/OpenApi/ContractExamplesOperationFilter.cs
@@ -44,6 +44,7 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
             || TryApplyAuthVerifyTokenGet(operation, normalizedPath, method)
             || TryApplyAuthPermissionsGet(operation, normalizedPath, method)
             || TryApplyAuthLogoutGet(operation, normalizedPath, method)
+            || TryApplySystemsListGet(operation, normalizedPath, method)
             || TryApplyRestorePost(operation, normalizedPath, method);
     }
 
@@ -126,6 +127,71 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
 
         AddJsonResponse(operation, "200", "Restauracao concluida.", new { message = "Registro restaurado com sucesso." });
         return true;
+    }
+
+    private static bool TryApplySystemsListGet(OpenApiOperation operation, string normalizedPath, string method)
+    {
+        if (normalizedPath != "/systems" || method != "GET")
+            return false;
+
+        EnsureSystemsListQueryParameters(operation);
+
+        AddJsonResponse(operation, "200", "Pagina de sistemas que casam com os filtros aplicados.", new
+        {
+            data = new[]
+            {
+                new
+                {
+                    id = "00000000-0000-0000-0000-000000000000",
+                    name = "Admin GUI",
+                    code = "ADMIN_GUI",
+                    description = "Painel administrativo.",
+                    createdAt = "2026-04-26T18:00:00+00:00",
+                    updatedAt = "2026-04-26T18:00:00+00:00",
+                    deletedAt = (string?)null
+                }
+            },
+            page = 1,
+            pageSize = 20,
+            total = 1
+        });
+        AddErrorResponse(
+            operation,
+            "400",
+            "Parametros de paginacao invalidos (page <= 0 ou pageSize fora do intervalo permitido).",
+            new { message = "pageSize deve estar entre 1 e 100." });
+        return true;
+    }
+
+    private static void EnsureSystemsListQueryParameters(OpenApiOperation operation)
+    {
+        EnsureQueryParameterDescription(
+            operation,
+            "q",
+            "Termo de busca case-insensitive em Name e Code (matching parcial via ILIKE).");
+        EnsureQueryParameterDescription(
+            operation,
+            "page",
+            "Numero da pagina (1-based, default 1). Valores <= 0 retornam 400.");
+        EnsureQueryParameterDescription(
+            operation,
+            "pageSize",
+            "Tamanho da pagina (default 20, maximo 100). Valores <= 0 ou > 100 retornam 400.");
+        EnsureQueryParameterDescription(
+            operation,
+            "includeDeleted",
+            "Quando true, inclui registros soft-deleted (DeletedAt != null). Default false.");
+    }
+
+    private static void EnsureQueryParameterDescription(OpenApiOperation operation, string parameterName, string description)
+    {
+        operation.Parameters ??= [];
+        var existing = operation.Parameters.FirstOrDefault(p =>
+            p.In == ParameterLocation.Query
+            && string.Equals(p.Name, parameterName, StringComparison.OrdinalIgnoreCase));
+
+        if (existing is OpenApiParameter mutable && string.IsNullOrWhiteSpace(mutable.Description))
+            mutable.Description = description;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Closes #151.

Estende `GET /api/v1/systems` com busca, paginação server-side e filtro de soft-deleted, destravando a EPIC `LF-Calegari/lfc-admin-gui#45` (em particular a sub-issue `#57` e dependentes `#58`–`#61`).

### Contrato novo

`GET /api/v1/systems?q=<string>&page=<int>&pageSize=<int>&includeDeleted=<bool>`

- `q` (default `""`): matching parcial **case-insensitive** em `Name` **e** `Code` via `EF.Functions.ILike`.
- `page` (default `1`, 1-based): valores `<= 0` retornam `400`.
- `pageSize` (default `20`, máx `100`): fora desse intervalo retorna `400`.
- `includeDeleted` (default `false`): quando `true`, usa `IgnoreQueryFilters()` para incluir registros com `DeletedAt != null`.

Resposta agora é um envelope:

```json
{ "data": [SystemResponse, ...], "page": 1, "pageSize": 20, "total": 42 }
```

`total` é a contagem após filtros e antes de `Skip/Take`. Ordenação estável por `Name asc, Id asc`.

### Mudanças

- `AuthService/Controllers/Systems/SystemsController.cs` — handler `GetAll` reescrito com os novos query params, validações `400`, busca via `ILike` com escape de `%`, `_`, `\`, ordenação determinística e envelope.
- `AuthService/Controllers/Common/PagedResponse.cs` — novo DTO genérico `PagedResponse<T>` para reuso em futuros endpoints paginados.
- `AuthService/OpenApi/ContractExamplesOperationFilter.cs` — novo helper `TryApplySystemsListGet` com exemplo do envelope no Swagger e descrições dos quatro query params.
- `AuthService.Tests/SystemsApiTests.cs` — `GetAll_ReturnsOnlyActiveSystems` ajustado para o envelope (regressão preservada) e 16 novos testes cobrindo cada AC.

### Breaking change

A resposta de `GET /api/v1/systems` muda de **array** para o envelope `{ data, page, pageSize, total }`. Consumidor conhecido: `lfc-admin-gui` (atualizado em `LF-Calegari/lfc-admin-gui#57` e demais sub-issues). Backend e front devem entrar na mesma janela de deploy.

## Test plan

- [x] `dotnet test` rodado localmente via `docker compose --profile test run --rm test`.
- [x] Suite de `SystemsApiTests` 100% verde no novo envelope (16 novos testes + 13 pré-existentes).
- [x] Falhas `ApiVersioningAndDocsTests.SwaggerJson_ContainsOnlyOfficialContractPaths` e `AuthApiTests.Permissions_UserWithoutPermissions_ReturnsSystemRouteCatalog` reproduzidas em `development` antes do PR — não são regressão deste PR.
- [ ] CI (SonarCloud workflow) verde.
- [ ] Smoke manual via Swagger `/docs` com cada combinação de filtros.
