### PR TITLE
fix(tests): resolve pre-existing failing tests blocking development QG (#159)

### DIFF
--- a/AuthService.Tests/ApiVersioningAndDocsTests.cs
+++ b/AuthService.Tests/ApiVersioningAndDocsTests.cs
@@ -88,8 +88,11 @@ public class ApiVersioningAndDocsTests : IAsyncLifetime
             "/api/v1/roles",
             "/api/v1/roles/{id}",
             "/api/v1/roles/{id}/restore",
+            "/api/v1/roles/{roleId}/permissions",
+            "/api/v1/roles/{roleId}/permissions/{permissionId}",
             "/api/v1/systems",
             "/api/v1/systems/routes",
+            "/api/v1/systems/routes/sync",
             "/api/v1/systems/routes/{id}",
             "/api/v1/systems/routes/{id}/restore",
             "/api/v1/systems/{id}",
@@ -100,7 +103,11 @@ public class ApiVersioningAndDocsTests : IAsyncLifetime
             "/api/v1/users",
             "/api/v1/users/{id}",
             "/api/v1/users/{id}/password",
-            "/api/v1/users/{id}/restore"
+            "/api/v1/users/{id}/restore",
+            "/api/v1/users/{userId}/permissions",
+            "/api/v1/users/{userId}/permissions/{permissionId}",
+            "/api/v1/users/{userId}/roles",
+            "/api/v1/users/{userId}/roles/{roleId}"
         };
 
         Assert.Equal(expected.OrderBy(p => p, StringComparer.Ordinal), paths);

--- a/AuthService.Tests/AuthApiTests.cs
+++ b/AuthService.Tests/AuthApiTests.cs
@@ -696,8 +696,7 @@ public class AuthApiTests : IAsyncLifetime
     [Fact]
     public async Task Permissions_UserWithoutPermissions_ReturnsSystemRouteCatalog()
     {
-        // Mesmo sem permissões atribuídas, routes reflete o catálogo do sistema do header
-        // (a resposta não filtra rotas por permissão de usuário hoje).
+        // Usuário sem permissões recebe routes vazio (rotas são filtradas por permissão).
         await _admin.PostAsJsonAsync("/api/v1/users",
             new { name = "Empty Perms", email = "empty.perms@example.com", password = "SenhaSegura1!", identity = 1, active = true },
             TestApiClient.JsonOptions);
@@ -717,7 +716,7 @@ public class AuthApiTests : IAsyncLifetime
         Assert.NotNull(body);
         Assert.NotNull(body.User);
         Assert.NotNull(body.Routes);
-        Assert.Contains(DefaultRouteCode, body.Routes);
+        Assert.Empty(body.Routes);
     }
 
     [Fact]

--- a/AuthService/Program.cs
+++ b/AuthService/Program.cs
@@ -71,6 +71,7 @@ builder.Services.AddSwaggerGen(options =>
         In = ParameterLocation.Header,
         Description = "JWT no header Authorization (Bearer {token})."
     });
+    options.CustomSchemaIds(type => type.FullName?.Replace("+", "."));
     options.DocumentFilter<V1PathPrefixDocumentFilter>();
     options.OperationFilter<ContractExamplesOperationFilter>();
 });


### PR DESCRIPTION
## 📌 Contexto

Dois testes em `AuthService.Tests` estavam vermelhos em `origin/development` desde antes da abertura da PR #158 (issue #155). O Quality Gate do SonarCloud falhava em qualquer PR para `development` enquanto isso não fosse corrigido, bloqueando a EPIC `LF-Calegari/lfc-admin-gui#46` e suas dependências (#155, #156, #157).

Esta PR cobre exclusivamente os fixes para destravar o tronco. **Não** introduz nova feature.

## 🎯 Objetivo

- Resolver `ApiVersioningAndDocsTests.SwaggerJson_ContainsOnlyOfficialContractPaths`.
- Resolver `AuthApiTests.Permissions_UserWithoutPermissions_ReturnsSystemRouteCatalog`.
- Voltar a `development` ao estado de Quality Gate verde.

## ⚙️ O que foi feito

### Fix 1 — Swagger schemaId collision

- `AuthService/Program.cs`: adicionado `options.CustomSchemaIds(type => type.FullName?.Replace("+", "."))` no `AddSwaggerGen`.
- Desambigua nested types `AssignPermissionRequest` (uma em `RolesController`, outra em `UsersController`) sem refatorar para classe compartilhada (fora de escopo declarado pela issue).
- Não impacta nenhum endpoint nem schema externo (clientes consomem por path/operation, não por schemaId interno).

### Fix 1.B — Lista expected do teste atualizada

- `AuthService.Tests/ApiVersioningAndDocsTests.cs`: array `expected` agora reflete os paths reais emitidos pelo `swagger/v1/swagger.json` em `development`. Foram **adicionados** 7 paths que já existiam no Swagger mas faltavam na lista:
  - `/api/v1/roles/{roleId}/permissions`
  - `/api/v1/roles/{roleId}/permissions/{permissionId}`
  - `/api/v1/systems/routes/sync`
  - `/api/v1/users/{userId}/permissions`
  - `/api/v1/users/{userId}/permissions/{permissionId}`
  - `/api/v1/users/{userId}/roles`
  - `/api/v1/users/{userId}/roles/{roleId}`
- Lista validada via dump do `swagger.json` real rodado dentro do container de teste.

### Fix 2 — Expectativa do teste de permissões

- `AuthService.Tests/AuthApiTests.cs::Permissions_UserWithoutPermissions_ReturnsSystemRouteCatalog`:
  - Comentário atualizado: `// Usuário sem permissões recebe routes vazio (rotas são filtradas por permissão).`
  - Assertion: `Assert.Contains(DefaultRouteCode, body.Routes)` → `Assert.Empty(body.Routes)`
- Decisão funcional já tomada (referência: PR #149): `/auth/permissions` filtra rotas por permissão de usuário; usuário sem permissões vê `routes: []`.
- O teste `Permissions_AuthenticatorSystem_ReturnsAuthenticatorRoutes` (root vê tudo) **continua verde**.

## 📁 Arquivos impactados

- `AuthService/Program.cs` — config Swashbuckle (`CustomSchemaIds`).
- `AuthService.Tests/ApiVersioningAndDocsTests.cs` — array `expected` 1:1 com paths reais.
- `AuthService.Tests/AuthApiTests.cs` — `Permissions_UserWithoutPermissions_ReturnsSystemRouteCatalog`.

## 🧪 Testes

Tudo via container Docker SDK 10.0 (`docker compose --profile test run --rm test`):

- `dotnet build`: **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes`: **zero divergências**.
- Suite completa: **203 passed / 0 failed / 203 total** (antes: 201 passed / 2 failed / 203 total — ambos os testes vermelhos viraram verdes).

> Observação: a issue mencionou `214/0/214` (provavelmente projeção de outra branch). Em `development` atual a baseline é 203 testes. Os 2 vermelhos preexistentes — alvos exclusivos desta PR — estão verdes; não há regressão.

## 🛡️ Segurança

- Mudança apenas em config de Swashbuckle (schemaIds internos) e em expectativas de testes.
- Comportamento de runtime de **todos os endpoints** inalterado.
- Sem mudança em endpoint/contrato público.

## ⚠️ Riscos

- Nenhum. Sem breaking change.

## 🔗 Issue relacionada

Closes #159