### PR TITLE
feat(clients): add server-side filter, search, pagination and includeDeleted to GET /clients (#169)

### DIFF
--- a/AuthService.Tests/ClientsApiTests.cs
+++ b/AuthService.Tests/ClientsApiTests.cs
@@ -431,13 +431,468 @@ public class ClientsApiTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.OK, getRestored.StatusCode);
     }
 
+    [Fact]
+    public async Task GetAll_NoFilters_UsesDefaultEnvelope()
+    {
+        var page = await GetClientsPageAsync("/api/v1/clients");
+        Assert.Equal(1, page.Page);
+        Assert.Equal(20, page.PageSize);
+        Assert.True(page.Total >= page.Data.Count);
+    }
+
+    [Fact]
+    public async Task GetAll_WithPagination_ReturnsCorrectSubset()
+    {
+        for (var i = 0; i < 5; i++)
+        {
+            await _client.PostAsJsonAsync("/api/v1/clients", new
+            {
+                type = "PF",
+                cpf = GenerateCpf(800000100 + i),
+                fullName = $"Pag Cliente {i:D2}"
+            }, TestApiClient.JsonOptions);
+        }
+
+        var first = await GetClientsPageAsync("/api/v1/clients?q=Pag%20Cliente&page=1&pageSize=2");
+        var second = await GetClientsPageAsync("/api/v1/clients?q=Pag%20Cliente&page=2&pageSize=2");
+        var third = await GetClientsPageAsync("/api/v1/clients?q=Pag%20Cliente&page=3&pageSize=2");
+
+        Assert.Equal(2, first.Data.Count);
+        Assert.Equal(2, second.Data.Count);
+        Assert.Single(third.Data);
+        Assert.Equal(5, first.Total);
+        Assert.Equal(5, second.Total);
+        Assert.Equal(5, third.Total);
+
+        var ids = first.Data.Concat(second.Data).Concat(third.Data).Select(c => c.Id).ToList();
+        Assert.Equal(ids.Count, ids.Distinct().Count());
+    }
+
+    [Fact]
+    public async Task GetAll_WithSearchQ_PartialMatchOnFullName()
+    {
+        var resp = await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PF",
+            cpf = GenerateCpf(800000200),
+            fullName = "Maria Aparecida Silva"
+        }, TestApiClient.JsonOptions);
+        resp.EnsureSuccessStatusCode();
+
+        var page = await GetClientsPageAsync("/api/v1/clients?q=Aparecida&pageSize=100");
+        Assert.Contains(page.Data, c => c.FullName == "Maria Aparecida Silva");
+    }
+
+    [Fact]
+    public async Task GetAll_WithSearchQ_PartialMatchOnCorporateName()
+    {
+        var resp = await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PJ",
+            cnpj = GenerateCnpj(80100200),
+            corporateName = "Fabrica Souza Tecnologia LTDA"
+        }, TestApiClient.JsonOptions);
+        resp.EnsureSuccessStatusCode();
+
+        var page = await GetClientsPageAsync("/api/v1/clients?q=Souza&pageSize=100");
+        Assert.Contains(page.Data, c => c.CorporateName == "Fabrica Souza Tecnologia LTDA");
+    }
+
+    [Fact]
+    public async Task GetAll_WithSearchQ_PartialMatchOnCpf()
+    {
+        var cpf = GenerateCpf(800000201);
+        var resp = await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PF",
+            cpf,
+            fullName = "Cliente CPF Filtro"
+        }, TestApiClient.JsonOptions);
+        resp.EnsureSuccessStatusCode();
+
+        var page = await GetClientsPageAsync($"/api/v1/clients?q={cpf[..6]}&pageSize=100");
+        Assert.Contains(page.Data, c => c.Cpf == cpf);
+    }
+
+    [Fact]
+    public async Task GetAll_WithSearchQ_PartialMatchOnCnpj()
+    {
+        var cnpj = GenerateCnpj(80100201);
+        var resp = await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PJ",
+            cnpj,
+            corporateName = "Empresa CNPJ Filtro LTDA"
+        }, TestApiClient.JsonOptions);
+        resp.EnsureSuccessStatusCode();
+
+        var page = await GetClientsPageAsync($"/api/v1/clients?q={cnpj[..6]}&pageSize=100");
+        Assert.Contains(page.Data, c => c.Cnpj == cnpj);
+    }
+
+    [Fact]
+    public async Task GetAll_WithSearchQ_IsCaseInsensitive()
+    {
+        var resp = await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PF",
+            cpf = GenerateCpf(800000202),
+            fullName = "Roberto Oliveira"
+        }, TestApiClient.JsonOptions);
+        resp.EnsureSuccessStatusCode();
+
+        var lower = await GetClientsPageAsync("/api/v1/clients?q=roberto&pageSize=100");
+        var upper = await GetClientsPageAsync("/api/v1/clients?q=ROBERTO&pageSize=100");
+        var mixed = await GetClientsPageAsync("/api/v1/clients?q=RoBeRtO&pageSize=100");
+
+        Assert.Contains(lower.Data, c => c.FullName == "Roberto Oliveira");
+        Assert.Contains(upper.Data, c => c.FullName == "Roberto Oliveira");
+        Assert.Contains(mixed.Data, c => c.FullName == "Roberto Oliveira");
+    }
+
+    [Fact]
+    public async Task GetAll_WithSearchQ_EscapesUnderscoreLiteral()
+    {
+        // Sem o escape, "_" viraria wildcard ILIKE e casaria qualquer caractere unico no lugar.
+        var resp1 = await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PF",
+            cpf = GenerateCpf(800000203),
+            fullName = "Foo_Lit_Bar"
+        }, TestApiClient.JsonOptions);
+        resp1.EnsureSuccessStatusCode();
+        var resp2 = await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PF",
+            cpf = GenerateCpf(800000204),
+            fullName = "FooXLitXBar"
+        }, TestApiClient.JsonOptions);
+        resp2.EnsureSuccessStatusCode();
+
+        var page = await GetClientsPageAsync("/api/v1/clients?q=_Lit_&pageSize=100");
+        Assert.Contains(page.Data, c => c.FullName == "Foo_Lit_Bar");
+        Assert.DoesNotContain(page.Data, c => c.FullName == "FooXLitXBar");
+    }
+
+    [Fact]
+    public async Task GetAll_WithTypePf_FiltersOnlyPfClients()
+    {
+        await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PF",
+            cpf = GenerateCpf(800000300),
+            fullName = "Cliente TypeFilter PF"
+        }, TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PJ",
+            cnpj = GenerateCnpj(80100300),
+            corporateName = "Empresa TypeFilter PJ LTDA"
+        }, TestApiClient.JsonOptions);
+
+        var page = await GetClientsPageAsync("/api/v1/clients?type=PF&pageSize=100");
+        Assert.All(page.Data, c => Assert.Equal("PF", c.Type));
+    }
+
+    [Fact]
+    public async Task GetAll_WithTypePj_FiltersOnlyPjClients()
+    {
+        await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PF",
+            cpf = GenerateCpf(800000301),
+            fullName = "Cliente TypeFilter PF2"
+        }, TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PJ",
+            cnpj = GenerateCnpj(80100301),
+            corporateName = "Empresa TypeFilter PJ2 LTDA"
+        }, TestApiClient.JsonOptions);
+
+        var page = await GetClientsPageAsync("/api/v1/clients?type=PJ&pageSize=100");
+        Assert.All(page.Data, c => Assert.Equal("PJ", c.Type));
+    }
+
+    [Fact]
+    public async Task GetAll_WithTypeInvalid_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync("/api/v1/clients?type=XX");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_WithActiveTrue_ReturnsOnlyActive()
+    {
+        var activeResp = await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PF",
+            cpf = GenerateCpf(800000400),
+            fullName = "Active Cliente"
+        }, TestApiClient.JsonOptions);
+        activeResp.EnsureSuccessStatusCode();
+        var activeDto = await activeResp.Content.ReadFromJsonAsync<ClientDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(activeDto);
+
+        var deletedCreate = await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PF",
+            cpf = GenerateCpf(800000401),
+            fullName = "Soft Deleted Cliente"
+        }, TestApiClient.JsonOptions);
+        deletedCreate.EnsureSuccessStatusCode();
+        var deletedDto = await deletedCreate.Content.ReadFromJsonAsync<ClientDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(deletedDto);
+        await _client.DeleteAsync($"/api/v1/clients/{deletedDto.Id}");
+
+        var page = await GetClientsPageAsync("/api/v1/clients?active=true&pageSize=100");
+        Assert.Contains(page.Data, c => c.Id == activeDto.Id);
+        Assert.DoesNotContain(page.Data, c => c.Id == deletedDto.Id);
+    }
+
+    [Fact]
+    public async Task GetAll_WithActiveFalse_ReturnsOnlySoftDeleted()
+    {
+        var activeResp = await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PF",
+            cpf = GenerateCpf(800000500),
+            fullName = "Stay Active Cliente"
+        }, TestApiClient.JsonOptions);
+        activeResp.EnsureSuccessStatusCode();
+        var activeDto = await activeResp.Content.ReadFromJsonAsync<ClientDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(activeDto);
+
+        var deletedCreate = await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PF",
+            cpf = GenerateCpf(800000501),
+            fullName = "Will Be Soft Deleted"
+        }, TestApiClient.JsonOptions);
+        deletedCreate.EnsureSuccessStatusCode();
+        var deletedDto = await deletedCreate.Content.ReadFromJsonAsync<ClientDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(deletedDto);
+        await _client.DeleteAsync($"/api/v1/clients/{deletedDto.Id}");
+
+        var page = await GetClientsPageAsync("/api/v1/clients?active=false&pageSize=100");
+        Assert.Contains(page.Data, c => c.Id == deletedDto.Id);
+        Assert.DoesNotContain(page.Data, c => c.Id == activeDto.Id);
+    }
+
+    [Fact]
+    public async Task GetAll_WithIncludeDeletedTrue_ReturnsActiveAndSoftDeleted()
+    {
+        var activeResp = await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PF",
+            cpf = GenerateCpf(800000600),
+            fullName = "Visible Active Cliente"
+        }, TestApiClient.JsonOptions);
+        activeResp.EnsureSuccessStatusCode();
+        var activeDto = await activeResp.Content.ReadFromJsonAsync<ClientDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(activeDto);
+
+        var deletedCreate = await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PF",
+            cpf = GenerateCpf(800000601),
+            fullName = "Visible Deleted Cliente"
+        }, TestApiClient.JsonOptions);
+        deletedCreate.EnsureSuccessStatusCode();
+        var deletedDto = await deletedCreate.Content.ReadFromJsonAsync<ClientDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(deletedDto);
+        await _client.DeleteAsync($"/api/v1/clients/{deletedDto.Id}");
+
+        var page = await GetClientsPageAsync("/api/v1/clients?includeDeleted=true&pageSize=100");
+        Assert.Contains(page.Data, c => c.Id == activeDto.Id && c.DeletedAt == null);
+        Assert.Contains(page.Data, c => c.Id == deletedDto.Id && c.DeletedAt != null);
+    }
+
+    [Fact]
+    public async Task GetAll_WithActiveAndIncludeDeleted_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync("/api/v1/clients?active=true&includeDeleted=true");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_WithPageSizeAboveLimit_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync("/api/v1/clients?pageSize=101");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_WithPageSizeZero_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync("/api/v1/clients?pageSize=0");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_WithPageZero_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync("/api/v1/clients?page=0");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_PageBeyondTotal_ReturnsEmptyDataAnd200()
+    {
+        await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PF",
+            cpf = GenerateCpf(800000700),
+            fullName = "Beyond Cliente Unico"
+        }, TestApiClient.JsonOptions);
+
+        var resp = await _client.GetAsync("/api/v1/clients?q=Beyond%20Cliente%20Unico&page=99&pageSize=10");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var page = await resp.Content.ReadFromJsonAsync<PagedClientsDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(page);
+        Assert.Empty(page.Data);
+        Assert.Equal(1, page.Total);
+    }
+
+    [Fact]
+    public async Task GetAll_OrderedByCreatedAt_Descending()
+    {
+        var first = await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PF",
+            cpf = GenerateCpf(800000800),
+            fullName = "Order Cliente AAA"
+        }, TestApiClient.JsonOptions);
+        first.EnsureSuccessStatusCode();
+        var firstDto = await first.Content.ReadFromJsonAsync<ClientDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(firstDto);
+
+        await Task.Delay(20);
+
+        var second = await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PF",
+            cpf = GenerateCpf(800000801),
+            fullName = "Order Cliente BBB"
+        }, TestApiClient.JsonOptions);
+        second.EnsureSuccessStatusCode();
+        var secondDto = await second.Content.ReadFromJsonAsync<ClientDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(secondDto);
+
+        var page = await GetClientsPageAsync("/api/v1/clients?q=Order%20Cliente&pageSize=100");
+        var ordered = page.Data
+            .Where(c => c.FullName != null && c.FullName.StartsWith("Order Cliente", StringComparison.Ordinal))
+            .Select(c => c.Id)
+            .ToList();
+        Assert.Equal(secondDto.Id, ordered[0]);
+        Assert.Equal(firstDto.Id, ordered[1]);
+    }
+
+    [Fact]
+    public async Task GetAll_HydratesUserIdsEmailsMobilesAndPhones_FromBatchLookup()
+    {
+        var create = await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PF",
+            cpf = GenerateCpf(800000900),
+            fullName = "Hidratacao Cliente"
+        }, TestApiClient.JsonOptions);
+        create.EnsureSuccessStatusCode();
+        var dto = await create.Content.ReadFromJsonAsync<ClientDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto);
+
+        await _client.PostAsJsonAsync($"/api/v1/clients/{dto.Id}/emails",
+            new { email = "hidratacao1@example.com" }, TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync($"/api/v1/clients/{dto.Id}/mobiles",
+            new { number = "+5518999990001" }, TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync($"/api/v1/clients/{dto.Id}/phones",
+            new { number = "+5518333330001" }, TestApiClient.JsonOptions);
+
+        var page = await GetClientsPageAsync($"/api/v1/clients?q=Hidratacao%20Cliente&pageSize=100");
+        var entry = Assert.Single(page.Data, c => c.Id == dto.Id);
+        Assert.Single(entry.ExtraEmails);
+        Assert.Equal("hidratacao1@example.com", entry.ExtraEmails[0].Email);
+        Assert.Single(entry.MobilePhones);
+        Assert.Equal("+5518999990001", entry.MobilePhones[0].Number);
+        Assert.Single(entry.LandlinePhones);
+        Assert.Equal("+5518333330001", entry.LandlinePhones[0].Number);
+    }
+
+    [Fact]
+    public async Task GetAll_TotalReflectsFilters_BeforePagination()
+    {
+        for (var i = 0; i < 3; i++)
+        {
+            await _client.PostAsJsonAsync("/api/v1/clients", new
+            {
+                type = "PF",
+                cpf = GenerateCpf(800001000 + i),
+                fullName = $"FiltroTot Cliente {i}"
+            }, TestApiClient.JsonOptions);
+        }
+        await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PF",
+            cpf = GenerateCpf(800001050),
+            fullName = "Outro Nome"
+        }, TestApiClient.JsonOptions);
+
+        var page = await GetClientsPageAsync("/api/v1/clients?q=FiltroTot&page=1&pageSize=2");
+        Assert.Equal(3, page.Total);
+        Assert.Equal(2, page.Data.Count);
+    }
+
+    [Fact]
+    public async Task GetAll_CombinedFilters_ApplyTogether()
+    {
+        await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PF",
+            cpf = GenerateCpf(800001100),
+            fullName = "Combo Maria"
+        }, TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/api/v1/clients", new
+        {
+            type = "PJ",
+            cnpj = GenerateCnpj(80101100),
+            corporateName = "Combo Maria LTDA"
+        }, TestApiClient.JsonOptions);
+
+        var page = await GetClientsPageAsync("/api/v1/clients?q=Combo%20Maria&type=PF&pageSize=100");
+        Assert.All(page.Data, c => Assert.Equal("PF", c.Type));
+        Assert.Contains(page.Data, c => c.FullName == "Combo Maria");
+        Assert.DoesNotContain(page.Data, c => c.CorporateName == "Combo Maria LTDA");
+    }
+
+    private async Task<PagedClientsDto> GetClientsPageAsync(string url)
+    {
+        var resp = await _client.GetAsync(url);
+        resp.EnsureSuccessStatusCode();
+        var page = await resp.Content.ReadFromJsonAsync<PagedClientsDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(page);
+        return page;
+    }
+
+    private sealed record PagedClientsDto(
+        List<ClientDto> Data,
+        int Page,
+        int PageSize,
+        int Total);
+
     private sealed record ClientDto(
         Guid Id,
         string Type,
         string? Cpf,
         string? FullName,
         string? Cnpj,
-        string? CorporateName);
+        string? CorporateName,
+        DateTime CreatedAt,
+        DateTime UpdatedAt,
+        DateTime? DeletedAt,
+        List<Guid> UserIds,
+        List<ClientEmailDto> ExtraEmails,
+        List<ClientPhoneDto> MobilePhones,
+        List<ClientPhoneDto> LandlinePhones);
     private sealed record ClientEmailDto(Guid Id, string Email, DateTime CreatedAt);
     private sealed record ClientPhoneDto(Guid Id, string Number, DateTime CreatedAt);
 

--- a/AuthService/Controllers/Clients/ClientsController.cs
+++ b/AuthService/Controllers/Clients/ClientsController.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.RegularExpressions;
 using AuthService.Auth;
+using AuthService.Controllers.Common;
 using AuthService.Data;
 using AuthService.Models;
 using Microsoft.AspNetCore.Authorization;
@@ -128,20 +129,188 @@ public class ClientsController : ControllerBase
         return CreatedAtAction(nameof(GetById), new { id = entity.Id }, await BuildResponseAsync(entity));
     }
 
+    /// <summary>Tamanho de página default quando o cliente não envia <c>pageSize</c>.</summary>
+    public const int DefaultPageSize = 20;
+
+    /// <summary>Limite superior para <c>pageSize</c>; valores acima retornam 400.</summary>
+    public const int MaxPageSize = 100;
+
     [HttpGet]
     [Authorize(Policy = PermissionPolicies.ClientsRead)]
-    public async Task<IActionResult> GetAll()
+    public async Task<IActionResult> GetAll(
+        [FromQuery] string? q = null,
+        [FromQuery] string? type = null,
+        [FromQuery] bool? active = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = DefaultPageSize,
+        [FromQuery] bool includeDeleted = false)
     {
-        var clients = await _db.Clients
+        if (page <= 0)
+            ModelState.AddModelError(nameof(page), "page deve ser maior ou igual a 1.");
+
+        if (pageSize <= 0 || pageSize > MaxPageSize)
+            ModelState.AddModelError(nameof(pageSize), $"pageSize deve estar entre 1 e {MaxPageSize}.");
+
+        string? normalizedType = null;
+        if (type is not null)
+        {
+            normalizedType = type.Trim().ToUpperInvariant();
+            if (normalizedType != "PF" && normalizedType != "PJ")
+                ModelState.AddModelError(nameof(type), "type deve ser PF ou PJ.");
+        }
+
+        if (active.HasValue && includeDeleted)
+        {
+            ModelState.AddModelError(
+                nameof(includeDeleted),
+                "active e includeDeleted são mutuamente excludentes.");
+        }
+
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        // includeDeleted=true: admin enxerga inclusive soft-deletados (DeletedAt != null).
+        // active=false: filtra apenas soft-deletados — incompativel com o query filter global de soft-delete,
+        // entao precisa de IgnoreQueryFilters. active=true: apenas ativos (default ja faz isso). Quando
+        // nada e informado, mantemos o query filter global agindo (cliente nao ve nem o IgnoreQueryFilters
+        // local, evitando vazar deletados em outros joins).
+        IQueryable<Client> query = (includeDeleted || active == false)
+            ? _db.Clients.IgnoreQueryFilters()
+            : _db.Clients;
+
+        if (active.HasValue)
+        {
+            query = active.Value
+                ? query.Where(c => c.DeletedAt == null)
+                : query.Where(c => c.DeletedAt != null);
+        }
+
+        if (normalizedType is not null)
+            query = query.Where(c => c.Type == normalizedType);
+
+        if (!string.IsNullOrWhiteSpace(q))
+        {
+            var pattern = $"%{EscapeLikePattern(q.Trim())}%";
+            query = query.Where(c =>
+                (c.FullName != null && EF.Functions.ILike(c.FullName, pattern, "\\"))
+                || (c.CorporateName != null && EF.Functions.ILike(c.CorporateName, pattern, "\\"))
+                || (c.Cpf != null && EF.Functions.ILike(c.Cpf, pattern, "\\"))
+                || (c.Cnpj != null && EF.Functions.ILike(c.Cnpj, pattern, "\\")));
+        }
+
+        // Query 1: COUNT pre-paginação (refletindo todos os filtros aplicados acima).
+        var total = await query.CountAsync();
+
+        // Query 2: página corrente, ordenada determinísticamente (CreatedAt DESC com Id como desempate
+        // estável para evitar duplicação/saltos entre páginas em ties de timestamp).
+        var pageClients = await query
+            .OrderByDescending(c => c.CreatedAt)
+            .ThenBy(c => c.Id)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
             .AsNoTracking()
-            .OrderBy(c => c.CreatedAt)
             .ToListAsync();
 
-        var result = new List<ClientResponse>(clients.Count);
-        foreach (var client in clients)
-            result.Add(await BuildResponseAsync(client));
+        var data = await BuildResponsesBatchAsync(pageClients);
 
-        return Ok(result);
+        return Ok(new PagedResponse<ClientResponse>(data, page, pageSize, total));
+    }
+
+    /// <summary>
+    /// Escapa caracteres curinga (<c>%</c>, <c>_</c>) e o caractere de escape (<c>\</c>) na entrada do usuário
+    /// para evitar que sejam interpretados como wildcards no <c>ILIKE</c>. Mantém o termo como busca literal parcial.
+    /// </summary>
+    private static string EscapeLikePattern(string value)
+    {
+        return value
+            .Replace("\\", "\\\\")
+            .Replace("%", "\\%")
+            .Replace("_", "\\_");
+    }
+
+    /// <summary>
+    /// Hidrata <see cref="ClientResponse"/> para uma página corrente em batch (3 queries IN), evitando o
+    /// N+1 do <see cref="BuildResponseAsync"/> (4 queries por cliente). A listagem total fica em
+    /// 5 queries (1 count + 1 page + 3 batch IN para users/emails/phones), independente do tamanho da página.
+    /// </summary>
+    private async Task<List<ClientResponse>> BuildResponsesBatchAsync(IReadOnlyList<Client> clients)
+    {
+        if (clients.Count == 0)
+            return new List<ClientResponse>(0);
+
+        var clientIds = clients.Select(c => c.Id).ToList();
+
+        // Query 3: UserIds por cliente (Users tem soft-delete; mantemos query filter global ativo,
+        // que esconde soft-deleted — alinhado ao comportamento atual de BuildResponseAsync).
+        var userRows = await _db.Users.AsNoTracking()
+            .Where(u => u.ClientId != null && clientIds.Contains(u.ClientId.Value))
+            .OrderBy(u => u.CreatedAt)
+            .Select(u => new { u.Id, ClientId = u.ClientId!.Value })
+            .ToListAsync();
+        var userIdsByClient = userRows
+            .GroupBy(r => r.ClientId)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<Guid>)g.Select(x => x.Id).ToList());
+
+        // Query 4: emails extras por cliente.
+        var emailRows = await _db.ClientEmails.AsNoTracking()
+            .Where(e => clientIds.Contains(e.ClientId))
+            .OrderBy(e => e.CreatedAt)
+            .Select(e => new { e.ClientId, e.Id, e.Email, e.CreatedAt })
+            .ToListAsync();
+        var emailsByClient = emailRows
+            .GroupBy(r => r.ClientId)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<ClientEmailResponse>)g
+                    .Select(x => new ClientEmailResponse(x.Id, x.Email, x.CreatedAt))
+                    .ToList());
+
+        // Query 5: telefones por cliente (mobile + landline juntos; particionados em memória).
+        var phoneRows = await _db.ClientPhones.AsNoTracking()
+            .Where(p => clientIds.Contains(p.ClientId))
+            .OrderBy(p => p.CreatedAt)
+            .Select(p => new { p.ClientId, p.Type, p.Id, p.Number, p.CreatedAt })
+            .ToListAsync();
+        var mobilesByClient = phoneRows
+            .Where(r => r.Type == "mobile")
+            .GroupBy(r => r.ClientId)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<ClientPhoneResponse>)g
+                    .Select(x => new ClientPhoneResponse(x.Id, x.Number, x.CreatedAt))
+                    .ToList());
+        var landlinesByClient = phoneRows
+            .Where(r => r.Type == "phone")
+            .GroupBy(r => r.ClientId)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<ClientPhoneResponse>)g
+                    .Select(x => new ClientPhoneResponse(x.Id, x.Number, x.CreatedAt))
+                    .ToList());
+
+        var emptyGuids = (IReadOnlyList<Guid>)Array.Empty<Guid>();
+        var emptyEmails = (IReadOnlyList<ClientEmailResponse>)Array.Empty<ClientEmailResponse>();
+        var emptyPhones = (IReadOnlyList<ClientPhoneResponse>)Array.Empty<ClientPhoneResponse>();
+
+        var result = new List<ClientResponse>(clients.Count);
+        foreach (var c in clients)
+        {
+            result.Add(new ClientResponse(
+                c.Id,
+                c.Type,
+                c.Cpf,
+                c.FullName,
+                c.Cnpj,
+                c.CorporateName,
+                c.CreatedAt,
+                c.UpdatedAt,
+                c.DeletedAt,
+                userIdsByClient.GetValueOrDefault(c.Id, emptyGuids),
+                emailsByClient.GetValueOrDefault(c.Id, emptyEmails),
+                mobilesByClient.GetValueOrDefault(c.Id, emptyPhones),
+                landlinesByClient.GetValueOrDefault(c.Id, emptyPhones)));
+        }
+        return result;
     }
 
     [HttpGet("{id:guid}")]

--- a/AuthService/Controllers/Clients/ClientsController.cs
+++ b/AuthService/Controllers/Clients/ClientsController.cs
@@ -18,6 +18,13 @@ public class ClientsController : ControllerBase
     private const string ClientWithCpfAlreadyExistsMessage = "Já existe cliente com este CPF.";
     private const string ClientWithCnpjAlreadyExistsMessage = "Já existe cliente com este CNPJ.";
     private const string ClientNotFoundMessage = "Cliente não encontrado.";
+
+    /// <summary>Discriminator usado em <see cref="ClientPhone.Type"/> para celulares.</summary>
+    private const string PhoneTypeMobile = "mobile";
+
+    /// <summary>Discriminator usado em <see cref="ClientPhone.Type"/> para telefones fixos.</summary>
+    private const string PhoneTypeLandline = "phone";
+
     private static readonly EmailAddressAttribute EmailValidator = new();
     private static readonly Regex PhoneRegex = new(
         @"^\+[1-9]\d{11,14}$",
@@ -145,6 +152,37 @@ public class ClientsController : ControllerBase
         [FromQuery] int pageSize = DefaultPageSize,
         [FromQuery] bool includeDeleted = false)
     {
+        var normalizedType = ValidateGetAllQueryParams(page, pageSize, type, active, includeDeleted);
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        var query = BuildClientsListingQuery(q, normalizedType, active, includeDeleted);
+
+        // Query 1: COUNT pre-paginação (refletindo todos os filtros aplicados).
+        var total = await query.CountAsync();
+
+        // Query 2: página corrente, ordenada determinísticamente (CreatedAt DESC com Id como desempate
+        // estável para evitar duplicação/saltos entre páginas em ties de timestamp).
+        var pageClients = await query
+            .OrderByDescending(c => c.CreatedAt)
+            .ThenBy(c => c.Id)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .AsNoTracking()
+            .ToListAsync();
+
+        var data = await BuildResponsesBatchAsync(pageClients);
+
+        return Ok(new PagedResponse<ClientResponse>(data, page, pageSize, total));
+    }
+
+    /// <summary>
+    /// Valida os query params de <see cref="GetAll"/> e retorna o <c>type</c> normalizado (uppercase trimmed)
+    /// quando informado. Erros são acumulados em <c>ModelState</c> para resposta unificada via
+    /// <c>ValidationProblem</c>.
+    /// </summary>
+    private string? ValidateGetAllQueryParams(int page, int pageSize, string? type, bool? active, bool includeDeleted)
+    {
         if (page <= 0)
             ModelState.AddModelError(nameof(page), "page deve ser maior ou igual a 1.");
 
@@ -166,14 +204,20 @@ public class ClientsController : ControllerBase
                 "active e includeDeleted são mutuamente excludentes.");
         }
 
-        if (!ModelState.IsValid)
-            return ValidationProblem(ModelState);
+        return normalizedType;
+    }
 
-        // includeDeleted=true: admin enxerga inclusive soft-deletados (DeletedAt != null).
-        // active=false: filtra apenas soft-deletados — incompativel com o query filter global de soft-delete,
-        // entao precisa de IgnoreQueryFilters. active=true: apenas ativos (default ja faz isso). Quando
-        // nada e informado, mantemos o query filter global agindo (cliente nao ve nem o IgnoreQueryFilters
-        // local, evitando vazar deletados em outros joins).
+    /// <summary>
+    /// Compõe o <see cref="IQueryable{Client}"/> base aplicando a flag de soft-delete (via
+    /// <c>IgnoreQueryFilters</c>) e os filtros de <c>active</c>, <c>type</c> e busca textual <c>q</c>.
+    /// </summary>
+    /// <remarks>
+    /// includeDeleted=true expõe soft-deletados; active=false força <c>IgnoreQueryFilters</c> porque
+    /// o query filter global esconderia os registros que ele pretende selecionar. Quando nenhum dos
+    /// dois é informado, o filtro global age e a leitura permanece restrita a registros ativos.
+    /// </remarks>
+    private IQueryable<Client> BuildClientsListingQuery(string? q, string? normalizedType, bool? active, bool includeDeleted)
+    {
         IQueryable<Client> query = (includeDeleted || active == false)
             ? _db.Clients.IgnoreQueryFilters()
             : _db.Clients;
@@ -198,22 +242,7 @@ public class ClientsController : ControllerBase
                 || (c.Cnpj != null && EF.Functions.ILike(c.Cnpj, pattern, "\\")));
         }
 
-        // Query 1: COUNT pre-paginação (refletindo todos os filtros aplicados acima).
-        var total = await query.CountAsync();
-
-        // Query 2: página corrente, ordenada determinísticamente (CreatedAt DESC com Id como desempate
-        // estável para evitar duplicação/saltos entre páginas em ties de timestamp).
-        var pageClients = await query
-            .OrderByDescending(c => c.CreatedAt)
-            .ThenBy(c => c.Id)
-            .Skip((page - 1) * pageSize)
-            .Take(pageSize)
-            .AsNoTracking()
-            .ToListAsync();
-
-        var data = await BuildResponsesBatchAsync(pageClients);
-
-        return Ok(new PagedResponse<ClientResponse>(data, page, pageSize, total));
+        return query;
     }
 
     /// <summary>
@@ -233,7 +262,7 @@ public class ClientsController : ControllerBase
     /// N+1 do <see cref="BuildResponseAsync"/> (4 queries por cliente). A listagem total fica em
     /// 5 queries (1 count + 1 page + 3 batch IN para users/emails/phones), independente do tamanho da página.
     /// </summary>
-    private async Task<List<ClientResponse>> BuildResponsesBatchAsync(IReadOnlyList<Client> clients)
+    private async Task<List<ClientResponse>> BuildResponsesBatchAsync(List<Client> clients)
     {
         if (clients.Count == 0)
             return new List<ClientResponse>(0);
@@ -272,7 +301,7 @@ public class ClientsController : ControllerBase
             .Select(p => new { p.ClientId, p.Type, p.Id, p.Number, p.CreatedAt })
             .ToListAsync();
         var mobilesByClient = phoneRows
-            .Where(r => r.Type == "mobile")
+            .Where(r => r.Type == PhoneTypeMobile)
             .GroupBy(r => r.ClientId)
             .ToDictionary(
                 g => g.Key,
@@ -280,7 +309,7 @@ public class ClientsController : ControllerBase
                     .Select(x => new ClientPhoneResponse(x.Id, x.Number, x.CreatedAt))
                     .ToList());
         var landlinesByClient = phoneRows
-            .Where(r => r.Type == "phone")
+            .Where(r => r.Type == PhoneTypeLandline)
             .GroupBy(r => r.ClientId)
             .ToDictionary(
                 g => g.Key,
@@ -461,22 +490,22 @@ public class ClientsController : ControllerBase
     [HttpPost("{id:guid}/mobiles")]
     [Authorize(Policy = PermissionPolicies.ClientsUpdate)]
     public Task<IActionResult> AddMobile(Guid id, [FromBody] AddPhoneRequest request) =>
-        AddPhoneInternal(id, request, "mobile", "Limite de 3 celulares por cliente.");
+        AddPhoneInternal(id, request, PhoneTypeMobile, "Limite de 3 celulares por cliente.");
 
     [HttpDelete("{id:guid}/mobiles/{phoneId:guid}")]
     [Authorize(Policy = PermissionPolicies.ClientsUpdate)]
     public Task<IActionResult> RemoveMobile(Guid id, Guid phoneId) =>
-        RemovePhoneInternal(id, phoneId, "mobile");
+        RemovePhoneInternal(id, phoneId, PhoneTypeMobile);
 
     [HttpPost("{id:guid}/phones")]
     [Authorize(Policy = PermissionPolicies.ClientsUpdate)]
     public Task<IActionResult> AddLandline(Guid id, [FromBody] AddPhoneRequest request) =>
-        AddPhoneInternal(id, request, "phone", "Limite de 3 telefones por cliente.");
+        AddPhoneInternal(id, request, PhoneTypeLandline, "Limite de 3 telefones por cliente.");
 
     [HttpDelete("{id:guid}/phones/{phoneId:guid}")]
     [Authorize(Policy = PermissionPolicies.ClientsUpdate)]
     public Task<IActionResult> RemoveLandline(Guid id, Guid phoneId) =>
-        RemovePhoneInternal(id, phoneId, "phone");
+        RemovePhoneInternal(id, phoneId, PhoneTypeLandline);
 
     private async Task<IActionResult> AddPhoneInternal(Guid clientId, AddPhoneRequest request, string type, string limitMessage)
     {
@@ -537,13 +566,13 @@ public class ClientsController : ControllerBase
             .ToListAsync();
 
         var mobiles = await _db.ClientPhones.AsNoTracking()
-            .Where(p => p.ClientId == client.Id && p.Type == "mobile")
+            .Where(p => p.ClientId == client.Id && p.Type == PhoneTypeMobile)
             .OrderBy(p => p.CreatedAt)
             .Select(p => new ClientPhoneResponse(p.Id, p.Number, p.CreatedAt))
             .ToListAsync();
 
         var phones = await _db.ClientPhones.AsNoTracking()
-            .Where(p => p.ClientId == client.Id && p.Type == "phone")
+            .Where(p => p.ClientId == client.Id && p.Type == PhoneTypeLandline)
             .OrderBy(p => p.CreatedAt)
             .Select(p => new ClientPhoneResponse(p.Id, p.Number, p.CreatedAt))
             .ToListAsync();

--- a/AuthService/OpenApi/ContractExamplesOperationFilter.cs
+++ b/AuthService/OpenApi/ContractExamplesOperationFilter.cs
@@ -53,6 +53,7 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
             || TryApplySystemsListGet(operation, normalizedPath, method)
             || TryApplyRoutesListGet(operation, normalizedPath, method)
             || TryApplyRoutesDelete(operation, normalizedPath, method)
+            || TryApplyClientsListGet(operation, normalizedPath, method)
             || TryApplyUsersForceLogoutPost(operation, normalizedPath, method)
             || TryApplyRestorePost(operation, normalizedPath, method);
     }
@@ -283,6 +284,74 @@ public sealed class ContractExamplesOperationFilter : IOperationFilter
             "Parametros de paginacao/filtro invalidos (page <= 0, pageSize fora do intervalo permitido ou systemId = Guid.Empty).",
             new { message = "pageSize deve estar entre 1 e 100." });
         return true;
+    }
+
+    private static bool TryApplyClientsListGet(OpenApiOperation operation, string normalizedPath, string method)
+    {
+        if (normalizedPath != "/clients" || method != "GET")
+            return false;
+
+        EnsureClientsListQueryParameters(operation);
+
+        AddJsonResponse(operation, "200", "Pagina de clientes que casam com os filtros aplicados.", new
+        {
+            data = new[]
+            {
+                new
+                {
+                    id = EmptyGuidExample,
+                    type = "PF",
+                    cpf = "52998224725",
+                    fullName = "Cliente Exemplo",
+                    cnpj = (string?)null,
+                    corporateName = (string?)null,
+                    createdAt = ExampleTimestamp,
+                    updatedAt = ExampleTimestamp,
+                    deletedAt = (string?)null,
+                    userIds = Array.Empty<string>(),
+                    extraEmails = Array.Empty<object>(),
+                    mobilePhones = Array.Empty<object>(),
+                    landlinePhones = Array.Empty<object>()
+                }
+            },
+            page = 1,
+            pageSize = 20,
+            total = 1
+        });
+        AddErrorResponse(
+            operation,
+            "400",
+            "Parametros invalidos (page <= 0, pageSize fora do intervalo, type != PF/PJ ou active+includeDeleted simultaneos).",
+            new { message = "type deve ser PF ou PJ." });
+        return true;
+    }
+
+    private static void EnsureClientsListQueryParameters(OpenApiOperation operation)
+    {
+        EnsureQueryParameterDescription(
+            operation,
+            "q",
+            "Termo de busca case-insensitive em FullName, CorporateName, Cpf e Cnpj (ILIKE; %, _ e \\ sao tratados como literais).");
+        EnsureQueryParameterDescription(
+            operation,
+            "type",
+            "Filtra por tipo de cliente: PF ou PJ. Demais valores retornam 400.");
+        EnsureQueryParameterDescription(
+            operation,
+            "active",
+            "Quando true, retorna apenas clientes ativos (DeletedAt IS NULL). Quando false, apenas soft-deletados. Mutuamente excludente com includeDeleted.");
+        EnsureQueryParameterDescription(
+            operation,
+            "page",
+            "Numero da pagina (1-based, default 1). Valores <= 0 retornam 400.");
+        EnsureQueryParameterDescription(
+            operation,
+            "pageSize",
+            "Tamanho da pagina (default 20, maximo 100). Valores <= 0 ou > 100 retornam 400.");
+        EnsureQueryParameterDescription(
+            operation,
+            "includeDeleted",
+            "Quando true, inclui clientes soft-deleted (DeletedAt != null). Default false. Mutuamente excludente com active.");
     }
 
     private static void EnsureRoutesListQueryParameters(OpenApiOperation operation)

--- a/README.md
+++ b/README.md
@@ -346,6 +346,19 @@ A operação é idempotente em re-execução: cada chamada incrementa o contador
 
 Regras de negócio principais: `type` imutável (`PF`/`PJ`), validação de CPF/CNPJ por tipo, unicidade global de CPF/CNPJ, máximo de 3 emails extras, 3 celulares e 3 telefones por cliente, bloqueio para remoção de email extra que esteja sendo usado como username.
 
+**`GET /api/v1/clients`** suporta filtro/busca/paginação via query string:
+
+| Param | Default | Notas |
+|-------|---------|-------|
+| `q` | `""` | Busca case-insensitive (ILIKE) com matching parcial em `FullName`, `CorporateName`, `Cpf` e `Cnpj` (OR). Caracteres `%`, `_` e `\` são escapados (literais). |
+| `type` | _ausente_ | `PF` ou `PJ`. Demais valores retornam **400**. |
+| `active` | _ausente_ | `true` retorna apenas ativos (`DeletedAt IS NULL`); `false` retorna apenas soft-deletados. Mutuamente excludente com `includeDeleted` (combinar retorna **400**). |
+| `page` | `1` | 1-based. `<= 0` retorna **400**. |
+| `pageSize` | `20` | Máximo `100`. `<= 0` ou `> 100` retornam **400**. |
+| `includeDeleted` | `false` | Quando `true`, inclui clientes soft-deletados (`DeletedAt != null`). Mutuamente excludente com `active`. |
+
+Resposta paginada: `{ data, page, pageSize, total }`. `total` reflete o total após filtros, antes de `Skip/Take`. Ordenação determinística por `CreatedAt` descendente, com `Id` como desempate. Página além do total retorna **200** com `data: []`. A listagem da página corrente faz no máximo **5 queries** ao banco (1 count + 1 page + 3 batch IN para `userIds`, emails extras e telefones), independente do tamanho da página — `GET /api/v1/clients/{id}` mantém a hidratação tradicional (4 queries para um cliente).
+
 ### Tipos de token — `/api/v1/tokens/types`
 
 | Método | Endpoint | Auth | Permissão |


### PR DESCRIPTION
## Resumo

Estende `GET /api/v1/clients` com filtros (`q`, `type`, `active`), paginação server-side (`page`, `pageSize`), `includeDeleted` para listagem admin, e resposta `PagedResponse<ClientResponse>`. Espelha o padrão consolidado em `RoutesController.GetAll` (PR #161). Otimiza o N+1 do `BuildResponseAsync` (4 queries por cliente) com hidratação batch (3 queries IN agregadas) — listagem total fica em **5 queries por request**, independente do tamanho da página.

## Contrato

| Param | Default | Notas |
|-------|---------|-------|
| `q` | `""` | ILIKE em `FullName`, `CorporateName`, `Cpf`, `Cnpj` (OR; `%`, `_`, `\` literais) |
| `type` | _ausente_ | `PF`/`PJ`; demais valores retornam **400** |
| `active` | _ausente_ | `true` só ativos; `false` só soft-deletados. Mutuamente excludente com `includeDeleted` |
| `page` | `1` | 1-based; `<= 0` → **400** |
| `pageSize` | `20` | Max 100; fora do intervalo → **400** |
| `includeDeleted` | `false` | `true` revela soft-deletados via `IgnoreQueryFilters` |

Ordenação: `CreatedAt DESC, Id` (desempate estável).

## Otimização N+1

- `GET /clients`: 1 count + 1 page + 3 batch IN (`Users.ClientId`, `ClientEmails.ClientId`, `ClientPhones.ClientId` particionado em memória via `Type`) = **5 queries por request**.
- `GET /clients/{id}` mantém `BuildResponseAsync` atual (4 queries para 1 cliente — aceitável pelo escopo).

## Mudanças

- `AuthService/Controllers/Clients/ClientsController.cs` — `GetAll(q, type, active, page, pageSize, includeDeleted)`, `EscapeLikePattern`, `BuildResponsesBatchAsync`, `DefaultPageSize=20`/`MaxPageSize=100`.
- `AuthService/OpenApi/ContractExamplesOperationFilter.cs` — `TryApplyClientsListGet` com exemplo `PagedResponse` e descrições dos 6 query params.
- `README.md` — seção Clientes com tabela de filtros e nota sobre 5-queries.
- `AuthService.Tests/ClientsApiTests.cs` — 23 novos testes de integração.

## Critério de aceite

- [x] `GET /clients` retorna `PagedResponse<ClientResponse>`.
- [x] Filtros `q`, `type`, `active`, `page`, `pageSize`, `includeDeleted` funcionam isolados e combinados.
- [x] `type` inválido retorna 400; `active`+`includeDeleted` simultâneos retornam 400.
- [x] Listagem em **no máximo 5 queries** (1 count + 1 page + 3 batch IN).
- [x] Testes integração: paginação, busca CPF/CNPJ/FullName/CorporateName, type PF/PJ, active=true/false, includeDeleted, ordenação, page além do total, hidratação batch.
- [x] README atualizado em Clientes com tabela de query params.

## Test plan

- [x] `dotnet build` (Container Only)
- [x] `dotnet format --verify-no-changes`
- [x] `dotnet test` — **271/271 verdes** (baseline 248 + 23 novos)
- [ ] SonarCloud Quality Gate
- [ ] Review humano

Closes #169

Generated with [Claude Code](https://claude.com/claude-code)