### PR TITLE
feat(users): add force-logout endpoint to invalidate target user sessions (#168)

### DIFF
--- a/AuthService.Tests/ApiVersioningAndDocsTests.cs
+++ b/AuthService.Tests/ApiVersioningAndDocsTests.cs
@@ -102,6 +102,7 @@ public class ApiVersioningAndDocsTests : IAsyncLifetime
             "/api/v1/tokens/types/{id}/restore",
             "/api/v1/users",
             "/api/v1/users/{id}",
+            "/api/v1/users/{id}/force-logout",
             "/api/v1/users/{id}/password",
             "/api/v1/users/{id}/restore",
             "/api/v1/users/{userId}/permissions",

--- a/AuthService.Tests/UsersApiTests.cs
+++ b/AuthService.Tests/UsersApiTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
+using AuthService.Controllers.Auth;
 using AuthService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -417,6 +419,154 @@ public class UsersApiTests : IAsyncLifetime
         var response = await _client.GetAsync($"/api/v1/users/{Guid.NewGuid()}");
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
+
+    [Fact]
+    public async Task ForceLogout_HappyPath_OldTokenStartsToFailWith401_AndIncrementsTokenVersion()
+    {
+        // Cria target e faz login para obter um token "antigo".
+        await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("Force Target", "force.target@example.com"), TestApiClient.JsonOptions);
+
+        var systemId = await TestApiClient.GetSystemIdAsync(_factory, TestApiClient.DefaultSystemCode);
+        var anon = _factory.CreateApiClient();
+        var login = await anon.PostAsJsonAsync("/api/v1/auth/login",
+            new { email = "force.target@example.com", password = "SenhaSegura1!", systemId },
+            TestApiClient.JsonOptions);
+        login.EnsureSuccessStatusCode();
+        var loginDto = await login.Content.ReadFromJsonAsync<LoginDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(loginDto);
+        var oldToken = loginDto.Token;
+
+        // Resolve o id do target para enviar à API.
+        Guid targetId;
+        int beforeTokenVersion;
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var row = await db.Users.AsNoTracking().FirstAsync(u => u.Email == "force.target@example.com");
+            targetId = row.Id;
+            beforeTokenVersion = row.TokenVersion;
+        }
+
+        var force = await _client.PostAsync($"/api/v1/users/{targetId}/force-logout", content: null);
+        Assert.Equal(HttpStatusCode.OK, force.StatusCode);
+
+        using var payload = JsonDocument.Parse(await force.Content.ReadAsStringAsync());
+        var root = payload.RootElement;
+        Assert.Equal("Sessões do usuário invalidadas com sucesso.", root.GetProperty("message").GetString());
+        Assert.Equal(targetId, root.GetProperty("userId").GetGuid());
+        Assert.Equal(beforeTokenVersion + 1, root.GetProperty("newTokenVersion").GetInt32());
+
+        // Persistência: TokenVersion incrementado.
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var row = await db.Users.AsNoTracking().FirstAsync(u => u.Id == targetId);
+            Assert.Equal(beforeTokenVersion + 1, row.TokenVersion);
+        }
+
+        // Token antigo deve falhar com 401 ao chamar endpoint protegido (claim tv não bate mais).
+        using var verifyReq = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/verify-token");
+        verifyReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", oldToken);
+        verifyReq.Headers.Add(AuthController.SystemIdHeader, systemId.ToString("D"));
+        verifyReq.Headers.Add(AuthController.RouteCodeHeader, "AUTH_V1_USERS_LIST");
+        var verifyRes = await anon.SendAsync(verifyReq);
+        Assert.Equal(HttpStatusCode.Unauthorized, verifyRes.StatusCode);
+    }
+
+    [Fact]
+    public async Task ForceLogout_Idempotent_EachCallIncrementsTokenVersion()
+    {
+        var create = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("Force Idem", "force.idem@example.com"), TestApiClient.JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto);
+
+        var first = await _client.PostAsync($"/api/v1/users/{dto.Id}/force-logout", content: null);
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+        var second = await _client.PostAsync($"/api/v1/users/{dto.Id}/force-logout", content: null);
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var row = await db.Users.AsNoTracking().FirstAsync(u => u.Id == dto.Id);
+        Assert.Equal(2, row.TokenVersion);
+    }
+
+    [Fact]
+    public async Task ForceLogout_SelfTarget_ReturnsBadRequest()
+    {
+        // Resolve o id do caller atual (root) consultando o banco.
+        Guid callerId;
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var row = await db.Users.AsNoTracking().FirstAsync(u => u.Email == RootUserSeeder.RootEmail);
+            callerId = row.Id;
+        }
+
+        var force = await _client.PostAsync($"/api/v1/users/{callerId}/force-logout", content: null);
+        Assert.Equal(HttpStatusCode.BadRequest, force.StatusCode);
+
+        using var payload = JsonDocument.Parse(await force.Content.ReadAsStringAsync());
+        var message = payload.RootElement.GetProperty("message").GetString();
+        Assert.Contains("/auth/logout", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ForceLogout_TargetNotFound_Returns404()
+    {
+        var force = await _client.PostAsync($"/api/v1/users/{Guid.NewGuid()}/force-logout", content: null);
+        Assert.Equal(HttpStatusCode.NotFound, force.StatusCode);
+    }
+
+    [Fact]
+    public async Task ForceLogout_TargetSoftDeleted_Returns404()
+    {
+        var create = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("Force Deleted", "force.deleted@example.com"), TestApiClient.JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto);
+
+        var del = await _client.DeleteAsync($"/api/v1/users/{dto.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, del.StatusCode);
+
+        var force = await _client.PostAsync($"/api/v1/users/{dto.Id}/force-logout", content: null);
+        Assert.Equal(HttpStatusCode.NotFound, force.StatusCode);
+    }
+
+    [Fact]
+    public async Task ForceLogout_CallerWithoutPermission_Returns403()
+    {
+        // Cria usuário-target.
+        var createTarget = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("Target Privilege", "force.target.priv@example.com"), TestApiClient.JsonOptions);
+        var target = await createTarget.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(target);
+
+        // Cria caller sem nenhuma role/permissão (user comum) e faz login com ele.
+        await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("Caller No Perm", "caller.noperm@example.com"), TestApiClient.JsonOptions);
+
+        var systemId = await TestApiClient.GetSystemIdAsync(_factory, TestApiClient.DefaultSystemCode);
+        var anon = _factory.CreateApiClient();
+        var login = await anon.PostAsJsonAsync("/api/v1/auth/login",
+            new { email = "caller.noperm@example.com", password = "SenhaSegura1!", systemId },
+            TestApiClient.JsonOptions);
+        login.EnsureSuccessStatusCode();
+        var loginDto = await login.Content.ReadFromJsonAsync<LoginDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(loginDto);
+
+        using var req = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/api/v1/users/{target.Id}/force-logout");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", loginDto.Token);
+        req.Headers.Add(AuthController.SystemIdHeader, systemId.ToString("D"));
+        var response = await anon.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    private sealed record LoginDto(string Token);
 
     private sealed record UserDto(
         Guid Id,

--- a/AuthService/Controllers/Users/UsersController.cs
+++ b/AuthService/Controllers/Users/UsersController.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
 using AuthService.Auth;
 using AuthService.Data;
 using AuthService.Models;
@@ -14,16 +15,21 @@ namespace AuthService.Controllers.Users;
 
 [ApiController]
 [Route("users")]
-public class UsersController : ControllerBase
+public partial class UsersController : ControllerBase
 {
     private const string UserNotFoundMessage = "Usuário não encontrado.";
+    private const string ForceLogoutSelfMessage =
+        "Não é possível forçar logout de si mesmo por este endpoint. Utilize GET /auth/logout.";
+    private const string InvalidCallerTokenMessage = "Token do chamador inválido.";
     private const int MaxBatchIds = 100;
 
     private readonly AppDbContext _db;
+    private readonly ILogger<UsersController> _logger;
 
-    public UsersController(AppDbContext db)
+    public UsersController(AppDbContext db, ILogger<UsersController> logger)
     {
         _db = db;
+        _logger = logger;
     }
 
     public class CreateUserRequest
@@ -444,6 +450,45 @@ public class UsersController : ControllerBase
         await _db.SaveChangesAsync();
         return Ok(new { message = "Usuário restaurado com sucesso." });
     }
+
+    public record ForceLogoutResponse(string Message, Guid UserId, int NewTokenVersion);
+
+    /// <summary>
+    /// Invalida todas as sessões ativas do usuário-alvo incrementando o <c>TokenVersion</c>.
+    /// Caller deve possuir <c>perm:Users.Update</c>. Self-target retorna 400 (orienta uso de
+    /// <c>GET /auth/logout</c>). Usuário inexistente ou soft-deletado retorna 404.
+    /// </summary>
+    [HttpPost("{id:guid}/force-logout")]
+    [Authorize(Policy = PermissionPolicies.UsersUpdate)]
+    public async Task<IActionResult> ForceLogout(Guid id)
+    {
+        var sub = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrEmpty(sub) || !Guid.TryParse(sub, out var callerId))
+            return Unauthorized(new { message = InvalidCallerTokenMessage });
+
+        if (callerId == id)
+            return BadRequest(new { message = ForceLogoutSelfMessage });
+
+        // Query filter global já remove soft-deletados (DeletedAt != null) → 404 esperado.
+        var user = await _db.Users.FirstOrDefaultAsync(u => u.Id == id);
+        if (user is null)
+            return NotFound(new { message = UserNotFoundMessage });
+
+        user.TokenVersion++;
+        user.UpdatedAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+
+        LogForceLogoutCompleted(user.Id, callerId, user.TokenVersion);
+        return Ok(new ForceLogoutResponse(
+            "Sessões do usuário invalidadas com sucesso.",
+            user.Id,
+            user.TokenVersion));
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "ForceLogout: target {UserId}, by {CallerId}, newTokenVersion={NewTokenVersion}")]
+    private partial void LogForceLogoutCompleted(Guid userId, Guid callerId, int newTokenVersion);
 
     public class AssignPermissionRequest
     {

--- a/AuthService/Data/AuthenticatorRoutesSeeder.cs
+++ b/AuthService/Data/AuthenticatorRoutesSeeder.cs
@@ -149,6 +149,8 @@ public static class AuthenticatorRoutesSeeder
             "Remove (soft-delete) um usuário."),
         ("AUTH_V1_USERS_RESTORE", "POST /api/v1/users/{id}/restore",
             "Restaura um usuário previamente removido."),
+        ("AUTH_V1_USERS_FORCE_LOGOUT", "POST /api/v1/users/{id}/force-logout",
+            "Invalida todas as sessões ativas do usuário-alvo (admin) via incremento do TokenVersion."),
         ("AUTH_V1_USERS_PERMISSIONS_ASSIGN", "POST /api/v1/users/{id}/permissions",
             "Vincula uma permissão diretamente ao usuário."),
         ("AUTH_V1_USERS_PERMISSIONS_REMOVE", "DELETE /api/v1/users/{id}/permissions/{permissionId}",

--- a/AuthService/OpenApi/ContractExamplesOperationFilter.cs
+++ b/AuthService/OpenApi/ContractExamplesOperationFilter.cs
@@ -53,6 +53,7 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
             || TryApplySystemsListGet(operation, normalizedPath, method)
             || TryApplyRoutesListGet(operation, normalizedPath, method)
             || TryApplyRoutesDelete(operation, normalizedPath, method)
+            || TryApplyUsersForceLogoutPost(operation, normalizedPath, method)
             || TryApplyRestorePost(operation, normalizedPath, method);
     }
 
@@ -134,6 +135,34 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
             return false;
 
         AddJsonResponse(operation, "200", "Restauracao concluida.", new { message = "Registro restaurado com sucesso." });
+        return true;
+    }
+
+    private static bool TryApplyUsersForceLogoutPost(OpenApiOperation operation, string normalizedPath, string method)
+    {
+        // POST /users/{id}/force-logout (issue #168): admin invalida sessões ativas do usuário-alvo
+        // incrementando o TokenVersion. Self-target retorna 400, soft-deleted/inexistente retorna 404.
+        if (method != "POST" || !normalizedPath.StartsWith("/users/", StringComparison.Ordinal))
+            return false;
+        if (!normalizedPath.EndsWith("/force-logout", StringComparison.Ordinal))
+            return false;
+
+        AddJsonResponse(operation, "200", "Sessoes do usuario invalidadas com sucesso.", new
+        {
+            message = "Sessões do usuário invalidadas com sucesso.",
+            userId = EmptyGuidExample,
+            newTokenVersion = 1
+        });
+        AddErrorResponse(
+            operation,
+            "400",
+            "Caller tentou forcar logout de si mesmo (use GET /auth/logout em vez disso).",
+            new { message = "Não é possível forçar logout de si mesmo por este endpoint. Utilize GET /auth/logout." });
+        AddErrorResponse(
+            operation,
+            "404",
+            "Usuario nao encontrado ou soft-deletado.",
+            new { message = "Usuário não encontrado." });
         return true;
     }
 

--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Query string: `?prune=false` (padrão). Quando `prune=true`, rotas do sistema qu
 | `PUT` | `/api/v1/users/{id}/password` | Sim | `perm:Users.Update` |
 | `DELETE` | `/api/v1/users/{id}` | Sim | `perm:Users.Delete` |
 | `POST` | `/api/v1/users/{id}/restore` | Sim | `perm:Users.Restore` |
+| `POST` | `/api/v1/users/{id}/force-logout` | Sim | `perm:Users.Update` |
 | `POST` | `/api/v1/users/{id}/permissions` | Sim | `perm:Users.Update` |
 | `DELETE` | `/api/v1/users/{id}/permissions/{permissionId}` | Sim | `perm:Users.Update` |
 | `POST` | `/api/v1/users/{id}/roles` | Sim | `perm:Users.Update` |
@@ -313,6 +314,18 @@ Query string: `?prune=false` (padrão). Quando `prune=true`, rotas do sistema qu
 **POST:** `name`, `email`, `password`, `identity`, `active` (opcional, padrão `true`). **PUT** usuário: `name`, `email`, `identity`, `active` (sem senha). Email normalizado (ex.: minúsculas).
 
 **GET** `/api/v1/users/{id}` retorna também os vínculos ativos **`roles`** (lista com `id` inteiro, `userId`, `roleId`, auditoria e `deletedAt`) e **`permissions`** (lista com `id` GUID, `userId`, `permissionId`, auditoria e `deletedAt`). Listagens **`GET /api/v1/users`** e respostas de criação/atualização devolvem `roles` e `permissions` como arrays vazios.
+
+**`POST /api/v1/users/{id}/force-logout`** — admin invalida todas as sessões ativas do usuário-alvo incrementando o `TokenVersion`. Mesmo mecanismo do `GET /auth/logout`, porém aplicado a um terceiro. Caller precisa de `perm:Users.Update`. O `JwtBearerHandler` valida o claim `tv` contra o banco a cada request, então tokens emitidos antes da chamada passam a falhar com 401 automaticamente. Self-target (`id` igual ao caller do JWT) retorna 400 e orienta a usar `/auth/logout`. Usuário inexistente ou soft-deletado retorna 404. Resposta `200 OK`:
+
+```json
+{
+  "message": "Sessões do usuário invalidadas com sucesso.",
+  "userId": "<guid>",
+  "newTokenVersion": 1
+}
+```
+
+A operação é idempotente em re-execução: cada chamada incrementa o contador (sessões emitidas entre as chamadas continuam válidas até o próximo incremento) e gera log estruturado `Information` `ForceLogout: target {UserId}, by {CallerId}, newTokenVersion={N}` para auditoria.
 
 ### Clientes — `/api/v1/clients`
 


### PR DESCRIPTION
## 📌 Contexto

A sub-issue [lfc-admin-gui#82](https://github.com/LF-Calegari/lfc-admin-gui/issues/82) requer que um administrador possa invalidar todas as sessões ativas de um usuário-alvo a partir do painel administrativo (caso típico: desligamento, suspeita de credencial vazada). Hoje só existe `GET /api/v1/auth/logout`, que incrementa o `TokenVersion` **do próprio usuário do JWT** — não há endpoint para invalidar sessão de terceiro.

## 🎯 Objetivo

Expor `POST /api/v1/users/{id}/force-logout` para o caso de uso de logout remoto administrativo, reaproveitando o mesmo mecanismo do `GET /auth/logout` (incremento de `TokenVersion` validado pelo `JwtBearerHandler`).

## ⚙️ O que foi feito

- `AuthService/Controllers/Users/UsersController.cs` virou `partial` para suportar `[LoggerMessage]` source-gen e ganhou:
  - `ForceLogoutResponse(message, userId, newTokenVersion)`.
  - `ForceLogout(Guid id)` sob `[Authorize(Policy = perm:Users.Update)]`:
    - lê `ClaimTypes.NameIdentifier` do caller (401 se ausente/malformado);
    - 400 quando `id == callerId` (mensagem orienta `/auth/logout`);
    - 404 quando o usuário não existe ou está soft-deleted (query filter global);
    - incrementa `TokenVersion` e atualiza `UpdatedAt`;
    - retorna `200 OK { message, userId, newTokenVersion }`;
    - emite log `Information` source-gen `ForceLogout: target {UserId}, by {CallerId}, newTokenVersion={N}`.
- `AuthService/Data/AuthenticatorRoutesSeeder.cs`: novo seed `AUTH_V1_USERS_FORCE_LOGOUT` no catálogo do sistema authenticator.
- `AuthService/OpenApi/ContractExamplesOperationFilter.cs`: novo helper `TryApplyUsersForceLogoutPost` (segue padrão de helpers dedicados — lição [PR #149]) e registro no dispatcher de `TryApplyEndpointSpecificResponses` antes do fallback `restore`.
- `README.md`: nova linha na tabela de Usuários e seção dedicada explicando contrato, comportamento idempotente e auditoria.
- `AuthService.Tests/ApiVersioningAndDocsTests.cs`: nova path canônica `/api/v1/users/{id}/force-logout` em `SwaggerJson_ContainsOnlyOfficialContractPaths`.

## 📁 Arquivos impactados

- `AuthService/Controllers/Users/UsersController.cs`
- `AuthService/Data/AuthenticatorRoutesSeeder.cs`
- `AuthService/OpenApi/ContractExamplesOperationFilter.cs`
- `AuthService.Tests/UsersApiTests.cs`
- `AuthService.Tests/ApiVersioningAndDocsTests.cs`
- `README.md`

## 🧪 Testes

5 testes de integração novos em `UsersApiTests.cs` (Container Only — `docker compose --profile test run --rm test`):

- [x] `ForceLogout_HappyPath_OldTokenStartsToFailWith401_AndIncrementsTokenVersion` — 200 OK, payload correto, `TokenVersion` persistido com +1, e token antigo do target passa a falhar com 401 em `/auth/verify-token`.
- [x] `ForceLogout_Idempotent_EachCallIncrementsTokenVersion` — duas chamadas seguidas levam o contador para 2.
- [x] `ForceLogout_SelfTarget_ReturnsBadRequest` — caller chamando o próprio id recebe 400 com mensagem citando `/auth/logout`.
- [x] `ForceLogout_TargetNotFound_Returns404` — id inexistente.
- [x] `ForceLogout_TargetSoftDeleted_Returns404` — soft-deleted barrado pelo query filter.
- [x] `ForceLogout_CallerWithoutPermission_Returns403` — usuário comum (sem `perm:Users.Update`) recebe 403 da policy.

Resultado final: **248/0/248 verdes** (242 baseline + 5 novos + 1 atualização de path-list canônica).

Build: `dotnet build` 0 warnings / 0 errors. Format: `dotnet format --verify-no-changes` zero divergências.

## 🛡️ Segurança

- **Autorização:** policy `perm:Users.Update` (mesma usada por `PUT /users/{id}` e demais mutações sensíveis de usuário) — já testada com 403.
- **Self-target:** bloqueado com 400 para evitar confusão de fluxo no admin (existe `/auth/logout` específico).
- **Auditoria:** log estruturado `Information` com `target`, `by` e `newTokenVersion` para rastreabilidade.
- **Exposição de dados:** resposta carrega apenas o id do alvo e o novo contador — nenhum dado sensível adicional.
- **JWT invalidation:** o `JwtBearerHandler` já compara o claim `tv` do token com o `TokenVersion` do banco a cada request (validado pelo teste do happy path), então tokens emitidos antes da chamada são automaticamente rejeitados com 401.

## ⚠️ Riscos

- Endpoint é idempotente em re-execução (cada chamada incrementa) — comportamento desejado e documentado tanto no README quanto na issue.
- Cross-repo: `lfc-admin-gui#82` consome este endpoint — contrato `{ message, userId, newTokenVersion }` está estável e documentado na seção do README.
- Não há mudança de modelo / migration (TokenVersion já existe).

## 🔗 Issue relacionada

Closes #168