### PR TITLE
feat(routes): block DELETE when active Permissions are linked (#157)

### DIFF
--- a/AuthService.Tests/PermissionsApiTests.cs
+++ b/AuthService.Tests/PermissionsApiTests.cs
@@ -318,6 +318,9 @@ public class PermissionsApiTests : IAsyncLifetime
     [Fact]
     public async Task GetAll_AndGetById_ExcludeWhenRouteSoftDeleted()
     {
+        // Issue #157 alterou o contrato: rotas com Permissions ativas não podem ser deletadas (409).
+        // Para validar a invariante "permissão some do GET após soft-delete da rota",
+        // o teste primeiro soft-deleta a permissão (liberando a rota para DELETE), depois soft-deleta a rota.
         var sysId = await CreateSystemAsync("PERM_SYS_ORPH");
         var routeId = await CreateRouteAsync(sysId, "PERM_ROUTE_ORPH");
         var typeId = await CreatePermissionTypeAsync("PERM_TYPE_ORPH");
@@ -325,7 +328,8 @@ public class PermissionsApiTests : IAsyncLifetime
         var dto = await create.Content.ReadFromJsonAsync<PermissionDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
-        await _client.DeleteAsync($"/api/v1/systems/routes/{routeId}");
+        Assert.Equal(HttpStatusCode.NoContent, (await _client.DeleteAsync($"/api/v1/permissions/{dto.Id}")).StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent, (await _client.DeleteAsync($"/api/v1/systems/routes/{routeId}")).StatusCode);
 
         Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/api/v1/permissions/{dto.Id}")).StatusCode);
 

--- a/AuthService.Tests/RoutesApiTests.cs
+++ b/AuthService.Tests/RoutesApiTests.cs
@@ -358,6 +358,229 @@ public class RoutesApiTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Delete_WithoutLinkedPermissions_ReturnsNoContent()
+    {
+        // Issue #157: rota sem Permissions vinculadas mantém o comportamento legado (204).
+        var sysId = await CreateSystemAsync("RT_SYS_LP_NONE");
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var routeId = await CreateRouteForLinkedPermissionsAsync(sysId, "S", "RT_LP_NONE", sttId);
+
+        var del = await _client.DeleteAsync($"/api/v1/systems/routes/{routeId}");
+        Assert.Equal(HttpStatusCode.NoContent, del.StatusCode);
+
+        await AssertRouteSoftDeletedAsync(routeId, expectDeleted: true);
+    }
+
+    [Fact]
+    public async Task Delete_WithOneActiveLinkedPermission_ReturnsConflictAndDoesNotMutate()
+    {
+        // Issue #157: 1 Permission ativa bloqueia o DELETE com 409 e linkedPermissionsCount=1.
+        var sysId = await CreateSystemAsync("RT_SYS_LP_ONE");
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var routeId = await CreateRouteForLinkedPermissionsAsync(sysId, "S", "RT_LP_ONE", sttId);
+        var typeId = await CreatePermissionTypeForLinkedPermissionsAsync("RT_LP_ONE_TYPE");
+
+        var perm = await _client.PostAsJsonAsync("/api/v1/permissions",
+            new { routeId, permissionTypeId = typeId, description = (string?)null }, TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.Created, perm.StatusCode);
+        var permDto = await perm.Content.ReadFromJsonAsync<PermissionRefDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(permDto);
+
+        var del = await _client.DeleteAsync($"/api/v1/systems/routes/{routeId}");
+        Assert.Equal(HttpStatusCode.Conflict, del.StatusCode);
+
+        var payload = await del.Content.ReadFromJsonAsync<DeleteConflictDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(payload);
+        Assert.Equal(1, payload.LinkedPermissionsCount);
+        Assert.False(string.IsNullOrWhiteSpace(payload.Message));
+        Assert.Contains("permissões ativas vinculadas", payload.Message);
+
+        // Caminho 409: rota não soft-deletada e permissão preservada.
+        await AssertRouteSoftDeletedAsync(routeId, expectDeleted: false);
+        await AssertPermissionDeletedAtAsync(permDto.Id, expectDeleted: false);
+    }
+
+    [Fact]
+    public async Task Delete_WithThreeActiveLinkedPermissions_ReturnsConflictWithCountThree()
+    {
+        // Issue #157: linkedPermissionsCount reflete a contagem exata de Permissions ativas.
+        var sysId = await CreateSystemAsync("RT_SYS_LP_THREE");
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var routeId = await CreateRouteForLinkedPermissionsAsync(sysId, "S", "RT_LP_THREE", sttId);
+
+        for (var i = 0; i < 3; i++)
+        {
+            var typeId = await CreatePermissionTypeForLinkedPermissionsAsync($"RT_LP_THREE_T{i}");
+            var perm = await _client.PostAsJsonAsync("/api/v1/permissions",
+                new { routeId, permissionTypeId = typeId, description = (string?)null }, TestApiClient.JsonOptions);
+            Assert.Equal(HttpStatusCode.Created, perm.StatusCode);
+        }
+
+        var del = await _client.DeleteAsync($"/api/v1/systems/routes/{routeId}");
+        Assert.Equal(HttpStatusCode.Conflict, del.StatusCode);
+        var payload = await del.Content.ReadFromJsonAsync<DeleteConflictDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(payload);
+        Assert.Equal(3, payload.LinkedPermissionsCount);
+
+        await AssertRouteSoftDeletedAsync(routeId, expectDeleted: false);
+    }
+
+    [Fact]
+    public async Task Delete_WithOnlySoftDeletedLinkedPermissions_ReturnsNoContent()
+    {
+        // Issue #157: Permissions soft-deletadas não bloqueiam (alinhado ao filtro global do EF).
+        var sysId = await CreateSystemAsync("RT_SYS_LP_SOFT");
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var routeId = await CreateRouteForLinkedPermissionsAsync(sysId, "S", "RT_LP_SOFT", sttId);
+        var typeId = await CreatePermissionTypeForLinkedPermissionsAsync("RT_LP_SOFT_TYPE");
+
+        var perm = await _client.PostAsJsonAsync("/api/v1/permissions",
+            new { routeId, permissionTypeId = typeId, description = (string?)null }, TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.Created, perm.StatusCode);
+        var permDto = await perm.Content.ReadFromJsonAsync<PermissionRefDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(permDto);
+
+        var deletePerm = await _client.DeleteAsync($"/api/v1/permissions/{permDto.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, deletePerm.StatusCode);
+        await AssertPermissionDeletedAtAsync(permDto.Id, expectDeleted: true);
+
+        var del = await _client.DeleteAsync($"/api/v1/systems/routes/{routeId}");
+        Assert.Equal(HttpStatusCode.NoContent, del.StatusCode);
+        await AssertRouteSoftDeletedAsync(routeId, expectDeleted: true);
+    }
+
+    [Fact]
+    public async Task Delete_WithMixedActiveAndSoftDeletedPermissions_ReturnsConflictWithActiveCountOnly()
+    {
+        // Issue #157: contagem ignora permissões soft-deletadas e foca apenas nas ativas.
+        var sysId = await CreateSystemAsync("RT_SYS_LP_MIX");
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var routeId = await CreateRouteForLinkedPermissionsAsync(sysId, "S", "RT_LP_MIX", sttId);
+
+        var typeIdA = await CreatePermissionTypeForLinkedPermissionsAsync("RT_LP_MIX_TA");
+        var typeIdB = await CreatePermissionTypeForLinkedPermissionsAsync("RT_LP_MIX_TB");
+        var typeIdC = await CreatePermissionTypeForLinkedPermissionsAsync("RT_LP_MIX_TC");
+
+        var permA = await _client.PostAsJsonAsync("/api/v1/permissions",
+            new { routeId, permissionTypeId = typeIdA, description = (string?)null }, TestApiClient.JsonOptions);
+        var permB = await _client.PostAsJsonAsync("/api/v1/permissions",
+            new { routeId, permissionTypeId = typeIdB, description = (string?)null }, TestApiClient.JsonOptions);
+        var permC = await _client.PostAsJsonAsync("/api/v1/permissions",
+            new { routeId, permissionTypeId = typeIdC, description = (string?)null }, TestApiClient.JsonOptions);
+
+        Assert.Equal(HttpStatusCode.Created, permA.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, permB.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, permC.StatusCode);
+
+        var permADto = await permA.Content.ReadFromJsonAsync<PermissionRefDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(permADto);
+
+        // Soft-delete da Permission A — restam B e C ativas vinculadas à rota.
+        Assert.Equal(HttpStatusCode.NoContent,
+            (await _client.DeleteAsync($"/api/v1/permissions/{permADto.Id}")).StatusCode);
+
+        var del = await _client.DeleteAsync($"/api/v1/systems/routes/{routeId}");
+        Assert.Equal(HttpStatusCode.Conflict, del.StatusCode);
+        var payload = await del.Content.ReadFromJsonAsync<DeleteConflictDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(payload);
+        Assert.Equal(2, payload.LinkedPermissionsCount);
+
+        await AssertRouteSoftDeletedAsync(routeId, expectDeleted: false);
+    }
+
+    [Fact]
+    public async Task Delete_BlockedByPermissions_DoesNotPersistAnySideEffect()
+    {
+        // Issue #157: contrato de "no side-effect" no caminho 409 — UpdatedAt da rota e DeletedAt
+        // da permissão devem permanecer idênticos aos valores de antes da chamada bloqueada.
+        var sysId = await CreateSystemAsync("RT_SYS_LP_NOSIDE");
+        var sttId = await GetDefaultSystemTokenTypeIdAsync();
+        var routeId = await CreateRouteForLinkedPermissionsAsync(sysId, "S", "RT_LP_NOSIDE", sttId);
+        var typeId = await CreatePermissionTypeForLinkedPermissionsAsync("RT_LP_NOSIDE_TYPE");
+
+        var perm = await _client.PostAsJsonAsync("/api/v1/permissions",
+            new { routeId, permissionTypeId = typeId, description = (string?)null }, TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.Created, perm.StatusCode);
+        var permDto = await perm.Content.ReadFromJsonAsync<PermissionRefDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(permDto);
+
+        var (routeUpdatedBefore, routeDeletedBefore) = await GetRouteTimestampsAsync(routeId);
+        var (permUpdatedBefore, permDeletedBefore) = await GetPermissionTimestampsAsync(permDto.Id);
+
+        var del = await _client.DeleteAsync($"/api/v1/systems/routes/{routeId}");
+        Assert.Equal(HttpStatusCode.Conflict, del.StatusCode);
+
+        var (routeUpdatedAfter, routeDeletedAfter) = await GetRouteTimestampsAsync(routeId);
+        var (permUpdatedAfter, permDeletedAfter) = await GetPermissionTimestampsAsync(permDto.Id);
+
+        Assert.Equal(routeUpdatedBefore, routeUpdatedAfter);
+        Assert.Equal(routeDeletedBefore, routeDeletedAfter);
+        Assert.Null(routeDeletedAfter);
+
+        Assert.Equal(permUpdatedBefore, permUpdatedAfter);
+        Assert.Equal(permDeletedBefore, permDeletedAfter);
+        Assert.Null(permDeletedAfter);
+    }
+
+    private async Task<Guid> CreateRouteForLinkedPermissionsAsync(Guid systemId, string name, string code, Guid systemTokenTypeId)
+    {
+        var resp = await _client.PostAsJsonAsync("/api/v1/systems/routes",
+            RouteCreateBody(systemId, name, code, systemTokenTypeId), TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        var dto = await resp.Content.ReadFromJsonAsync<RouteDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto);
+        return dto.Id;
+    }
+
+    private async Task<Guid> CreatePermissionTypeForLinkedPermissionsAsync(string code)
+    {
+        var resp = await _client.PostAsJsonAsync("/api/v1/permissions/types",
+            new { name = code, code, description = (string?)null }, TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        var dto = await resp.Content.ReadFromJsonAsync<PermissionTypeRefDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto);
+        return dto.Id;
+    }
+
+    private async Task AssertRouteSoftDeletedAsync(Guid routeId, bool expectDeleted)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var row = await db.Routes.IgnoreQueryFilters().SingleAsync(r => r.Id == routeId);
+        if (expectDeleted)
+            Assert.NotNull(row.DeletedAt);
+        else
+            Assert.Null(row.DeletedAt);
+    }
+
+    private async Task AssertPermissionDeletedAtAsync(Guid permissionId, bool expectDeleted)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var row = await db.Permissions.IgnoreQueryFilters().SingleAsync(p => p.Id == permissionId);
+        if (expectDeleted)
+            Assert.NotNull(row.DeletedAt);
+        else
+            Assert.Null(row.DeletedAt);
+    }
+
+    private async Task<(DateTime UpdatedAt, DateTime? DeletedAt)> GetRouteTimestampsAsync(Guid routeId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var row = await db.Routes.IgnoreQueryFilters().SingleAsync(r => r.Id == routeId);
+        return (row.UpdatedAt, row.DeletedAt);
+    }
+
+    private async Task<(DateTime UpdatedAt, DateTime? DeletedAt)> GetPermissionTimestampsAsync(Guid permissionId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var row = await db.Permissions.IgnoreQueryFilters().SingleAsync(p => p.Id == permissionId);
+        return (row.UpdatedAt, row.DeletedAt);
+    }
+
+    [Fact]
     public async Task Restore_Deleted_ThenAppearsInGetAll_AndGetByIdWorks()
     {
         var sysId = await CreateSystemAsync("RT_SYS_R1");
@@ -852,6 +1075,10 @@ public class RoutesApiTests : IAsyncLifetime
 
     private sealed record SystemRefDto(Guid Id);
     private sealed record TokenTypeRefDto(Guid Id);
+    private sealed record PermissionRefDto(Guid Id);
+    private sealed record PermissionTypeRefDto(Guid Id);
+
+    private sealed record DeleteConflictDto(string Message, int LinkedPermissionsCount);
 
     private sealed record RouteDto(
         Guid Id,

--- a/AuthService/Controllers/Routes/RoutesController.cs
+++ b/AuthService/Controllers/Routes/RoutesController.cs
@@ -345,6 +345,14 @@ public class RoutesController : ControllerBase
         return Ok(updated);
     }
 
+    /// <summary>
+    /// Mensagem estável retornada no payload do <c>409</c> quando o soft-delete da rota é
+    /// bloqueado por Permissions ativas vinculadas. Mantida como constante para que testes
+    /// possam validar substring sem depender de literal duplicado.
+    /// </summary>
+    public const string DeleteBlockedByPermissionsMessage =
+        "Não é possível excluir a rota: existem permissões ativas vinculadas. Remova as permissões antes.";
+
     [HttpDelete("{id:guid}")]
     [Authorize(Policy = PermissionPolicies.SystemsRoutesDelete)]
     public async Task<IActionResult> DeleteById(Guid id)
@@ -352,6 +360,21 @@ public class RoutesController : ControllerBase
         var entity = await _db.Routes.FirstOrDefaultAsync(r => r.Id == id);
         if (entity is null)
             return NotFound(new { message = "Route não encontrada." });
+
+        // Bloqueio cooperativo: Permissions ativas (DeletedAt == null) vinculadas a esta rota
+        // impedem o soft-delete (issue #157). Permissions soft-deletadas não bloqueiam, em
+        // consonância com o filtro global do EF — a UX admin já não as enxerga. O caminho 409
+        // não persiste nenhuma alteração (entity permanece com DeletedAt/UpdatedAt originais).
+        var linkedPermissionsCount = await _db.Permissions
+            .CountAsync(p => p.RouteId == id);
+        if (linkedPermissionsCount > 0)
+        {
+            return Conflict(new
+            {
+                message = DeleteBlockedByPermissionsMessage,
+                linkedPermissionsCount
+            });
+        }
 
         entity.DeletedAt = DateTime.UtcNow;
         entity.UpdatedAt = DateTime.UtcNow;

--- a/AuthService/OpenApi/ContractExamplesOperationFilter.cs
+++ b/AuthService/OpenApi/ContractExamplesOperationFilter.cs
@@ -52,6 +52,7 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
             || TryApplyAuthLogoutGet(operation, normalizedPath, method)
             || TryApplySystemsListGet(operation, normalizedPath, method)
             || TryApplyRoutesListGet(operation, normalizedPath, method)
+            || TryApplyRoutesDelete(operation, normalizedPath, method)
             || TryApplyRestorePost(operation, normalizedPath, method);
     }
 
@@ -133,6 +134,33 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
             return false;
 
         AddJsonResponse(operation, "200", "Restauracao concluida.", new { message = "Registro restaurado com sucesso." });
+        return true;
+    }
+
+    private static bool TryApplyRoutesDelete(OpenApiOperation operation, string normalizedPath, string method)
+    {
+        // DELETE /systems/routes/{id} (issue #157): documentar o 409 com payload
+        // { message, linkedPermissionsCount } quando há Permissions ativas vinculadas.
+        if (method != "DELETE" || !normalizedPath.StartsWith("/systems/routes/", StringComparison.Ordinal))
+            return false;
+        if (normalizedPath.EndsWith("/restore", StringComparison.Ordinal))
+            return false;
+
+        AddNoContentResponse(operation);
+        AddErrorResponse(
+            operation,
+            "404",
+            "Route nao encontrada.",
+            new { message = "Route não encontrada." });
+        AddErrorResponse(
+            operation,
+            "409",
+            "Route possui Permissions ativas vinculadas; remova as permissoes antes de excluir.",
+            new
+            {
+                message = "Não é possível excluir a rota: existem permissões ativas vinculadas. Remova as permissões antes.",
+                linkedPermissionsCount = 1
+            });
         return true;
     }
 

--- a/README.md
+++ b/README.md
@@ -255,11 +255,13 @@ Corpo típico de criação/atualização: `name`, `code`, `description` (opciona
 | `GET` | `/api/v1/systems/routes` | Sim | `perm:SystemsRoutes.Read` |
 | `GET` | `/api/v1/systems/routes/{id}` | Sim | `perm:SystemsRoutes.Read` |
 | `PUT` | `/api/v1/systems/routes/{id}` | Sim | `perm:SystemsRoutes.Update` |
-| `DELETE` | `/api/v1/systems/routes/{id}` | Sim | `perm:SystemsRoutes.Delete` |
+| `DELETE` | `/api/v1/systems/routes/{id}` | Sim | `perm:SystemsRoutes.Delete` (¹) |
 | `POST` | `/api/v1/systems/routes/{id}/restore` | Sim | `perm:SystemsRoutes.Restore` |
 | `POST` | `/api/v1/systems/routes/sync` | Sim | `perm:SystemsRoutes.Update` |
 
 `systemId` obrigatório; `code` único globalmente. Listagens consideram sistema pai ativo.
+
+(¹) **`DELETE /api/v1/systems/routes/{id}`** retorna **409 Conflict** quando a rota tem `Permissions` ativas (`DeletedAt IS NULL`) vinculadas. Payload: `{ "message": "Não é possível excluir a rota: existem permissões ativas vinculadas. Remova as permissões antes.", "linkedPermissionsCount": N }`. No caminho 409, nenhum side-effect é persistido (rota e permissões permanecem inalteradas). Permissões soft-deletadas não bloqueiam o delete. Para forçar a remoção, exclua/soft-delete as Permissions vinculadas antes (ou use `POST /sync?prune=true` para cascade pelo catálogo).
 
 **`GET /api/v1/systems/routes`** suporta filtro/busca/paginação via query string:
 


### PR DESCRIPTION
## Contexto

Implementa o bloqueio do `DELETE /api/v1/systems/routes/{id}` quando a rota tem Permissions ativas vinculadas, conforme contrato detalhado na issue #157. Destrava a sub-issue `lfc-admin-gui#65` (mensagem clara em modal de exclusão).

## Objetivo

- Antes do soft-delete da rota, contar Permissions ativas (`DeletedAt IS NULL`) com `RouteId == id`.
- Se `count >= 1` → `409 Conflict` com `{ message, linkedPermissionsCount: N }`.
- Se `count == 0` → soft-delete + `204` (preserva comportamento atual).
- `404` para rota inexistente preservado.
- Caminho `409` é side-effect free (rota e permissões permanecem inalteradas).
- Permissões soft-deletadas **não** bloqueiam (alinhado ao filtro global do EF).

## O que foi feito

- `RoutesController.DeleteById`: pré-verificação via `_db.Permissions.CountAsync(p => p.RouteId == id)`. Filtro global de soft-delete já remove permissões deletadas da contagem. Constante `DeleteBlockedByPermissionsMessage` (mensagem PT-BR estável para tests).
- `ContractExamplesOperationFilter`: novo helper `TryApplyRoutesDelete` que documenta 404 e 409 com payload exemplificando `linkedPermissionsCount` para `DELETE /systems/routes/{id}` (mantém o dispatcher curto, alinhado à lição PR #149 sobre Cognitive Complexity).
- `README.md`: nota footnote `(¹)` na tabela de endpoints de rotas explicando o 409, payload e como contornar (deletar Permissions primeiro ou usar `sync?prune=true`).
- `RoutesApiTests`: 6 cenários novos (`Delete_WithoutLinkedPermissions...204`, `Delete_WithOneActiveLinkedPermission...409`, `Delete_WithThreeActiveLinkedPermissions...409`, `Delete_WithOnlySoftDeletedLinkedPermissions...204`, `Delete_WithMixedActiveAndSoftDeletedPermissions...409 com count=2`, `Delete_BlockedByPermissions_DoesNotPersistAnySideEffect`).
- `PermissionsApiTests.GetAll_AndGetById_ExcludeWhenRouteSoftDeleted`: ajustado para soft-deletar a permissão antes da rota, preservando a invariante que o teste valida e respeitando o novo bloqueio do DELETE.

## Arquivos impactados

- `AuthService/Controllers/Routes/RoutesController.cs`
- `AuthService/OpenApi/ContractExamplesOperationFilter.cs`
- `AuthService.Tests/RoutesApiTests.cs`
- `AuthService.Tests/PermissionsApiTests.cs`
- `README.md`

## Testes

Container Only (Docker SDK 10.0):

- `dotnet build` → `0 Warning(s), 0 Error(s)`
- `dotnet format --verify-no-changes` → sem divergências
- `docker compose --profile test run --rm test` → **242/0/242** (era 236; +6 novos testes da issue)

## Segurança

Sem impacto. A operação continua sob `[Authorize(Policy = SystemsRoutesDelete)]`. Validação de input (Guid via route-binding) e payload de erro não vazam dados sensíveis. Sem queries SQL raw / interpolação. Sem novos secrets.

## Riscos / Pendências

- **Breaking change parcial**: clientes que confiavam que `DELETE` sempre retornava `204`/`404` passam a ver `409`. Documentado na issue. Consumidor: `lfc-admin-gui` (sub-issue #65 trata UX).
- N+1: nenhum (única query adicional `Count`, `O(1)` rota → permissions usando índice `IX_Permissions_RouteId`).
- Memory leak: nenhum (sem novos timers/listeners/streams).
- Migration: nenhuma (apenas mudança de comportamento, sem schema).

## Issue relacionada

Closes #157