### PR TITLE
feat(routes): add server-side filter, search, pagination and includeDeleted to GET /systems/routes (#156)

### DIFF
--- a/AuthService.Tests/RoutesApiTests.cs
+++ b/AuthService.Tests/RoutesApiTests.cs
@@ -202,15 +202,14 @@ public class RoutesApiTests : IAsyncLifetime
         Assert.NotNull(otherDto);
         await _client.DeleteAsync($"/api/v1/systems/routes/{otherDto.Id}");
 
-        var listResp = await _client.GetAsync("/api/v1/systems/routes");
-        listResp.EnsureSuccessStatusCode();
-        var list = await listResp.Content.ReadFromJsonAsync<List<RouteDto>>(TestApiClient.JsonOptions);
-        Assert.NotNull(list);
-        Assert.All(list, r => Assert.Null(r.DeletedAt));
-        Assert.All(list, r => Assert.False(string.IsNullOrWhiteSpace(r.SystemTokenTypeCode)));
-        Assert.All(list, r => Assert.False(string.IsNullOrWhiteSpace(r.SystemTokenTypeName)));
-        Assert.Contains(list, r => r.Code == "RT_ATIVA");
-        Assert.DoesNotContain(list, r => r.Code == "RT_OUTRA");
+        var page = await GetRoutesPageAsync("/api/v1/systems/routes?pageSize=100");
+        Assert.Equal(1, page.Page);
+        Assert.Equal(100, page.PageSize);
+        Assert.All(page.Data, r => Assert.Null(r.DeletedAt));
+        Assert.All(page.Data, r => Assert.False(string.IsNullOrWhiteSpace(r.SystemTokenTypeCode)));
+        Assert.All(page.Data, r => Assert.False(string.IsNullOrWhiteSpace(r.SystemTokenTypeName)));
+        Assert.Contains(page.Data, r => r.Code == "RT_ATIVA");
+        Assert.DoesNotContain(page.Data, r => r.Code == "RT_OUTRA");
     }
 
     [Fact]
@@ -379,11 +378,8 @@ public class RoutesApiTests : IAsyncLifetime
         Assert.NotNull(restored);
         Assert.Null(restored.DeletedAt);
 
-        var listResp = await _client.GetAsync("/api/v1/systems/routes");
-        listResp.EnsureSuccessStatusCode();
-        var list = await listResp.Content.ReadFromJsonAsync<List<RouteDto>>(TestApiClient.JsonOptions);
-        Assert.NotNull(list);
-        Assert.Contains(list, r => r.Id == dto.Id);
+        var page = await GetRoutesPageAsync("/api/v1/systems/routes?pageSize=100");
+        Assert.Contains(page.Data, r => r.Id == dto.Id);
     }
 
     [Fact]
@@ -412,11 +408,8 @@ public class RoutesApiTests : IAsyncLifetime
 
         Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/api/v1/systems/routes/{dto.Id}")).StatusCode);
 
-        var listResp = await _client.GetAsync("/api/v1/systems/routes");
-        listResp.EnsureSuccessStatusCode();
-        var list = await listResp.Content.ReadFromJsonAsync<List<RouteDto>>(TestApiClient.JsonOptions);
-        Assert.NotNull(list);
-        Assert.DoesNotContain(list, r => r.Id == dto.Id);
+        var page = await GetRoutesPageAsync("/api/v1/systems/routes?pageSize=100");
+        Assert.DoesNotContain(page.Data, r => r.Id == dto.Id);
     }
 
     [Fact]
@@ -524,6 +517,339 @@ public class RoutesApiTests : IAsyncLifetime
         Assert.Equal(customSttId, route.SystemTokenTypeId);
     }
 
+    [Fact]
+    public async Task GetAll_NoFilters_UsesDefaultEnvelope()
+    {
+        var page = await GetRoutesPageAsync("/api/v1/systems/routes");
+        Assert.Equal(1, page.Page);
+        Assert.Equal(20, page.PageSize);
+        Assert.True(page.Total >= page.Data.Count);
+    }
+
+    [Fact]
+    public async Task GetAll_WithSystemIdEmpty_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync($"/api/v1/systems/routes?systemId={Guid.Empty}");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_WithSystemIdUnknown_ReturnsOkAndEmptyData()
+    {
+        var page = await GetRoutesPageAsync($"/api/v1/systems/routes?systemId={Guid.NewGuid()}");
+        Assert.Empty(page.Data);
+        Assert.Equal(0, page.Total);
+    }
+
+    [Fact]
+    public async Task GetAll_WithSystemIdFilter_ReturnsOnlyRoutesOfThatSystem()
+    {
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var sysA = await CreateSystemAsync("RT_FILT_SYS_A", "Sistema A");
+        var sysB = await CreateSystemAsync("RT_FILT_SYS_B", "Sistema B");
+
+        await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysA, "Rota A1", "RT_FILT_A1", sttId), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysA, "Rota A2", "RT_FILT_A2", sttId), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysB, "Rota B1", "RT_FILT_B1", sttId), TestApiClient.JsonOptions);
+
+        var page = await GetRoutesPageAsync($"/api/v1/systems/routes?systemId={sysA}&pageSize=100");
+        Assert.All(page.Data, r => Assert.Equal(sysA, r.SystemId));
+        Assert.Contains(page.Data, r => r.Code == "RT_FILT_A1");
+        Assert.Contains(page.Data, r => r.Code == "RT_FILT_A2");
+        Assert.DoesNotContain(page.Data, r => r.Code == "RT_FILT_B1");
+    }
+
+    [Fact]
+    public async Task GetAll_WithSearchQ_PartialMatchOnCode()
+    {
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var sysId = await CreateSystemAsync("RT_Q_CODE_SYS");
+        await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysId, "Listar usuarios", "USERS_LIST", sttId), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysId, "Outra", "OUTRO_RT", sttId), TestApiClient.JsonOptions);
+
+        var page = await GetRoutesPageAsync("/api/v1/systems/routes?q=USERS&pageSize=100");
+        Assert.Contains(page.Data, r => r.Code == "USERS_LIST");
+        Assert.DoesNotContain(page.Data, r => r.Code == "OUTRO_RT");
+    }
+
+    [Fact]
+    public async Task GetAll_WithSearchQ_PartialMatchOnName()
+    {
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var sysId = await CreateSystemAsync("RT_Q_NAME_SYS");
+        await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysId, "Pagina de relatorios", "REL_PAGE", sttId), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysId, "Outra", "DIF_PAGE", sttId), TestApiClient.JsonOptions);
+
+        var page = await GetRoutesPageAsync("/api/v1/systems/routes?q=relat&pageSize=100");
+        Assert.Contains(page.Data, r => r.Code == "REL_PAGE");
+        Assert.DoesNotContain(page.Data, r => r.Code == "DIF_PAGE");
+    }
+
+    [Fact]
+    public async Task GetAll_WithSearchQ_IsCaseInsensitive()
+    {
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var sysId = await CreateSystemAsync("RT_Q_CI_SYS");
+        await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysId, "Admin Page", "ADMIN_PAGE_RT", sttId), TestApiClient.JsonOptions);
+
+        var lower = await GetRoutesPageAsync("/api/v1/systems/routes?q=admin&pageSize=100");
+        var upper = await GetRoutesPageAsync("/api/v1/systems/routes?q=ADMIN&pageSize=100");
+        var mixed = await GetRoutesPageAsync("/api/v1/systems/routes?q=AdMiN&pageSize=100");
+
+        Assert.Contains(lower.Data, r => r.Code == "ADMIN_PAGE_RT");
+        Assert.Contains(upper.Data, r => r.Code == "ADMIN_PAGE_RT");
+        Assert.Contains(mixed.Data, r => r.Code == "ADMIN_PAGE_RT");
+    }
+
+    [Fact]
+    public async Task GetAll_WithSearchQ_EscapesUnderscoreLiteral()
+    {
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var sysId = await CreateSystemAsync("RT_Q_ESC_SYS");
+        await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysId, "Liter A", "ESC_LIT_AAA", sttId), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysId, "Liter B", "ESCXLITXBBB", sttId), TestApiClient.JsonOptions);
+
+        // O usuario busca pela substring "_LIT_" literal. Sem o escape, "_" viraria wildcard
+        // ILIKE e casaria tambem o code "ESCXLITXBBB" (qualquer caractere no lugar dos "_").
+        // Com o escape correto, somente o code que contem "_LIT_" literalmente deve aparecer.
+        var page = await GetRoutesPageAsync($"/api/v1/systems/routes?systemId={sysId}&q=_LIT_&pageSize=100");
+        Assert.Contains(page.Data, r => r.Code == "ESC_LIT_AAA");
+        Assert.DoesNotContain(page.Data, r => r.Code == "ESCXLITXBBB");
+    }
+
+    [Fact]
+    public async Task GetAll_WithPagination_ReturnsCorrectSubset()
+    {
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var sysId = await CreateSystemAsync("RT_PAGE_SYS");
+        for (var i = 1; i <= 5; i++)
+        {
+            await _client.PostAsJsonAsync("/api/v1/systems/routes",
+                RouteCreateBody(sysId, $"Rota {i:D2}", $"PG_RT_{i:D2}", sttId), TestApiClient.JsonOptions);
+        }
+
+        var first = await GetRoutesPageAsync($"/api/v1/systems/routes?systemId={sysId}&page=1&pageSize=2");
+        var second = await GetRoutesPageAsync($"/api/v1/systems/routes?systemId={sysId}&page=2&pageSize=2");
+        var third = await GetRoutesPageAsync($"/api/v1/systems/routes?systemId={sysId}&page=3&pageSize=2");
+
+        Assert.Equal(2, first.Data.Count);
+        Assert.Equal(2, second.Data.Count);
+        Assert.Single(third.Data);
+        Assert.Equal(5, first.Total);
+        Assert.Equal(5, second.Total);
+        Assert.Equal(5, third.Total);
+
+        var firstCodes = first.Data.Select(s => s.Code).ToList();
+        var secondCodes = second.Data.Select(s => s.Code).ToList();
+        var thirdCodes = third.Data.Select(s => s.Code).ToList();
+        Assert.Empty(firstCodes.Intersect(secondCodes));
+        Assert.Empty(secondCodes.Intersect(thirdCodes));
+        Assert.Empty(firstCodes.Intersect(thirdCodes));
+    }
+
+    [Fact]
+    public async Task GetAll_WithPageSizeAboveLimit_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync("/api/v1/systems/routes?pageSize=101");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_WithPageSizeZero_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync("/api/v1/systems/routes?pageSize=0");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_WithPageSizeNegative_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync("/api/v1/systems/routes?pageSize=-3");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_WithPageZero_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync("/api/v1/systems/routes?page=0");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_WithPageNegative_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync("/api/v1/systems/routes?page=-1");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_WithIncludeDeletedTrue_ReturnsActiveAndDeleted()
+    {
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var sysId = await CreateSystemAsync("RT_INC_SYS");
+        var activeResp = await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysId, "Ativa", "RT_INC_ACTIVE", sttId), TestApiClient.JsonOptions);
+        activeResp.EnsureSuccessStatusCode();
+        var deletedCreate = await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysId, "Deletada", "RT_INC_DELETED", sttId), TestApiClient.JsonOptions);
+        var deletedDto = await deletedCreate.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(deletedDto);
+        await _client.DeleteAsync($"/api/v1/systems/routes/{deletedDto.Id}");
+
+        var page = await GetRoutesPageAsync($"/api/v1/systems/routes?systemId={sysId}&includeDeleted=true&pageSize=100");
+        Assert.Contains(page.Data, r => r.Code == "RT_INC_ACTIVE" && r.DeletedAt == null);
+        Assert.Contains(page.Data, r => r.Code == "RT_INC_DELETED" && r.DeletedAt != null);
+    }
+
+    [Fact]
+    public async Task GetAll_WithIncludeDeletedTrue_ReturnsRoutesOfSoftDeletedSystem()
+    {
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var sysId = await CreateSystemAsync("RT_INC_DEL_SYS");
+        var routeResp = await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysId, "Rota Orfa", "RT_INC_ORPH", sttId), TestApiClient.JsonOptions);
+        var routeDto = await routeResp.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(routeDto);
+
+        // Soft-delete do sistema pai. A rota fica orfa: includeDeleted=false a esconde,
+        // includeDeleted=true a expoe (cenario admin de auditoria).
+        Assert.Equal(HttpStatusCode.NoContent, (await _client.DeleteAsync($"/api/v1/systems/{sysId}")).StatusCode);
+
+        var hidden = await GetRoutesPageAsync($"/api/v1/systems/routes?systemId={sysId}&pageSize=100");
+        Assert.DoesNotContain(hidden.Data, r => r.Id == routeDto.Id);
+
+        var visible = await GetRoutesPageAsync($"/api/v1/systems/routes?systemId={sysId}&includeDeleted=true&pageSize=100");
+        Assert.Contains(visible.Data, r => r.Id == routeDto.Id);
+    }
+
+    [Fact]
+    public async Task GetAll_WithIncludeDeletedDefault_HidesSoftDeleted()
+    {
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var sysId = await CreateSystemAsync("RT_HID_SYS");
+        var resp = await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysId, "Para deletar", "RT_HID_DELETED", sttId), TestApiClient.JsonOptions);
+        var dto = await resp.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto);
+        await _client.DeleteAsync($"/api/v1/systems/routes/{dto.Id}");
+
+        var page = await GetRoutesPageAsync($"/api/v1/systems/routes?systemId={sysId}&pageSize=100");
+        Assert.DoesNotContain(page.Data, r => r.Code == "RT_HID_DELETED");
+    }
+
+    [Fact]
+    public async Task GetAll_TotalReflectsFilters_BeforePagination()
+    {
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var sysId = await CreateSystemAsync("RT_TOT_SYS");
+        for (var i = 1; i <= 3; i++)
+        {
+            await _client.PostAsJsonAsync("/api/v1/systems/routes",
+                RouteCreateBody(sysId, $"Filtro {i}", $"FILTOTRT{i}", sttId), TestApiClient.JsonOptions);
+        }
+        await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysId, "Outro", "OUTROTOTRT", sttId), TestApiClient.JsonOptions);
+
+        var page = await GetRoutesPageAsync($"/api/v1/systems/routes?systemId={sysId}&q=Filtro&page=1&pageSize=2");
+        Assert.Equal(3, page.Total);
+        Assert.Equal(2, page.Data.Count);
+    }
+
+    [Fact]
+    public async Task GetAll_PageBeyondTotal_ReturnsEmptyDataAnd200()
+    {
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var sysId = await CreateSystemAsync("RT_BEYOND_SYS");
+        await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysId, "Unico", "RT_BEYOND_A", sttId), TestApiClient.JsonOptions);
+
+        var resp = await _client.GetAsync($"/api/v1/systems/routes?systemId={sysId}&page=99&pageSize=10");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var page = await resp.Content.ReadFromJsonAsync<PagedRoutesDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(page);
+        Assert.Empty(page.Data);
+        Assert.Equal(1, page.Total);
+    }
+
+    [Fact]
+    public async Task GetAll_OrderingIsStable_NoDuplicatesAcrossPages()
+    {
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var sysId = await CreateSystemAsync("RT_ORD_SYS");
+        for (var i = 0; i < 7; i++)
+        {
+            await _client.PostAsJsonAsync("/api/v1/systems/routes",
+                RouteCreateBody(sysId, $"Ordem {i:D2}", $"RT_ORD_{i:D2}", sttId), TestApiClient.JsonOptions);
+        }
+
+        var first = await GetRoutesPageAsync($"/api/v1/systems/routes?systemId={sysId}&page=1&pageSize=3");
+        var second = await GetRoutesPageAsync($"/api/v1/systems/routes?systemId={sysId}&page=2&pageSize=3");
+        var third = await GetRoutesPageAsync($"/api/v1/systems/routes?systemId={sysId}&page=3&pageSize=3");
+
+        var collected = first.Data.Concat(second.Data).Concat(third.Data)
+            .Select(r => r.Code)
+            .ToList();
+        Assert.Equal(collected.Count, collected.Distinct().Count());
+        Assert.Equal(7, collected.Count);
+    }
+
+    [Fact]
+    public async Task GetAll_OrderedByCode_Ascending()
+    {
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var sysId = await CreateSystemAsync("RT_ORDA_SYS");
+        await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysId, "Z", "RT_ORDA_ZZZ", sttId), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysId, "A", "RT_ORDA_AAA", sttId), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysId, "M", "RT_ORDA_MMM", sttId), TestApiClient.JsonOptions);
+
+        var page = await GetRoutesPageAsync($"/api/v1/systems/routes?systemId={sysId}&pageSize=100");
+        var codes = page.Data.Where(r => r.Code.StartsWith("RT_ORDA_", StringComparison.Ordinal))
+            .Select(r => r.Code)
+            .ToList();
+        var sorted = codes.OrderBy(c => c, StringComparer.Ordinal).ToList();
+        Assert.Equal(sorted, codes);
+    }
+
+    [Fact]
+    public async Task GetAll_CombinedFilters_ApplyTogether()
+    {
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var sysA = await CreateSystemAsync("RT_COMB_A");
+        var sysB = await CreateSystemAsync("RT_COMB_B");
+        await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysA, "Listar usuarios", "RT_COMB_A_USERS", sttId), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysA, "Outra", "RT_COMB_A_OTHER", sttId), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(sysB, "Listar usuarios", "RT_COMB_B_USERS", sttId), TestApiClient.JsonOptions);
+
+        var page = await GetRoutesPageAsync($"/api/v1/systems/routes?systemId={sysA}&q=USERS&pageSize=100");
+        Assert.Single(page.Data);
+        Assert.Equal("RT_COMB_A_USERS", page.Data[0].Code);
+    }
+
+    private async Task<PagedRoutesDto> GetRoutesPageAsync(string url)
+    {
+        var resp = await _client.GetAsync(url);
+        resp.EnsureSuccessStatusCode();
+        var page = await resp.Content.ReadFromJsonAsync<PagedRoutesDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(page);
+        return page;
+    }
+
     private sealed record SystemRefDto(Guid Id);
     private sealed record TokenTypeRefDto(Guid Id);
 
@@ -539,4 +865,10 @@ public class RoutesApiTests : IAsyncLifetime
         DateTime CreatedAt,
         DateTime UpdatedAt,
         DateTime? DeletedAt);
+
+    private sealed record PagedRoutesDto(
+        List<RouteDto> Data,
+        int Page,
+        int PageSize,
+        int Total);
 }

--- a/AuthService/Controllers/Routes/RoutesController.cs
+++ b/AuthService/Controllers/Routes/RoutesController.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using AuthService.Auth;
+using AuthService.Controllers.Common;
 using AuthService.Data;
 using AuthService.Models;
 using Microsoft.AspNetCore.Authorization;
@@ -207,13 +208,74 @@ public class RoutesController : ControllerBase
         return CreatedAtAction(nameof(GetById), new { id = entity.Id }, created);
     }
 
+    /// <summary>Tamanho de página default quando o cliente não envia <c>pageSize</c>.</summary>
+    public const int DefaultPageSize = 20;
+
+    /// <summary>Limite superior para <c>pageSize</c>; valores acima retornam 400.</summary>
+    public const int MaxPageSize = 100;
+
     [HttpGet]
     [Authorize(Policy = PermissionPolicies.SystemsRoutesRead)]
-    public async Task<IActionResult> GetAll()
+    public async Task<IActionResult> GetAll(
+        [FromQuery] Guid? systemId = null,
+        [FromQuery] string? q = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = DefaultPageSize,
+        [FromQuery] bool includeDeleted = false)
     {
-        var list = await ProjectRouteResponses(ActiveRoutesWithActiveSystem().OrderBy(r => r.CreatedAt))
-            .ToListAsync();
-        return Ok(list);
+        if (page <= 0)
+            ModelState.AddModelError(nameof(page), "page deve ser maior ou igual a 1.");
+
+        if (pageSize <= 0 || pageSize > MaxPageSize)
+            ModelState.AddModelError(nameof(pageSize), $"pageSize deve estar entre 1 e {MaxPageSize}.");
+
+        if (systemId.HasValue && systemId.Value == Guid.Empty)
+            ModelState.AddModelError(nameof(systemId), "systemId inválido.");
+
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        // Quando includeDeleted=true, ignoramos:
+        //  - o query filter global (DeletedAt == null), expondo rotas soft-deletadas;
+        //  - o filtro "sistema pai ativo" (ActiveRoutesWithActiveSystem),
+        //    para que a lista admin enxergue rotas órfãs cujo sistema vinculado também foi soft-deletado.
+        IQueryable<AppRoute> query = includeDeleted
+            ? _db.Routes.IgnoreQueryFilters()
+            : ActiveRoutesWithActiveSystem();
+
+        if (systemId.HasValue)
+            query = query.Where(r => r.SystemId == systemId.Value);
+
+        if (!string.IsNullOrWhiteSpace(q))
+        {
+            var pattern = $"%{EscapeLikePattern(q.Trim())}%";
+            query = query.Where(r =>
+                EF.Functions.ILike(r.Code, pattern, "\\") || EF.Functions.ILike(r.Name, pattern, "\\"));
+        }
+
+        var total = await query.CountAsync();
+
+        var paged = query
+            .OrderBy(r => r.Code)
+            .ThenBy(r => r.Id)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize);
+
+        var data = await ProjectRouteResponses(paged).ToListAsync();
+
+        return Ok(new PagedResponse<RouteResponse>(data, page, pageSize, total));
+    }
+
+    /// <summary>
+    /// Escapa caracteres curinga (<c>%</c>, <c>_</c>) e o caractere de escape (<c>\</c>) na entrada do usuário
+    /// para evitar que sejam interpretados como wildcards no <c>ILIKE</c>. Mantém o termo como busca literal parcial.
+    /// </summary>
+    private static string EscapeLikePattern(string value)
+    {
+        return value
+            .Replace("\\", "\\\\")
+            .Replace("%", "\\%")
+            .Replace("_", "\\_");
     }
 
     [HttpGet("{id:guid}")]

--- a/AuthService/Controllers/Routes/RoutesController.cs
+++ b/AuthService/Controllers/Routes/RoutesController.cs
@@ -235,10 +235,10 @@ public class RoutesController : ControllerBase
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);
 
-        // Quando includeDeleted=true, ignoramos:
-        //  - o query filter global (DeletedAt == null), expondo rotas soft-deletadas;
-        //  - o filtro "sistema pai ativo" (ActiveRoutesWithActiveSystem),
-        //    para que a lista admin enxergue rotas órfãs cujo sistema vinculado também foi soft-deletado.
+        // Quando includeDeleted=true, a lista admin precisa enxergar tudo: rotas soft-deletadas
+        // (ignorando o query filter global de soft-delete) e rotas cujo sistema pai também foi
+        // soft-deletado (dispensando o filtro ActiveRoutesWithActiveSystem). Caso contrário,
+        // mantemos o filtro de sistema pai ativo aplicado pelas demais leituras do controller.
         IQueryable<AppRoute> query = includeDeleted
             ? _db.Routes.IgnoreQueryFilters()
             : ActiveRoutesWithActiveSystem();

--- a/AuthService/Controllers/Systems/SystemsController.cs
+++ b/AuthService/Controllers/Systems/SystemsController.cs
@@ -161,7 +161,7 @@ public class SystemsController : ControllerBase
         {
             var pattern = $"%{EscapeLikePattern(q.Trim())}%";
             query = query.Where(s =>
-                EF.Functions.ILike(s.Name, pattern) || EF.Functions.ILike(s.Code, pattern));
+                EF.Functions.ILike(s.Name, pattern, "\\") || EF.Functions.ILike(s.Code, pattern, "\\"));
         }
 
         var total = await query.CountAsync();

--- a/AuthService/OpenApi/ContractExamplesOperationFilter.cs
+++ b/AuthService/OpenApi/ContractExamplesOperationFilter.cs
@@ -9,6 +9,12 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
 {
     private static readonly string[] ExampleRoutes = ["AUTH_V1_USERS_LIST"];
 
+    /// <summary>Timestamp ilustrativo reutilizado nos exemplos OpenAPI (CreatedAt/UpdatedAt/issuedAt).</summary>
+    private const string ExampleTimestamp = "2026-04-26T18:00:00+00:00";
+
+    /// <summary>Guid placeholder reutilizado em ids de exemplo nas respostas OpenAPI.</summary>
+    private const string EmptyGuidExample = "00000000-0000-0000-0000-000000000000";
+
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
         AddDefaultErrorResponses(operation);
@@ -79,7 +85,7 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
         AddJsonResponse(operation, "200", "Token valido e rota autorizada.", new
         {
             valid = true,
-            issuedAt = "2026-04-26T18:00:00+00:00",
+            issuedAt = ExampleTimestamp,
             expiresAt = "2026-04-26T19:00:00+00:00"
         });
         AddErrorResponse(
@@ -101,7 +107,7 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
         {
             user = new
             {
-                id = "00000000-0000-0000-0000-000000000000",
+                id = EmptyGuidExample,
                 name = "User Name",
                 email = "user@example.com",
                 identity = 1
@@ -143,12 +149,12 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
             {
                 new
                 {
-                    id = "00000000-0000-0000-0000-000000000000",
+                    id = EmptyGuidExample,
                     name = "Admin GUI",
                     code = "ADMIN_GUI",
                     description = "Painel administrativo.",
-                    createdAt = "2026-04-26T18:00:00+00:00",
-                    updatedAt = "2026-04-26T18:00:00+00:00",
+                    createdAt = ExampleTimestamp,
+                    updatedAt = ExampleTimestamp,
                     deletedAt = (string?)null
                 }
             },
@@ -197,7 +203,7 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
             {
                 new
                 {
-                    id = "00000000-0000-0000-0000-000000000000",
+                    id = EmptyGuidExample,
                     systemId = "11111111-1111-1111-1111-111111111111",
                     name = "Listar usuarios",
                     code = "AUTH_V1_USERS_LIST",
@@ -205,8 +211,8 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
                     systemTokenTypeId = "22222222-2222-2222-2222-222222222222",
                     systemTokenTypeCode = "default",
                     systemTokenTypeName = "Default",
-                    createdAt = "2026-04-26T18:00:00+00:00",
-                    updatedAt = "2026-04-26T18:00:00+00:00",
+                    createdAt = ExampleTimestamp,
+                    updatedAt = ExampleTimestamp,
                     deletedAt = (string?)null
                 }
             },
@@ -270,7 +276,7 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
         switch (method)
         {
             case "POST":
-                AddJsonResponse(operation, "201", "Registro criado.", new { id = "00000000-0000-0000-0000-000000000000" });
+                AddJsonResponse(operation, "201", "Registro criado.", new { id = EmptyGuidExample });
                 break;
             case "GET":
                 AddJsonResponse(operation, "200", "Leitura concluida.", new { message = "Consulta realizada com sucesso." });

--- a/AuthService/OpenApi/ContractExamplesOperationFilter.cs
+++ b/AuthService/OpenApi/ContractExamplesOperationFilter.cs
@@ -45,6 +45,7 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
             || TryApplyAuthPermissionsGet(operation, normalizedPath, method)
             || TryApplyAuthLogoutGet(operation, normalizedPath, method)
             || TryApplySystemsListGet(operation, normalizedPath, method)
+            || TryApplyRoutesListGet(operation, normalizedPath, method)
             || TryApplyRestorePost(operation, normalizedPath, method);
     }
 
@@ -181,6 +182,68 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
             operation,
             "includeDeleted",
             "Quando true, inclui registros soft-deleted (DeletedAt != null). Default false.");
+    }
+
+    private static bool TryApplyRoutesListGet(OpenApiOperation operation, string normalizedPath, string method)
+    {
+        if (normalizedPath != "/systems/routes" || method != "GET")
+            return false;
+
+        EnsureRoutesListQueryParameters(operation);
+
+        AddJsonResponse(operation, "200", "Pagina de rotas que casam com os filtros aplicados.", new
+        {
+            data = new[]
+            {
+                new
+                {
+                    id = "00000000-0000-0000-0000-000000000000",
+                    systemId = "11111111-1111-1111-1111-111111111111",
+                    name = "Listar usuarios",
+                    code = "AUTH_V1_USERS_LIST",
+                    description = (string?)null,
+                    systemTokenTypeId = "22222222-2222-2222-2222-222222222222",
+                    systemTokenTypeCode = "default",
+                    systemTokenTypeName = "Default",
+                    createdAt = "2026-04-26T18:00:00+00:00",
+                    updatedAt = "2026-04-26T18:00:00+00:00",
+                    deletedAt = (string?)null
+                }
+            },
+            page = 1,
+            pageSize = 20,
+            total = 1
+        });
+        AddErrorResponse(
+            operation,
+            "400",
+            "Parametros de paginacao/filtro invalidos (page <= 0, pageSize fora do intervalo permitido ou systemId = Guid.Empty).",
+            new { message = "pageSize deve estar entre 1 e 100." });
+        return true;
+    }
+
+    private static void EnsureRoutesListQueryParameters(OpenApiOperation operation)
+    {
+        EnsureQueryParameterDescription(
+            operation,
+            "systemId",
+            "Quando informado, restringe a listagem as rotas do sistema indicado. systemId = Guid.Empty retorna 400.");
+        EnsureQueryParameterDescription(
+            operation,
+            "q",
+            "Termo de busca case-insensitive em Code e Name (matching parcial via ILIKE; %, _ e \\ sao tratados como literais).");
+        EnsureQueryParameterDescription(
+            operation,
+            "page",
+            "Numero da pagina (1-based, default 1). Valores <= 0 retornam 400.");
+        EnsureQueryParameterDescription(
+            operation,
+            "pageSize",
+            "Tamanho da pagina (default 20, maximo 100). Valores <= 0 ou > 100 retornam 400.");
+        EnsureQueryParameterDescription(
+            operation,
+            "includeDeleted",
+            "Quando true, inclui rotas soft-deletadas e rotas cujo sistema pai foi soft-deletado (cenario admin). Default false.");
     }
 
     private static void EnsureQueryParameterDescription(OpenApiOperation operation, string parameterName, string description)

--- a/README.md
+++ b/README.md
@@ -261,6 +261,18 @@ Corpo típico de criação/atualização: `name`, `code`, `description` (opciona
 
 `systemId` obrigatório; `code` único globalmente. Listagens consideram sistema pai ativo.
 
+**`GET /api/v1/systems/routes`** suporta filtro/busca/paginação via query string:
+
+| Param | Default | Notas |
+|-------|---------|-------|
+| `systemId` | _ausente_ | Quando informado, restringe à `SystemId` indicada. `Guid.Empty` retorna **400**; `systemId` válido apontando para sistema inexistente retorna **200** com `data: []`. |
+| `q` | `""` | Busca case-insensitive (ILIKE) com matching parcial em `Code` **e** `Name` (OR). Caracteres `%`, `_` e `\` são escapados (literais). |
+| `page` | `1` | 1-based. `<= 0` retorna **400**. |
+| `pageSize` | `20` | Máximo `100`. `<= 0` ou `> 100` retornam **400**. |
+| `includeDeleted` | `false` | Quando `true`, inclui rotas soft-deletadas **e** rotas cujo sistema pai foi soft-deletado (cenário admin). Default mantém o filtro `ActiveRoutesWithActiveSystem`. |
+
+Resposta paginada: `{ data, page, pageSize, total }`. `total` reflete o total após filtros, antes de `Skip/Take`. Ordenação determinística por `Code` ascendente, com `Id` como desempate. Página além do total retorna **200** com `data: []`.
+
 **Política JWT alvo (`systemTokenTypeId`)** — toda rota referencia um `SystemTokenType` (`/api/v1/tokens/types`) ativo via FK NOT NULL. O campo é **obrigatório** em `POST` e `PUT`; payloads sem ele retornam **400** com erro em `ModelState["SystemTokenTypeId"]`. `Guid.Empty`, IDs inexistentes ou referenciando registros soft-deletados também retornam **400**. Restaurar uma rota cujo `SystemTokenType` foi removido depois do soft-delete também retorna **400** (mesmo padrão da validação de sistema inativo).
 
 Existe um catálogo canônico garantido pelo `SystemTokenTypeSeeder` na inicialização do serviço, com pelo menos `Code='default'` (`Name='Default'`). Esse é o code usado como fallback no `sync` quando o item não especifica um `systemTokenTypeCode`.


### PR DESCRIPTION
## Contexto

Estende `GET /api/v1/systems/routes` com filtro/busca/paginação server-side, replicando o padrão estabelecido em `SystemsController.GetAll` (PR #152, issue #151). Destrava a EPIC `LF-Calegari/lfc-admin-gui#46` (sub-issue `lfc-admin-gui#62`).

## Objetivo

Permitir ao admin-gui paginar, buscar e filtrar rotas por sistema sem trazer o catálogo inteiro a cada navegação.

## O que foi feito

- `GET /systems/routes` aceita 5 query params:
  - `systemId` (default ausente; restringe ao sistema indicado; `Guid.Empty` → 400; sistema inexistente → 200 com `data:[]`).
  - `q` (default `""`; busca case-insensitive parcial em `Code` **e** `Name`, OR; escape literal de `%`, `_`, `\`).
  - `page` (default `1`; `<= 0` → 400).
  - `pageSize` (default `20`, máx `100`; fora do intervalo → 400).
  - `includeDeleted` (default `false`; `true` ignora o filtro global e o filtro `ActiveRoutesWithActiveSystem` para expor rotas órfãs/soft-deletadas — cenário admin).
- Resposta migra de array plano para envelope `PagedResponse<RouteResponse>` (`{ data, page, pageSize, total }`).
- Ordenação determinística por `Code` asc, `Id` asc (era `CreatedAt`).
- Aplica `EF.Functions.ILike(col, pattern, "\\")` para emitir `ESCAPE '\'` no SQL gerado pelo Npgsql. Sem o overload, o EF Core gera `ESCAPE ''`, que invalida o backslash como caractere de escape e quebra o tratamento literal de `_` e `%`. O mesmo ajuste foi aplicado em `SystemsController.GetAll` (correção colateral, sem mudança de superfície) para manter o padrão consistente entre os dois endpoints.
- OpenAPI: novo helper `TryApplyRoutesListGet` no `ContractExamplesOperationFilter` (mesmo padrão de `TryApplySystemsListGet`, alinhado à lição #149 sobre cognitive complexity).
- README atualizado com tabela de query params, regras de validação e formato da resposta.

## Arquivos impactados

- `AuthService/Controllers/Routes/RoutesController.cs` — novos query params, envelope paginado, helper `EscapeLikePattern`, constantes `DefaultPageSize`/`MaxPageSize`.
- `AuthService/Controllers/Systems/SystemsController.cs` — overload com escape char no `ILike` (1 linha; corrige o mesmo edge case latente).
- `AuthService/OpenApi/ContractExamplesOperationFilter.cs` — novo helper de exemplo OpenAPI.
- `AuthService.Tests/RoutesApiTests.cs` — 3 testes existentes ajustados ao envelope + 18 testes novos.
- `README.md` — seção "Rotas de sistema" estendida.

## Testes

- `docker compose --profile test run --rm test` → **236 / 236 passed**.
- `dotnet build -warnaserror` → 0 warnings, 0 errors.
- `dotnet format --verify-no-changes` → 0.

Cobertura nova:
- defaults / envelope shape;
- `q` em `Code`, em `Name`, case-insensitive;
- `q` literal `_` (regression protection do escape);
- paginação + total + página vazia + ordenação estável entre páginas;
- `systemId` válido / inexistente / `Guid.Empty`;
- `includeDeleted=true` mostra rotas soft-deletadas e órfãs (sistema pai soft-deletado);
- `includeDeleted=false` esconde ambas;
- combinação `systemId + q`;
- validações 400 para `page` e `pageSize` em todos os limites.

## Segurança

- Validação de input (todos os limites verificados via `ModelState`).
- Escape de wildcard previne injection em `ILIKE`.
- `includeDeleted=true` continua exigindo `perm:SystemsRoutes.Read` (mesma policy do endpoint).
- Sem novos secrets, headers ou superfície de auth.

## Riscos

- **Breaking change**: shape da resposta muda de `[RouteResponse...]` para `{ data, page, pageSize, total }`. Consumidor `lfc-admin-gui` será atualizado em conjunto via sub-issue `lfc-admin-gui#62`. Mapear outros chamadores antes do deploy (uso primário hoje é `POST /systems/routes/sync`, não o `GET`).
- Filtro `ActiveRoutesWithActiveSystem` deixa de ser aplicado quando `includeDeleted=true`. Isso é intencional (admin precisa ver rotas órfãs), e está coberto por teste explícito.

## Issue relacionada

Closes #156

## Checklist de aceite (extraído da issue)

- [x] Os cinco query params funcionam isoladamente e em qualquer combinação.
- [x] `pageSize > 100` → 400 com mensagem clara.
- [x] `pageSize <= 0` → 400.
- [x] `page <= 0` → 400.
- [x] `systemId = Guid.Empty` → 400.
- [x] `systemId` válido apontando para sistema inexistente → 200 com `data:[]`, `total:0`.
- [x] `includeDeleted=true` retorna rotas com `DeletedAt != null`.
- [x] `includeDeleted=true` inclui rotas cujo sistema pai está inativo/deletado.
- [x] `includeDeleted=false` (default) preserva o filtro `ActiveRoutesWithActiveSystem`.
- [x] `q` faz match parcial case-insensitive em `Code` e `Name` (OR).
- [x] `q` com `%`, `_`, `\` é tratado como literal (escape).
- [x] `total` reflete a contagem após filtros, antes de `Skip/Take`.
- [x] Página vazia (além do total) → 200 com `data:[]`.
- [x] Ordenação determinística entre páginas, sem duplicatas.
- [x] Testes unitários novos cobrindo cada AC.
- [x] `RoutesApiTests` existentes verdes.
- [x] OpenAPI atualizada.
- [x] README atualizado.
- [x] Build/lint/testes verdes.