### PR TITLE
feat(routes): add SystemTokenTypeId required FK to Routes (#155)

### DIFF
--- a/AuthService.Tests/PermissionsApiTests.cs
+++ b/AuthService.Tests/PermissionsApiTests.cs
@@ -36,12 +36,25 @@ public class PermissionsApiTests : IAsyncLifetime
 
     private async Task<Guid> CreateRouteAsync(Guid systemId, string code, string name = "Rota")
     {
+        var systemTokenTypeId = await GetDefaultSystemTokenTypeIdAsync();
         var r = await _client.PostAsJsonAsync("/api/v1/systems/routes",
-            new { systemId, name, code, description = (string?)null }, TestApiClient.JsonOptions);
+            new { systemId, name, code, description = (string?)null, systemTokenTypeId }, TestApiClient.JsonOptions);
         r.EnsureSuccessStatusCode();
         var dto = await r.Content.ReadFromJsonAsync<RefDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
         return dto.Id;
+    }
+
+    private async Task<Guid> GetDefaultSystemTokenTypeIdAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var id = await db.SystemTokenTypes
+            .Where(t => t.Code == SystemTokenTypeSeeder.DefaultCode)
+            .Select(t => (Guid?)t.Id)
+            .FirstOrDefaultAsync();
+        Assert.True(id.HasValue && id.Value != Guid.Empty);
+        return id!.Value;
     }
 
     private async Task<Guid> CreatePermissionTypeAsync(string code, string name = "Tipo")

--- a/AuthService.Tests/RoutesApiTests.cs
+++ b/AuthService.Tests/RoutesApiTests.cs
@@ -34,19 +34,41 @@ public class RoutesApiTests : IAsyncLifetime
         return dto.Id;
     }
 
-    private static object RouteCreateBody(Guid systemId, string name, string code, string? description = null) =>
-        new { systemId, name, code, description };
+    private async Task<Guid> GetDefaultSystemTokenTypeIdAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var id = await db.SystemTokenTypes
+            .Where(t => t.Code == SystemTokenTypeSeeder.DefaultCode)
+            .Select(t => (Guid?)t.Id)
+            .FirstOrDefaultAsync();
+        Assert.True(id.HasValue && id.Value != Guid.Empty);
+        return id!.Value;
+    }
 
-    private static object RouteUpdateBody(Guid systemId, string name, string code, string? description = null) =>
-        new { systemId, name, code, description };
+    private async Task<Guid> CreateActiveSystemTokenTypeAsync(string code, string name = "Custom")
+    {
+        var resp = await _client.PostAsJsonAsync("/api/v1/tokens/types", new { name, code, description = (string?)null }, TestApiClient.JsonOptions);
+        resp.EnsureSuccessStatusCode();
+        var dto = await resp.Content.ReadFromJsonAsync<TokenTypeRefDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto);
+        return dto.Id;
+    }
+
+    private static object RouteCreateBody(Guid systemId, string name, string code, Guid systemTokenTypeId, string? description = null) =>
+        new { systemId, name, code, description, systemTokenTypeId };
+
+    private static object RouteUpdateBody(Guid systemId, string name, string code, Guid systemTokenTypeId, string? description = null) =>
+        new { systemId, name, code, description, systemTokenTypeId };
 
     [Fact]
     public async Task Create_Post_WithValidSystemId_ReturnsCreated_UtcAndNullDeletedAt()
     {
         var sysId = await CreateSystemAsync("RT_SYS_1");
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
 
         var response = await _client.PostAsJsonAsync("/api/v1/systems/routes",
-            RouteCreateBody(sysId, "Rota A", "ROUTE_A", "Opcional"), TestApiClient.JsonOptions);
+            RouteCreateBody(sysId, "Rota A", "ROUTE_A", sttId, "Opcional"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
         var dto = await response.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
@@ -55,6 +77,9 @@ public class RoutesApiTests : IAsyncLifetime
         Assert.Null(dto.DeletedAt);
         Assert.Equal("ROUTE_A", dto.Code);
         Assert.Equal("Opcional", dto.Description);
+        Assert.Equal(sttId, dto.SystemTokenTypeId);
+        Assert.Equal(SystemTokenTypeSeeder.DefaultCode, dto.SystemTokenTypeCode);
+        Assert.False(string.IsNullOrWhiteSpace(dto.SystemTokenTypeName));
         Assert.True(dto.CreatedAt > DateTime.MinValue);
         Assert.True(dto.UpdatedAt > DateTime.MinValue);
     }
@@ -62,16 +87,59 @@ public class RoutesApiTests : IAsyncLifetime
     [Fact]
     public async Task Create_WithInvalidSystemId_ReturnsBadRequest()
     {
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
         var response = await _client.PostAsJsonAsync("/api/v1/systems/routes",
-            RouteCreateBody(Guid.NewGuid(), "X", "CODE_X"), TestApiClient.JsonOptions);
+            RouteCreateBody(Guid.NewGuid(), "X", "CODE_X", sttId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]
     public async Task Create_WithoutSystemId_ReturnsBadRequest()
     {
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
         var response = await _client.PostAsJsonAsync("/api/v1/systems/routes",
-            new { name = "Rota sem sistema", code = "RT_NO_SYS" }, TestApiClient.JsonOptions);
+            new { name = "Rota sem sistema", code = "RT_NO_SYS", systemTokenTypeId = sttId }, TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_WithoutSystemTokenTypeId_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_NO_STT");
+        var response = await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            new { systemId = sysId, name = "Rota sem stt", code = "RT_NO_STT" }, TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_WithEmptySystemTokenTypeId_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_EMPTY_STT");
+        var response = await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysId, "Rota empty stt", "RT_EMPTY_STT", Guid.Empty), TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_WithUnknownSystemTokenTypeId_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_INV_STT");
+        var response = await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysId, "Rota inv stt", "RT_INV_STT", Guid.NewGuid()), TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_WithInactiveSystemTokenTypeId_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_DEL_STT");
+        var customId = await CreateActiveSystemTokenTypeAsync("STT_DEL_FOR_RT");
+
+        var del = await _client.DeleteAsync($"/api/v1/tokens/types/{customId}");
+        Assert.Equal(HttpStatusCode.NoContent, del.StatusCode);
+
+        var response = await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysId, "Rota stt deletado", "RT_DEL_STT", customId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
@@ -79,9 +147,10 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task Create_DuplicateCode_ReturnsConflict()
     {
         var sysId = await CreateSystemAsync("RT_SYS_DUP");
-        await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "A", "DUP_CODE"), TestApiClient.JsonOptions);
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "A", "DUP_CODE", sttId), TestApiClient.JsonOptions);
 
-        var response = await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "B", "DUP_CODE"), TestApiClient.JsonOptions);
+        var response = await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "B", "DUP_CODE", sttId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
 
@@ -89,10 +158,11 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task Create_DuplicateCode_NormalizesWhitespace_ReturnsConflict()
     {
         var sysId = await CreateSystemAsync("RT_SYS_WS");
-        await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "A", "ABC_RT"), TestApiClient.JsonOptions);
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "A", "ABC_RT", sttId), TestApiClient.JsonOptions);
 
         var response = await _client.PostAsJsonAsync("/api/v1/systems/routes",
-            RouteCreateBody(sysId, "B", "  ABC_RT  "), TestApiClient.JsonOptions);
+            RouteCreateBody(sysId, "B", "  ABC_RT  ", sttId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
 
@@ -100,9 +170,10 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task Create_ConcurrentSameCode_OneCreatedOneConflict()
     {
         var sysId = await CreateSystemAsync("RT_SYS_CONC");
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
         const string code = "CONC_RT";
-        var t1 = _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "A", code), TestApiClient.JsonOptions);
-        var t2 = _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "B", code), TestApiClient.JsonOptions);
+        var t1 = _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "A", code, sttId), TestApiClient.JsonOptions);
+        var t2 = _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "B", code, sttId), TestApiClient.JsonOptions);
         await Task.WhenAll(t1, t2);
         var statuses = new[] { (await t1).StatusCode, (await t2).StatusCode };
         Assert.Contains(HttpStatusCode.Created, statuses);
@@ -113,18 +184,20 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task Create_WhitespaceOnlyName_ReturnsBadRequest()
     {
         var sysId = await CreateSystemAsync("RT_SYS_WN");
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
         var response = await _client.PostAsJsonAsync("/api/v1/systems/routes",
-            RouteCreateBody(sysId, "   ", "C1"), TestApiClient.JsonOptions);
+            RouteCreateBody(sysId, "   ", "C1", sttId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]
-    public async Task GetAll_ReturnsOnlyActiveRoutes()
+    public async Task GetAll_ReturnsOnlyActiveRoutes_AndPopulatesDenormalizedTokenTypeFields()
     {
         var sysId = await CreateSystemAsync("RT_SYS_GA");
-        await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "Ativa", "RT_ATIVA"), TestApiClient.JsonOptions);
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "Ativa", "RT_ATIVA", sttId), TestApiClient.JsonOptions);
 
-        var other = await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "Outra", "RT_OUTRA"), TestApiClient.JsonOptions);
+        var other = await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "Outra", "RT_OUTRA", sttId), TestApiClient.JsonOptions);
         var otherDto = await other.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
         Assert.NotNull(otherDto);
         await _client.DeleteAsync($"/api/v1/systems/routes/{otherDto.Id}");
@@ -134,6 +207,8 @@ public class RoutesApiTests : IAsyncLifetime
         var list = await listResp.Content.ReadFromJsonAsync<List<RouteDto>>(TestApiClient.JsonOptions);
         Assert.NotNull(list);
         Assert.All(list, r => Assert.Null(r.DeletedAt));
+        Assert.All(list, r => Assert.False(string.IsNullOrWhiteSpace(r.SystemTokenTypeCode)));
+        Assert.All(list, r => Assert.False(string.IsNullOrWhiteSpace(r.SystemTokenTypeName)));
         Assert.Contains(list, r => r.Code == "RT_ATIVA");
         Assert.DoesNotContain(list, r => r.Code == "RT_OUTRA");
     }
@@ -142,11 +217,17 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task GetById_Active_ReturnsOk_Deleted_Returns404()
     {
         var sysId = await CreateSystemAsync("RT_SYS_G1");
-        var create = await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "S", "RT_G1"), TestApiClient.JsonOptions);
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var create = await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "S", "RT_G1", sttId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        Assert.Equal(HttpStatusCode.OK, (await _client.GetAsync($"/api/v1/systems/routes/{dto.Id}")).StatusCode);
+        var getOkResp = await _client.GetAsync($"/api/v1/systems/routes/{dto.Id}");
+        Assert.Equal(HttpStatusCode.OK, getOkResp.StatusCode);
+        var getOk = await getOkResp.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(getOk);
+        Assert.Equal(sttId, getOk.SystemTokenTypeId);
+        Assert.Equal(SystemTokenTypeSeeder.DefaultCode, getOk.SystemTokenTypeCode);
 
         await _client.DeleteAsync($"/api/v1/systems/routes/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/api/v1/systems/routes/{dto.Id}")).StatusCode);
@@ -156,17 +237,18 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task Update_Active_ReturnsOk_Deleted_Returns404()
     {
         var sysId = await CreateSystemAsync("RT_SYS_U1");
-        var create = await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "S", "RT_U1"), TestApiClient.JsonOptions);
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var create = await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "S", "RT_U1", sttId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
         var putOk = await _client.PutAsJsonAsync($"/api/v1/systems/routes/{dto.Id}",
-            RouteUpdateBody(sysId, "S2", "RT_U1", null), TestApiClient.JsonOptions);
+            RouteUpdateBody(sysId, "S2", "RT_U1", sttId, null), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.OK, putOk.StatusCode);
 
         await _client.DeleteAsync($"/api/v1/systems/routes/{dto.Id}");
         var put404 = await _client.PutAsJsonAsync($"/api/v1/systems/routes/{dto.Id}",
-            RouteUpdateBody(sysId, "S3", "RT_U1"), TestApiClient.JsonOptions);
+            RouteUpdateBody(sysId, "S3", "RT_U1", sttId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.NotFound, put404.StatusCode);
     }
 
@@ -174,12 +256,13 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task Update_WithInvalidSystemId_ReturnsBadRequest()
     {
         var sysId = await CreateSystemAsync("RT_SYS_UINV");
-        var create = await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "S", "RT_INV"), TestApiClient.JsonOptions);
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var create = await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "S", "RT_INV", sttId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
         var put = await _client.PutAsJsonAsync($"/api/v1/systems/routes/{dto.Id}",
-            RouteUpdateBody(Guid.NewGuid(), "S", "RT_INV"), TestApiClient.JsonOptions);
+            RouteUpdateBody(Guid.NewGuid(), "S", "RT_INV", sttId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
     }
 
@@ -187,21 +270,70 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task Update_WithoutSystemId_ReturnsBadRequest()
     {
         var sysId = await CreateSystemAsync("RT_SYS_MISSING");
-        var create = await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "S", "RT_MISSING"), TestApiClient.JsonOptions);
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var create = await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "S", "RT_MISSING", sttId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
         var put = await _client.PutAsJsonAsync($"/api/v1/systems/routes/{dto.Id}",
-            new { name = "S atualizado", code = "RT_MISSING" }, TestApiClient.JsonOptions);
+            new { name = "S atualizado", code = "RT_MISSING", systemTokenTypeId = sttId }, TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_WithoutSystemTokenTypeId_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_MISSING_STT");
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var create = await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "S", "RT_MISS_STT", sttId), TestApiClient.JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto);
+
+        var put = await _client.PutAsJsonAsync($"/api/v1/systems/routes/{dto.Id}",
+            new { systemId = sysId, name = "S2", code = "RT_MISS_STT" }, TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_WithUnknownSystemTokenTypeId_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_UPD_INV_STT");
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var create = await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "S", "RT_UPD_INV_STT", sttId), TestApiClient.JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto);
+
+        var put = await _client.PutAsJsonAsync($"/api/v1/systems/routes/{dto.Id}",
+            RouteUpdateBody(sysId, "S2", "RT_UPD_INV_STT", Guid.NewGuid()), TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_WithInactiveSystemTokenTypeId_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_UPD_DEL_STT");
+        var defaultSttId = await GetDefaultSystemTokenTypeIdAsync();
+        var customSttId = await CreateActiveSystemTokenTypeAsync("STT_UPD_DEL");
+
+        var create = await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "S", "RT_UPD_DEL_STT", defaultSttId), TestApiClient.JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto);
+
+        var del = await _client.DeleteAsync($"/api/v1/tokens/types/{customSttId}");
+        Assert.Equal(HttpStatusCode.NoContent, del.StatusCode);
+
+        var put = await _client.PutAsJsonAsync($"/api/v1/systems/routes/{dto.Id}",
+            RouteUpdateBody(sysId, "S2", "RT_UPD_DEL_STT", customSttId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
     }
 
     [Fact]
     public async Task Update_NonExistentId_WithInvalidSystemId_Returns404()
     {
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
         var missingId = Guid.NewGuid();
         var put = await _client.PutAsJsonAsync($"/api/v1/systems/routes/{missingId}",
-            RouteUpdateBody(Guid.NewGuid(), "S", "RT_NO404"), TestApiClient.JsonOptions);
+            RouteUpdateBody(Guid.NewGuid(), "S", "RT_NO404", sttId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.NotFound, put.StatusCode);
     }
 
@@ -209,7 +341,8 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task Delete_SoftDelete_ThenDeleteAgain_Returns404()
     {
         var sysId = await CreateSystemAsync("RT_SYS_D1");
-        var create = await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "S", "RT_D1"), TestApiClient.JsonOptions);
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var create = await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "S", "RT_D1", sttId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
@@ -229,7 +362,8 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task Restore_Deleted_ThenAppearsInGetAll_AndGetByIdWorks()
     {
         var sysId = await CreateSystemAsync("RT_SYS_R1");
-        var create = await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "S", "RT_R1"), TestApiClient.JsonOptions);
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var create = await _client.PostAsJsonAsync("/api/v1/systems/routes", RouteCreateBody(sysId, "S", "RT_R1", sttId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
@@ -256,10 +390,11 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task Create_WithDeletedSystem_ReturnsBadRequest()
     {
         var sysId = await CreateSystemAsync("RT_SYS_DELSYS");
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
         await _client.DeleteAsync($"/api/v1/systems/{sysId}");
 
         var response = await _client.PostAsJsonAsync("/api/v1/systems/routes",
-            RouteCreateBody(sysId, "R", "RT_DELSYS"), TestApiClient.JsonOptions);
+            RouteCreateBody(sysId, "R", "RT_DELSYS", sttId), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
@@ -267,8 +402,9 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task GetAll_AndGetById_ExcludeRoutesWhenSystemSoftDeleted()
     {
         var sysId = await CreateSystemAsync("RT_SYS_ORPH");
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
         var create = await _client.PostAsJsonAsync("/api/v1/systems/routes",
-            RouteCreateBody(sysId, "R", "RT_ORPH"), TestApiClient.JsonOptions);
+            RouteCreateBody(sysId, "R", "RT_ORPH", sttId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
@@ -287,8 +423,9 @@ public class RoutesApiTests : IAsyncLifetime
     public async Task Restore_WhenSystemSoftDeleted_ReturnsBadRequest()
     {
         var sysId = await CreateSystemAsync("RT_SYS_RSYS");
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
         var create = await _client.PostAsJsonAsync("/api/v1/systems/routes",
-            RouteCreateBody(sysId, "S", "RT_RSYS"), TestApiClient.JsonOptions);
+            RouteCreateBody(sysId, "S", "RT_RSYS", sttId), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
@@ -299,7 +436,96 @@ public class RoutesApiTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.BadRequest, restore.StatusCode);
     }
 
+    [Fact]
+    public async Task Restore_WhenSystemTokenTypeSoftDeleted_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("RT_SYS_RSTT");
+        var customSttId = await CreateActiveSystemTokenTypeAsync("STT_RSTT");
+
+        var create = await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysId, "S", "RT_RSTT", customSttId), TestApiClient.JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto);
+
+        // soft-delete da rota
+        Assert.Equal(HttpStatusCode.NoContent, (await _client.DeleteAsync($"/api/v1/systems/routes/{dto.Id}")).StatusCode);
+        // soft-delete do SystemTokenType referenciado
+        Assert.Equal(HttpStatusCode.NoContent, (await _client.DeleteAsync($"/api/v1/tokens/types/{customSttId}")).StatusCode);
+
+        var restore = await _client.PostAsync($"/api/v1/systems/routes/{dto.Id}/restore", null);
+        Assert.Equal(HttpStatusCode.BadRequest, restore.StatusCode);
+    }
+
+    [Fact]
+    public async Task Sync_WithoutSystemTokenTypeCode_DefaultsToCanonicalDefault()
+    {
+        var sysId = await CreateSystemAsync("RT_SYNC_DEF", "Sistema sync default");
+        var defaultSttId = await GetDefaultSystemTokenTypeIdAsync();
+
+        var body = new
+        {
+            systemCode = "RT_SYNC_DEF",
+            routes = new[]
+            {
+                new { code = "SYNC_DEF_RT", name = "Rota sync default", description = (string?)null, permissionTypeCode = (string?)null, systemTokenTypeCode = (string?)null }
+            }
+        };
+
+        var resp = await _client.PostAsJsonAsync("/api/v1/systems/routes/sync", body, TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var route = await db.Routes.SingleAsync(r => r.Code == "SYNC_DEF_RT");
+        Assert.Equal(defaultSttId, route.SystemTokenTypeId);
+    }
+
+    [Fact]
+    public async Task Sync_WithUnknownSystemTokenTypeCode_ReturnsBadRequest_AndListsUnknownCodes()
+    {
+        var sysId = await CreateSystemAsync("RT_SYNC_UNK_STT", "Sistema sync stt unknown");
+
+        var body = new
+        {
+            systemCode = "RT_SYNC_UNK_STT",
+            routes = new[]
+            {
+                new { code = "SYNC_UNK_STT_RT", name = "Rota stt unknown", description = (string?)null, permissionTypeCode = (string?)null, systemTokenTypeCode = "stt-nope-1" }
+            }
+        };
+
+        var resp = await _client.PostAsJsonAsync("/api/v1/systems/routes/sync", body, TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var content = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("stt-nope-1", content);
+    }
+
+    [Fact]
+    public async Task Sync_WithKnownSystemTokenTypeCode_PersistsOnRoute()
+    {
+        var sysId = await CreateSystemAsync("RT_SYNC_KNOWN_STT", "Sistema sync stt known");
+        var customSttId = await CreateActiveSystemTokenTypeAsync("STT_SYNC_KNOWN");
+
+        var body = new
+        {
+            systemCode = "RT_SYNC_KNOWN_STT",
+            routes = new[]
+            {
+                new { code = "SYNC_KNOWN_STT_RT", name = "Rota stt known", description = (string?)null, permissionTypeCode = (string?)null, systemTokenTypeCode = "STT_SYNC_KNOWN" }
+            }
+        };
+
+        var resp = await _client.PostAsJsonAsync("/api/v1/systems/routes/sync", body, TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var route = await db.Routes.SingleAsync(r => r.Code == "SYNC_KNOWN_STT_RT");
+        Assert.Equal(customSttId, route.SystemTokenTypeId);
+    }
+
     private sealed record SystemRefDto(Guid Id);
+    private sealed record TokenTypeRefDto(Guid Id);
 
     private sealed record RouteDto(
         Guid Id,
@@ -307,6 +533,9 @@ public class RoutesApiTests : IAsyncLifetime
         string Name,
         string Code,
         string? Description,
+        Guid SystemTokenTypeId,
+        string SystemTokenTypeCode,
+        string SystemTokenTypeName,
         DateTime CreatedAt,
         DateTime UpdatedAt,
         DateTime? DeletedAt);

--- a/AuthService.Tests/WebAppFactory.cs
+++ b/AuthService.Tests/WebAppFactory.cs
@@ -73,6 +73,7 @@ public class WebAppFactory : WebApplicationFactory<Program>
         // Em "Testing" o Program.cs não roda os seeders — replicamos a mesma sequência usada em produção
         // para que os testes de integração tenham o catálogo do authenticator e o usuário root prontos.
         SystemSeeder.EnsureSystemsAsync(db).GetAwaiter().GetResult();
+        SystemTokenTypeSeeder.EnsureSystemTokenTypesAsync(db).GetAwaiter().GetResult();
         AuthenticatorRoutesSeeder.EnsureRoutesAsync(db).GetAwaiter().GetResult();
         PermissionTypeSeeder.EnsurePermissionTypesAsync(db).GetAwaiter().GetResult();
         AuthenticatorPermissionsSeeder.EnsurePermissionsAsync(db).GetAwaiter().GetResult();

--- a/AuthService/Controllers/Routes/RoutesController.cs
+++ b/AuthService/Controllers/Routes/RoutesController.cs
@@ -36,6 +36,9 @@ public class RoutesController : ControllerBase
 
         [MaxLength(500, ErrorMessage = "Description deve ter no máximo 500 caracteres.")]
         public string? Description { get; set; }
+
+        [Required(ErrorMessage = "SystemTokenTypeId é obrigatório.")]
+        public Guid? SystemTokenTypeId { get; set; }
     }
 
     public class UpdateRouteRequest
@@ -53,6 +56,9 @@ public class RoutesController : ControllerBase
 
         [MaxLength(500, ErrorMessage = "Description deve ter no máximo 500 caracteres.")]
         public string? Description { get; set; }
+
+        [Required(ErrorMessage = "SystemTokenTypeId é obrigatório.")]
+        public Guid? SystemTokenTypeId { get; set; }
     }
 
     public record RouteResponse(
@@ -61,13 +67,13 @@ public class RoutesController : ControllerBase
         string Name,
         string Code,
         string? Description,
+        Guid SystemTokenTypeId,
+        string SystemTokenTypeCode,
+        string SystemTokenTypeName,
         DateTime CreatedAt,
         DateTime UpdatedAt,
         DateTime? DeletedAt
     );
-
-    private static RouteResponse ToResponse(AppRoute r) =>
-        new(r.Id, r.SystemId, r.Name, r.Code, r.Description, r.CreatedAt, r.UpdatedAt, r.DeletedAt);
 
     private static void ValidateNormalizedFields(
         ModelStateDictionary modelState,
@@ -97,13 +103,48 @@ public class RoutesController : ControllerBase
     private async Task<bool> SystemExistsAndActiveAsync(Guid systemId) =>
         systemId != Guid.Empty && await _db.Systems.AnyAsync(s => s.Id == systemId);
 
+    private async Task<bool> SystemTokenTypeExistsAndActiveAsync(Guid systemTokenTypeId) =>
+        systemTokenTypeId != Guid.Empty
+        && await _db.SystemTokenTypes.AnyAsync(t => t.Id == systemTokenTypeId);
+
     /// <summary>Routes ativas cujo sistema pai ainda está ativo (leitura alinhada a POST/PUT).</summary>
     private IQueryable<AppRoute> ActiveRoutesWithActiveSystem() =>
         _db.Routes.Where(r => _db.Systems.Any(s => s.Id == r.SystemId));
 
+    /// <summary>
+    /// Projeção do response com Join (left) para denormalizar Code/Name do SystemTokenType. Não usa
+    /// <c>IgnoreQueryFilters()</c> em DbSets aninhadas para evitar o efeito colateral do EF Core de
+    /// propagar o "ignore" para os operadores de raiz (que vazaria rotas soft-deletadas). Mantemos o
+    /// vínculo via Join com a tabela ATIVA de SystemTokenTypes — quando o SystemTokenType referenciado
+    /// foi soft-deletado pós-creation, o response mostra strings vazias para Code/Name (Left Join),
+    /// e o controller bloqueia o restore via <see cref="SystemTokenTypeExistsAndActiveAsync"/>.
+    /// </summary>
+    private IQueryable<RouteResponse> ProjectRouteResponses(IQueryable<AppRoute> source) =>
+        from r in source
+        join t in _db.SystemTokenTypes on r.SystemTokenTypeId equals t.Id into tg
+        from t in tg.DefaultIfEmpty()
+        select new RouteResponse(
+            r.Id,
+            r.SystemId,
+            r.Name,
+            r.Code,
+            r.Description,
+            r.SystemTokenTypeId,
+            t != null ? t.Code : string.Empty,
+            t != null ? t.Name : string.Empty,
+            r.CreatedAt,
+            r.UpdatedAt,
+            r.DeletedAt);
+
     private ActionResult InvalidSystemIdResult()
     {
         ModelState.AddModelError(nameof(CreateRouteRequest.SystemId), "SystemId inválido ou sistema inativo.");
+        return ValidationProblem(ModelState);
+    }
+
+    private ActionResult InvalidSystemTokenTypeIdResult()
+    {
+        ModelState.AddModelError(nameof(CreateRouteRequest.SystemTokenTypeId), "SystemTokenTypeId inválido ou inativo.");
         return ValidationProblem(ModelState);
     }
 
@@ -115,9 +156,13 @@ public class RoutesController : ControllerBase
             return ValidationProblem(ModelState);
 
         var systemId = request.SystemId!.Value;
+        var systemTokenTypeId = request.SystemTokenTypeId!.Value;
 
         if (!await SystemExistsAndActiveAsync(systemId))
             return InvalidSystemIdResult();
+
+        if (!await SystemTokenTypeExistsAndActiveAsync(systemTokenTypeId))
+            return InvalidSystemTokenTypeIdResult();
 
         var name = request.Name.Trim();
         var code = request.Code.Trim();
@@ -137,6 +182,7 @@ public class RoutesController : ControllerBase
             Name = name,
             Code = code,
             Description = description,
+            SystemTokenTypeId = systemTokenTypeId,
             CreatedAt = now,
             UpdatedAt = now,
             DeletedAt = null
@@ -156,24 +202,16 @@ public class RoutesController : ControllerBase
             return InvalidSystemIdResult();
         }
 
-        return CreatedAtAction(nameof(GetById), new { id = entity.Id }, ToResponse(entity));
+        var created = await ProjectRouteResponses(_db.Routes.Where(r => r.Id == entity.Id))
+            .FirstAsync();
+        return CreatedAtAction(nameof(GetById), new { id = entity.Id }, created);
     }
 
     [HttpGet]
     [Authorize(Policy = PermissionPolicies.SystemsRoutesRead)]
     public async Task<IActionResult> GetAll()
     {
-        var list = await ActiveRoutesWithActiveSystem()
-            .OrderBy(r => r.CreatedAt)
-            .Select(r => new RouteResponse(
-                r.Id,
-                r.SystemId,
-                r.Name,
-                r.Code,
-                r.Description,
-                r.CreatedAt,
-                r.UpdatedAt,
-                r.DeletedAt))
+        var list = await ProjectRouteResponses(ActiveRoutesWithActiveSystem().OrderBy(r => r.CreatedAt))
             .ToListAsync();
         return Ok(list);
     }
@@ -182,10 +220,11 @@ public class RoutesController : ControllerBase
     [Authorize(Policy = PermissionPolicies.SystemsRoutesRead)]
     public async Task<IActionResult> GetById(Guid id)
     {
-        var entity = await ActiveRoutesWithActiveSystem().FirstOrDefaultAsync(r => r.Id == id);
-        if (entity is null)
+        var dto = await ProjectRouteResponses(ActiveRoutesWithActiveSystem().Where(r => r.Id == id))
+            .FirstOrDefaultAsync();
+        if (dto is null)
             return NotFound(new { message = "Route não encontrada." });
-        return Ok(ToResponse(entity));
+        return Ok(dto);
     }
 
     [HttpPut("{id:guid}")]
@@ -200,9 +239,13 @@ public class RoutesController : ControllerBase
             return NotFound(new { message = "Route não encontrada." });
 
         var systemId = request.SystemId!.Value;
+        var systemTokenTypeId = request.SystemTokenTypeId!.Value;
 
         if (!await SystemExistsAndActiveAsync(systemId))
             return InvalidSystemIdResult();
+
+        if (!await SystemTokenTypeExistsAndActiveAsync(systemTokenTypeId))
+            return InvalidSystemTokenTypeIdResult();
 
         var name = request.Name.Trim();
         var code = request.Code.Trim();
@@ -219,6 +262,7 @@ public class RoutesController : ControllerBase
         entity.Name = name;
         entity.Code = code;
         entity.Description = description;
+        entity.SystemTokenTypeId = systemTokenTypeId;
         entity.UpdatedAt = DateTime.UtcNow;
 
         try
@@ -234,7 +278,9 @@ public class RoutesController : ControllerBase
             return InvalidSystemIdResult();
         }
 
-        return Ok(ToResponse(entity));
+        var updated = await ProjectRouteResponses(_db.Routes.Where(r => r.Id == entity.Id))
+            .FirstAsync();
+        return Ok(updated);
     }
 
     [HttpDelete("{id:guid}")]
@@ -270,6 +316,14 @@ public class RoutesController : ControllerBase
             });
         }
 
+        if (!await SystemTokenTypeExistsAndActiveAsync(entity.SystemTokenTypeId))
+        {
+            return BadRequest(new
+            {
+                message = "Não é possível restaurar a route: o SystemTokenType vinculado está inativo ou foi removido."
+            });
+        }
+
         entity.DeletedAt = null;
         entity.UpdatedAt = DateTime.UtcNow;
         await _db.SaveChangesAsync();
@@ -292,6 +346,14 @@ public class RoutesController : ControllerBase
         /// <summary>Code do PermissionType (ex.: read/create). Se informado, cria/reativa a Permission(Route, Type).</summary>
         [MaxLength(50, ErrorMessage = "PermissionTypeCode deve ter no máximo 50 caracteres.")]
         public string? PermissionTypeCode { get; set; }
+
+        /// <summary>
+        /// Code do SystemTokenType ("política JWT alvo"). Opcional: quando omitido, usa o code canônico
+        /// <c>default</c>. Se informado e desconhecido/inativo, o sync inteiro retorna 400 listando os codes
+        /// inválidos (mesmo padrão de PermissionTypeCode).
+        /// </summary>
+        [MaxLength(50, ErrorMessage = "SystemTokenTypeCode deve ter no máximo 50 caracteres.")]
+        public string? SystemTokenTypeCode { get; set; }
     }
 
     public class SyncRoutesRequest
@@ -349,6 +411,39 @@ public class RoutesController : ControllerBase
             return ValidationProblem(ModelState);
         }
 
+        // Resolve SystemTokenType: items podem informar SystemTokenTypeCode (opcional). Quando omitido,
+        // assume "default". Códigos desconhecidos (ou referenciando registros soft-deletados) retornam 400.
+        var explicitTokenCodes = request.Routes
+            .Where(r => !string.IsNullOrWhiteSpace(r.SystemTokenTypeCode))
+            .Select(r => r.SystemTokenTypeCode!)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        var requiredTokenCodes = explicitTokenCodes.Contains(SystemTokenTypeSeeder.DefaultCode, StringComparer.Ordinal)
+            ? explicitTokenCodes
+            : explicitTokenCodes.Concat(new[] { SystemTokenTypeSeeder.DefaultCode }).ToList();
+
+        var tokenIdByCode = await _db.SystemTokenTypes.AsNoTracking()
+            .Where(t => requiredTokenCodes.Contains(t.Code))
+            .ToDictionaryAsync(t => t.Code, t => t.Id, StringComparer.Ordinal);
+
+        var unknownTokenCodes = explicitTokenCodes
+            .Where(c => !tokenIdByCode.ContainsKey(c))
+            .ToList();
+        if (unknownTokenCodes.Count > 0)
+        {
+            ModelState.AddModelError(nameof(request.Routes),
+                $"SystemTokenTypeCode desconhecido(s): {string.Join(", ", unknownTokenCodes)}.");
+            return ValidationProblem(ModelState);
+        }
+
+        if (!tokenIdByCode.TryGetValue(SystemTokenTypeSeeder.DefaultCode, out var defaultTokenTypeId))
+        {
+            ModelState.AddModelError(nameof(request.Routes),
+                $"SystemTokenType '{SystemTokenTypeSeeder.DefaultCode}' não encontrado. Execute o SystemTokenTypeSeeder.");
+            return ValidationProblem(ModelState);
+        }
+
         var existingRoutes = await _db.Routes.IgnoreQueryFilters()
             .Where(r => r.SystemId == system.Id)
             .ToListAsync();
@@ -363,12 +458,17 @@ public class RoutesController : ControllerBase
 
         foreach (var item in request.Routes)
         {
+            var resolvedTokenTypeId = string.IsNullOrWhiteSpace(item.SystemTokenTypeCode)
+                ? defaultTokenTypeId
+                : tokenIdByCode[item.SystemTokenTypeCode!];
+
             Guid routeId;
             if (existingByCode.TryGetValue(item.Code, out var existing))
             {
                 var changed = false;
                 if (existing.Name != item.Name) { existing.Name = item.Name; changed = true; }
                 if (existing.Description != item.Description) { existing.Description = item.Description; changed = true; }
+                if (existing.SystemTokenTypeId != resolvedTokenTypeId) { existing.SystemTokenTypeId = resolvedTokenTypeId; changed = true; }
                 if (existing.DeletedAt is not null) { existing.DeletedAt = null; reactivated++; }
                 if (changed) updated++;
                 existing.UpdatedAt = utc;
@@ -382,6 +482,7 @@ public class RoutesController : ControllerBase
                     Name = item.Name,
                     Code = item.Code,
                     Description = item.Description,
+                    SystemTokenTypeId = resolvedTokenTypeId,
                     CreatedAt = utc,
                     UpdatedAt = utc,
                     DeletedAt = null

--- a/AuthService/Data/AppDbContext.cs
+++ b/AuthService/Data/AppDbContext.cs
@@ -24,11 +24,18 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     {
         base.OnModelCreating(modelBuilder);
 
-        modelBuilder.Entity<AppRoute>()
-            .HasOne<AppSystem>()
-            .WithMany()
-            .HasForeignKey(r => r.SystemId)
-            .OnDelete(DeleteBehavior.Restrict);
+        modelBuilder.Entity<AppRoute>(entity =>
+        {
+            entity.HasOne<AppSystem>()
+                .WithMany()
+                .HasForeignKey(r => r.SystemId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity.HasOne<AppSystemTokenType>()
+                .WithMany()
+                .HasForeignKey(r => r.SystemTokenTypeId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
 
         modelBuilder.Entity<Client>(entity =>
         {

--- a/AuthService/Data/AuthenticatorRoutesSeeder.cs
+++ b/AuthService/Data/AuthenticatorRoutesSeeder.cs
@@ -170,6 +170,15 @@ public static class AuthenticatorRoutesSeeder
             throw new InvalidOperationException(
                 $"Sistema '{SystemCode}' não encontrado. Execute o SystemSeeder antes do AuthenticatorRoutesSeeder.");
 
+        var defaultTokenTypeId = await db.SystemTokenTypes.AsNoTracking()
+            .Where(t => t.Code == SystemTokenTypeSeeder.DefaultCode)
+            .Select(t => (Guid?)t.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (defaultTokenTypeId is null || defaultTokenTypeId == Guid.Empty)
+            throw new InvalidOperationException(
+                $"SystemTokenType '{SystemTokenTypeSeeder.DefaultCode}' não encontrado. Execute o SystemTokenTypeSeeder antes do AuthenticatorRoutesSeeder.");
+
         var utc = DateTime.UtcNow;
 
         foreach (var (code, name, description) in Routes)
@@ -185,6 +194,7 @@ public static class AuthenticatorRoutesSeeder
                     Code = code,
                     Name = name,
                     Description = description,
+                    SystemTokenTypeId = defaultTokenTypeId.Value,
                     CreatedAt = utc,
                     UpdatedAt = utc,
                     DeletedAt = null
@@ -195,6 +205,7 @@ public static class AuthenticatorRoutesSeeder
             existing.SystemId = systemId.Value;
             existing.Name = name;
             existing.Description = description;
+            existing.SystemTokenTypeId = defaultTokenTypeId.Value;
             if (existing.DeletedAt is not null)
                 existing.DeletedAt = null;
             existing.UpdatedAt = utc;

--- a/AuthService/Data/Migrations/20260430185253_Routes_AddSystemTokenTypeId.Designer.cs
+++ b/AuthService/Data/Migrations/20260430185253_Routes_AddSystemTokenTypeId.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AuthService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace AuthService.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260430185253_Routes_AddSystemTokenTypeId")]
+    partial class Routes_AddSystemTokenTypeId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AuthService/Data/Migrations/20260430185253_Routes_AddSystemTokenTypeId.cs
+++ b/AuthService/Data/Migrations/20260430185253_Routes_AddSystemTokenTypeId.cs
@@ -1,0 +1,89 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AuthService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class Routes_AddSystemTokenTypeId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // 1) Adiciona a coluna como nullable (transitório) para permitir backfill em bases pré-existentes
+            //    sem violar NOT NULL antes da population.
+            migrationBuilder.AddColumn<Guid>(
+                name: "SystemTokenTypeId",
+                table: "Routes",
+                type: "uuid",
+                nullable: true);
+
+            // 2) Garante que existe pelo menos um SystemTokenType canônico com Code='default' para servir
+            //    como referência do backfill. Idempotente via ON CONFLICT — não recria se já existir
+            //    (seeder pode ter rodado, ou outra migration/processo já garantiu).
+            migrationBuilder.Sql(@"
+                INSERT INTO ""SystemTokenTypes"" (""Id"", ""Name"", ""Code"", ""Description"", ""CreatedAt"", ""UpdatedAt"", ""DeletedAt"")
+                VALUES (
+                    gen_random_uuid(),
+                    'Default',
+                    'default',
+                    'Política JWT padrão para rotas autenticadas (Bearer JWT do usuário corrente).',
+                    now() AT TIME ZONE 'UTC',
+                    now() AT TIME ZONE 'UTC',
+                    NULL
+                )
+                ON CONFLICT (""Code"") DO NOTHING;
+            ");
+
+            // 3) Backfill: rotas pré-existentes apontam para o SystemTokenType 'default'.
+            migrationBuilder.Sql(@"
+                UPDATE ""Routes""
+                SET ""SystemTokenTypeId"" = (SELECT ""Id"" FROM ""SystemTokenTypes"" WHERE ""Code"" = 'default' LIMIT 1)
+                WHERE ""SystemTokenTypeId"" IS NULL;
+            ");
+
+            // 4) Promove para NOT NULL após o backfill.
+            migrationBuilder.AlterColumn<Guid>(
+                name: "SystemTokenTypeId",
+                table: "Routes",
+                type: "uuid",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            // 5) Index e FK com onDelete: Restrict (não permitir apagar SystemTokenType referenciado por rotas).
+            migrationBuilder.CreateIndex(
+                name: "IX_Routes_SystemTokenTypeId",
+                table: "Routes",
+                column: "SystemTokenTypeId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Routes_SystemTokenTypes_SystemTokenTypeId",
+                table: "Routes",
+                column: "SystemTokenTypeId",
+                principalTable: "SystemTokenTypes",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Reverte na ordem inversa. NÃO apaga registros de SystemTokenTypes — eles podem estar em uso
+            // por outros consumidores pós-down (semântica de "release" da coluna, não do catálogo).
+            migrationBuilder.DropForeignKey(
+                name: "FK_Routes_SystemTokenTypes_SystemTokenTypeId",
+                table: "Routes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Routes_SystemTokenTypeId",
+                table: "Routes");
+
+            migrationBuilder.DropColumn(
+                name: "SystemTokenTypeId",
+                table: "Routes");
+        }
+    }
+}

--- a/AuthService/Data/SystemTokenTypeSeeder.cs
+++ b/AuthService/Data/SystemTokenTypeSeeder.cs
@@ -1,0 +1,49 @@
+using AuthService.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace AuthService.Data;
+
+/// <summary>Garante o catálogo canônico de SystemTokenTypes (idempotente).</summary>
+public static class SystemTokenTypeSeeder
+{
+    /// <summary>Code do SystemTokenType padrão usado quando uma rota não especifica política JWT explícita.</summary>
+    public const string DefaultCode = "default";
+
+    private static readonly (string Code, string Name, string Description)[] SystemTokenTypes =
+    [
+        (DefaultCode, "Default", "Política JWT padrão para rotas autenticadas (Bearer JWT do usuário corrente).")
+    ];
+
+    public static async Task EnsureSystemTokenTypesAsync(AppDbContext db, CancellationToken cancellationToken = default)
+    {
+        var utc = DateTime.UtcNow;
+
+        foreach (var (code, name, description) in SystemTokenTypes)
+        {
+            var existing = await db.SystemTokenTypes.IgnoreQueryFilters()
+                .FirstOrDefaultAsync(t => t.Code == code, cancellationToken);
+
+            if (existing is null)
+            {
+                db.SystemTokenTypes.Add(new AppSystemTokenType
+                {
+                    Name = name,
+                    Code = code,
+                    Description = description,
+                    CreatedAt = utc,
+                    UpdatedAt = utc,
+                    DeletedAt = null
+                });
+                continue;
+            }
+
+            existing.Name = name;
+            existing.Description = description;
+            if (existing.DeletedAt is not null)
+                existing.DeletedAt = null;
+            existing.UpdatedAt = utc;
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/AuthService/Models/AppRoute.cs
+++ b/AuthService/Models/AppRoute.cs
@@ -6,6 +6,7 @@ namespace AuthService.Models;
 
 [Index(nameof(Code), IsUnique = true, Name = "UX_Routes_Code")]
 [Index(nameof(SystemId), nameof(Code), IsUnique = true, Name = "UX_Routes_SystemId_Code")]
+[Index(nameof(SystemTokenTypeId), Name = "IX_Routes_SystemTokenTypeId")]
 [Index(nameof(DeletedAt), Name = "IX_Routes_DeletedAt")]
 [Table("Routes")]
 public class AppRoute : ISoftDelete
@@ -26,6 +27,9 @@ public class AppRoute : ISoftDelete
 
     [StringLength(500)]
     public string? Description { get; set; }
+
+    [Required]
+    public Guid SystemTokenTypeId { get; set; }
 
     [Required]
     public DateTime CreatedAt { get; set; }

--- a/AuthService/Program.cs
+++ b/AuthService/Program.cs
@@ -104,6 +104,7 @@ if (!app.Environment.IsEnvironment("Testing"))
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
         await db.Database.MigrateAsync();
         await SystemSeeder.EnsureSystemsAsync(db);
+        await SystemTokenTypeSeeder.EnsureSystemTokenTypesAsync(db);
         await AuthenticatorRoutesSeeder.EnsureRoutesAsync(db);
         await PermissionTypeSeeder.EnsurePermissionTypesAsync(db);
         await AuthenticatorPermissionsSeeder.EnsurePermissionsAsync(db);

--- a/README.md
+++ b/README.md
@@ -261,18 +261,24 @@ Corpo típico de criação/atualização: `name`, `code`, `description` (opciona
 
 `systemId` obrigatório; `code` único globalmente. Listagens consideram sistema pai ativo.
 
+**Política JWT alvo (`systemTokenTypeId`)** — toda rota referencia um `SystemTokenType` (`/api/v1/tokens/types`) ativo via FK NOT NULL. O campo é **obrigatório** em `POST` e `PUT`; payloads sem ele retornam **400** com erro em `ModelState["SystemTokenTypeId"]`. `Guid.Empty`, IDs inexistentes ou referenciando registros soft-deletados também retornam **400**. Restaurar uma rota cujo `SystemTokenType` foi removido depois do soft-delete também retorna **400** (mesmo padrão da validação de sistema inativo).
+
+Existe um catálogo canônico garantido pelo `SystemTokenTypeSeeder` na inicialização do serviço, com pelo menos `Code='default'` (`Name='Default'`). Esse é o code usado como fallback no `sync` quando o item não especifica um `systemTokenTypeCode`.
+
+`GET /api/v1/systems/routes` e `GET /api/v1/systems/routes/{id}` retornam, além dos campos da rota, três campos denormalizados via Join: `systemTokenTypeId`, `systemTokenTypeCode`, `systemTokenTypeName`. Os campos `code` e `name` do token type **não** entram no body de `POST`/`PUT` — são apenas leitura.
+
 **`POST /api/v1/systems/routes/sync`** — auto-registro do catálogo de rotas por um sistema-cliente. Body:
 
 ```json
 {
   "systemCode": "kurtto",
   "routes": [
-    { "code": "KURTTO_V1_X_LIST", "name": "GET /api/v1/x", "description": "...", "permissionTypeCode": "read" }
+    { "code": "KURTTO_V1_X_LIST", "name": "GET /api/v1/x", "description": "...", "permissionTypeCode": "read", "systemTokenTypeCode": "default" }
   ]
 }
 ```
 
-Query string: `?prune=false` (padrão). Quando `prune=true`, rotas do sistema que **sumirem** do payload são soft-deletadas junto com suas Permissions vinculadas. Quando `permissionTypeCode` é informado, a `Permission(Route, Type)` correspondente é criada/reativada automaticamente. Resposta: `{ created, updated, reactivated, deleted }`. Erros: 404 (`systemCode` desconhecido), 400 (`permissionTypeCode` desconhecido ou `code` duplicado no payload), 409 (`code` já em uso por outro sistema — `UX_Routes_Code` é unique global).
+Query string: `?prune=false` (padrão). Quando `prune=true`, rotas do sistema que **sumirem** do payload são soft-deletadas junto com suas Permissions vinculadas. Quando `permissionTypeCode` é informado, a `Permission(Route, Type)` correspondente é criada/reativada automaticamente. `systemTokenTypeCode` é **opcional** — quando omitido, o sync usa `default`. Resposta: `{ created, updated, reactivated, deleted }`. Erros: 404 (`systemCode` desconhecido), 400 (`permissionTypeCode` desconhecido, `systemTokenTypeCode` desconhecido — listando os codes inválidos — ou `code` duplicado no payload), 409 (`code` já em uso por outro sistema — `UX_Routes_Code` é unique global).
 
 ### Usuários — `/api/v1/users`
 


### PR DESCRIPTION
## Resumo

Adiciona campo `SystemTokenTypeId` (FK NOT NULL para `SystemTokenTypes`) em `Routes` para destravar a EPIC `LF-Calegari/lfc-admin-gui#46` (CRUD de Rotas por Sistema). O campo modela a "política JWT alvo" reaproveitando o catálogo já exposto em `/api/v1/tokens/types`, sem nova entidade.

## Mudanças

- **Modelo `AppRoute`**: nova propriedade `Guid SystemTokenTypeId` `[Required]` + `IX_Routes_SystemTokenTypeId`.
- **`AppDbContext`**: relacionamento `HasOne<AppSystemTokenType>()` com `OnDelete(Restrict)`.
- **Migration `Routes_AddSystemTokenTypeId`**: ADD COLUMN nullable, garante `SystemTokenType('default')` via `INSERT ... ON CONFLICT DO NOTHING`, backfill das rotas existentes, `SET NOT NULL`, `IX` e `FK_Routes_SystemTokenTypes_*`. `Down` preserva o catálogo.
- **`SystemTokenTypeSeeder`**: novo seeder canônico idempotente (mesmo padrão de `PermissionTypeSeeder`), garantindo `Code='default'` (`Name='Default'`). Plugado em `Program.cs` e `WebAppFactory` antes de `AuthenticatorRoutesSeeder`.
- **`AuthenticatorRoutesSeeder`**: lookup do `default SystemTokenTypeId` no início; falha clara se ausente.
- **`RoutesController`**:
  - `Create`/`Update` validando FK obrigatória/ativa (400 para `Guid.Empty`, inexistente ou soft-deletado).
  - `GetAll`/`GetById` com Left Join populando `systemTokenTypeId`/`systemTokenTypeCode`/`systemTokenTypeName` denormalizados na response.
  - `Restore` bloqueando quando `SystemTokenType` referenciado está inativo.
  - `Sync` aceita `systemTokenTypeCode` opcional por item (default `default`); codes desconhecidos retornam 400 listando os codes inválidos (mesmo padrão de `PermissionTypeCode`).
- **Tests**:
  - `RoutesApiTests`: payloads ajustados + 12 novos cenários (FK ausente, `Guid.Empty`, inexistente, soft-deletada; `Update` mesmo conjunto; `Restore` com SystemTokenType inativo; `Sync` ausente/desconhecido/conhecido).
  - `PermissionsApiTests.CreateRouteAsync` propaga `systemTokenTypeId` default.
- **README**: documenta o campo obrigatório, os 3 denormalizados na response, e o `systemTokenTypeCode` opcional do sync.

## Checklist do contrato (issue #155)

- [x] Migration aplica em base limpa **e** em base com Routes pré-existentes, sem perda de dados.
- [x] `Down` roda sem erro e não afeta `SystemTokenTypes`.
- [x] `SystemTokenTypeSeeder` idempotente (segunda execução não duplica).
- [x] `POST /systems/routes` exige `SystemTokenTypeId` (400 sem ele).
- [x] `POST /systems/routes` com FK inválida (`Guid.Empty`, inexistente, soft-deletada) → 400.
- [x] `PUT /systems/routes/{id}` mesma cobertura.
- [x] `GET /systems/routes` e `GET /systems/routes/{id}` retornam os 3 campos denormalizados.
- [x] `POST /systems/routes/sync` sem `SystemTokenTypeCode` → usa `default`.
- [x] `POST /systems/routes/sync` com code desconhecido → 400 listando inválidos.
- [x] `POST /systems/routes/{id}/restore` → 400 se SystemTokenType inativo.
- [x] `RoutesApiTests` atualizado e verde.
- [x] OpenAPI/Swagger reflete o novo campo.
- [x] README atualizado.
- [x] `dotnet build`: 0 warnings, 0 errors. `dotnet format --verify-no-changes`: limpo.

## Validação

Executada via Docker (Container Only):

- `dotnet build AuthService.sln`: **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes`: **0 divergências**.
- `dotnet ef migrations has-pending-model-changes`: **No changes** (modelo e snapshot consistentes).
- `docker compose --profile test run --rm test`: **212 passed / 2 failed / 214 total**. As 2 falhas (`AuthApiTests.Permissions_UserWithoutPermissions_ReturnsSystemRouteCatalog` e `ApiVersioningAndDocsTests.SwaggerJson_ContainsOnlyOfficialContractPaths`) **foram reproduzidas idênticas em `origin/development` sem o diff desta PR** (comprovado com `git stash`). São pré-existentes — **não são regressões desta PR**.

## Impacto

**Breaking change**: clientes HTTP que hoje chamam `POST /systems/routes` ou `PUT /systems/routes/{id}` sem `systemTokenTypeId` passarão a receber 400. Consumidor conhecido: `lfc-admin-gui` (atualização coordenada via EPIC `LF-Calegari/lfc-admin-gui#46` e sub-issues `#62`, `#63`, `#64`).

`POST /systems/routes/sync` permanece compatível (campo opcional, default `default`).

## Fora de escopo

- CRUD de `SystemTokenTypes` — já existe em `/api/v1/tokens/types`.
- Múltiplas políticas por rota (M:N) — issue pede campo único.
- Lógica de aplicação da política em validação JWT — apenas catálogo nesta entrega.

## Referências

- EPIC: `LF-Calegari/lfc-admin-gui#46`
- Sub-issues: `LF-Calegari/lfc-admin-gui#62`, `#63`, `#64`
- Padrão de migration prévio: `AuthService/Data/Migrations/20260427120000_PermissionsRelateToRoutes.cs`
- Padrão de seeder prévio: `AuthService/Data/PermissionTypeSeeder.cs`

Closes #155
