### PR TITLE
feat(users): add server-side filter, search, pagination and includeDeleted to GET /users (#166)

### DIFF
--- a/AuthService.Tests/UsersApiTests.cs
+++ b/AuthService.Tests/UsersApiTests.cs
@@ -164,13 +164,10 @@ public class UsersApiTests : IAsyncLifetime
         Assert.NotNull(toDelete);
         await _client.DeleteAsync($"/api/v1/users/{toDelete.Id}");
 
-        var listResp = await _client.GetAsync("/api/v1/users");
-        listResp.EnsureSuccessStatusCode();
-        var list = await listResp.Content.ReadFromJsonAsync<List<UserDto>>(TestApiClient.JsonOptions);
-        Assert.NotNull(list);
-        Assert.All(list, u => Assert.Null(u.DeletedAt));
-        Assert.Contains(list, u => u.Email == "ativo@example.com");
-        Assert.DoesNotContain(list, u => u.Email == "outro@example.com");
+        var listPage = await GetUsersPageAsync("/api/v1/users?pageSize=100");
+        Assert.All(listPage.Data, u => Assert.Null(u.DeletedAt));
+        Assert.Contains(listPage.Data, u => u.Email == "ativo@example.com");
+        Assert.DoesNotContain(listPage.Data, u => u.Email == "outro@example.com");
     }
 
     [Fact]
@@ -337,11 +334,8 @@ public class UsersApiTests : IAsyncLifetime
         Assert.NotNull(restored);
         Assert.Null(restored.DeletedAt);
 
-        var listResp = await _client.GetAsync("/api/v1/users");
-        listResp.EnsureSuccessStatusCode();
-        var list = await listResp.Content.ReadFromJsonAsync<List<UserDto>>(TestApiClient.JsonOptions);
-        Assert.NotNull(list);
-        Assert.Contains(list, u => u.Id == dto.Id);
+        var listPage = await GetUsersPageAsync("/api/v1/users?pageSize=100");
+        Assert.Contains(listPage.Data, u => u.Id == dto.Id);
     }
 
     [Fact]
@@ -404,11 +398,8 @@ public class UsersApiTests : IAsyncLifetime
     public async Task GetAll_ReturnsEmptyRolesAndPermissions_OnEachUser()
     {
         await _client.PostAsJsonAsync("/api/v1/users", UserCreateBody("Lista", "list.empty@example.com"), TestApiClient.JsonOptions);
-        var listResp = await _client.GetAsync("/api/v1/users");
-        listResp.EnsureSuccessStatusCode();
-        var list = await listResp.Content.ReadFromJsonAsync<List<UserDetailDto>>(TestApiClient.JsonOptions);
-        Assert.NotNull(list);
-        var row = list.First(u => u.Email == "list.empty@example.com");
+        var page = await GetUsersDetailPageAsync("/api/v1/users?pageSize=100");
+        var row = page.Data.First(u => u.Email == "list.empty@example.com");
         Assert.Empty(row.Roles);
         Assert.Empty(row.Permissions);
     }
@@ -565,6 +556,381 @@ public class UsersApiTests : IAsyncLifetime
         var response = await anon.SendAsync(req);
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
+
+    [Fact]
+    public async Task GetAll_NoFilters_UsesDefaultEnvelope()
+    {
+        var page = await GetUsersPageAsync("/api/v1/users");
+        Assert.Equal(1, page.Page);
+        Assert.Equal(20, page.PageSize);
+        Assert.True(page.Total >= page.Data.Count);
+    }
+
+    [Fact]
+    public async Task GetAll_WithPagination_ReturnsCorrectSubset()
+    {
+        for (var i = 0; i < 5; i++)
+        {
+            await _client.PostAsJsonAsync("/api/v1/users",
+                UserCreateBody($"Pag User {i:D2}", $"pag.user.{i:D2}@example.com"),
+                TestApiClient.JsonOptions);
+        }
+
+        var first = await GetUsersPageAsync("/api/v1/users?q=Pag%20User&page=1&pageSize=2");
+        var second = await GetUsersPageAsync("/api/v1/users?q=Pag%20User&page=2&pageSize=2");
+        var third = await GetUsersPageAsync("/api/v1/users?q=Pag%20User&page=3&pageSize=2");
+
+        Assert.Equal(2, first.Data.Count);
+        Assert.Equal(2, second.Data.Count);
+        Assert.Single(third.Data);
+        Assert.Equal(5, first.Total);
+        Assert.Equal(5, second.Total);
+        Assert.Equal(5, third.Total);
+
+        var ids = first.Data.Concat(second.Data).Concat(third.Data).Select(u => u.Id).ToList();
+        Assert.Equal(ids.Count, ids.Distinct().Count());
+    }
+
+    [Fact]
+    public async Task GetAll_WithSearchQ_PartialMatchOnName()
+    {
+        var resp = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("Aparecida Silva Q", "aparecida.q@example.com"),
+            TestApiClient.JsonOptions);
+        resp.EnsureSuccessStatusCode();
+
+        var page = await GetUsersPageAsync("/api/v1/users?q=Aparecida&pageSize=100");
+        Assert.Contains(page.Data, u => u.Email == "aparecida.q@example.com");
+    }
+
+    [Fact]
+    public async Task GetAll_WithSearchQ_PartialMatchOnEmail()
+    {
+        var resp = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("Email Match", "email.match.unique@example.com"),
+            TestApiClient.JsonOptions);
+        resp.EnsureSuccessStatusCode();
+
+        var page = await GetUsersPageAsync("/api/v1/users?q=email.match.unique&pageSize=100");
+        Assert.Contains(page.Data, u => u.Email == "email.match.unique@example.com");
+    }
+
+    [Fact]
+    public async Task GetAll_WithSearchQ_IsCaseInsensitive()
+    {
+        var resp = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("Roberto Oliveira Q", "roberto.q@example.com"),
+            TestApiClient.JsonOptions);
+        resp.EnsureSuccessStatusCode();
+
+        var lower = await GetUsersPageAsync("/api/v1/users?q=roberto&pageSize=100");
+        var upper = await GetUsersPageAsync("/api/v1/users?q=ROBERTO&pageSize=100");
+        var mixed = await GetUsersPageAsync("/api/v1/users?q=RoBeRtO&pageSize=100");
+
+        Assert.Contains(lower.Data, u => u.Email == "roberto.q@example.com");
+        Assert.Contains(upper.Data, u => u.Email == "roberto.q@example.com");
+        Assert.Contains(mixed.Data, u => u.Email == "roberto.q@example.com");
+    }
+
+    [Fact]
+    public async Task GetAll_WithSearchQ_EscapesUnderscoreLiteral()
+    {
+        // Sem o escape, "_" viraria wildcard ILIKE e casaria qualquer caractere unico no lugar.
+        var resp1 = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("Foo_Lit_BarUser", "foo.litbar1@example.com"),
+            TestApiClient.JsonOptions);
+        resp1.EnsureSuccessStatusCode();
+        var resp2 = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("FooXLitXBarUser", "foo.litbar2@example.com"),
+            TestApiClient.JsonOptions);
+        resp2.EnsureSuccessStatusCode();
+
+        var page = await GetUsersPageAsync("/api/v1/users?q=_Lit_&pageSize=100");
+        Assert.Contains(page.Data, u => u.Name == "Foo_Lit_BarUser");
+        Assert.DoesNotContain(page.Data, u => u.Name == "FooXLitXBarUser");
+    }
+
+    [Fact]
+    public async Task GetAll_WithClientIdFilter_ReturnsOnlyMatching()
+    {
+        // Cria dois usuários, cada um vinculado ao seu próprio cliente auto-gerado pelo POST /users.
+        var aResp = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("ClientFilter A", "client.filter.a@example.com"),
+            TestApiClient.JsonOptions);
+        aResp.EnsureSuccessStatusCode();
+        var aDto = await aResp.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(aDto);
+        Assert.NotNull(aDto.ClientId);
+
+        var bResp = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("ClientFilter B", "client.filter.b@example.com"),
+            TestApiClient.JsonOptions);
+        bResp.EnsureSuccessStatusCode();
+        var bDto = await bResp.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(bDto);
+        Assert.NotNull(bDto.ClientId);
+
+        var page = await GetUsersPageAsync($"/api/v1/users?clientId={aDto.ClientId}&pageSize=100");
+        Assert.All(page.Data, u => Assert.Equal(aDto.ClientId, u.ClientId));
+        Assert.Contains(page.Data, u => u.Id == aDto.Id);
+        Assert.DoesNotContain(page.Data, u => u.Id == bDto.Id);
+    }
+
+    [Fact]
+    public async Task GetAll_WithClientIdEmpty_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync($"/api/v1/users?clientId={Guid.Empty}");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_WithClientIdNonExistent_ReturnsEmpty()
+    {
+        var page = await GetUsersPageAsync($"/api/v1/users?clientId={Guid.NewGuid()}&pageSize=100");
+        Assert.Empty(page.Data);
+        Assert.Equal(0, page.Total);
+    }
+
+    [Fact]
+    public async Task GetAll_WithActiveTrue_ReturnsOnlyActive()
+    {
+        var activeResp = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("ActiveTrue Stay", "active.true.stay@example.com"),
+            TestApiClient.JsonOptions);
+        activeResp.EnsureSuccessStatusCode();
+        var activeDto = await activeResp.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(activeDto);
+
+        var deletedResp = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("ActiveTrue Gone", "active.true.gone@example.com"),
+            TestApiClient.JsonOptions);
+        deletedResp.EnsureSuccessStatusCode();
+        var deletedDto = await deletedResp.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(deletedDto);
+        await _client.DeleteAsync($"/api/v1/users/{deletedDto.Id}");
+
+        var page = await GetUsersPageAsync("/api/v1/users?active=true&pageSize=100");
+        Assert.Contains(page.Data, u => u.Id == activeDto.Id);
+        Assert.DoesNotContain(page.Data, u => u.Id == deletedDto.Id);
+    }
+
+    [Fact]
+    public async Task GetAll_WithActiveFalse_ReturnsOnlySoftDeleted()
+    {
+        var activeResp = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("ActiveFalse Stay", "active.false.stay@example.com"),
+            TestApiClient.JsonOptions);
+        activeResp.EnsureSuccessStatusCode();
+        var activeDto = await activeResp.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(activeDto);
+
+        var deletedResp = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("ActiveFalse Gone", "active.false.gone@example.com"),
+            TestApiClient.JsonOptions);
+        deletedResp.EnsureSuccessStatusCode();
+        var deletedDto = await deletedResp.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(deletedDto);
+        await _client.DeleteAsync($"/api/v1/users/{deletedDto.Id}");
+
+        var page = await GetUsersPageAsync("/api/v1/users?active=false&pageSize=100");
+        Assert.Contains(page.Data, u => u.Id == deletedDto.Id);
+        Assert.DoesNotContain(page.Data, u => u.Id == activeDto.Id);
+    }
+
+    [Fact]
+    public async Task GetAll_WithIncludeDeletedTrue_ReturnsActiveAndSoftDeleted()
+    {
+        var activeResp = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("Incl Active", "incl.active.user@example.com"),
+            TestApiClient.JsonOptions);
+        activeResp.EnsureSuccessStatusCode();
+        var activeDto = await activeResp.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(activeDto);
+
+        var deletedResp = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("Incl Deleted", "incl.deleted.user@example.com"),
+            TestApiClient.JsonOptions);
+        deletedResp.EnsureSuccessStatusCode();
+        var deletedDto = await deletedResp.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(deletedDto);
+        await _client.DeleteAsync($"/api/v1/users/{deletedDto.Id}");
+
+        var page = await GetUsersPageAsync("/api/v1/users?includeDeleted=true&pageSize=100");
+        Assert.Contains(page.Data, u => u.Id == activeDto.Id && u.DeletedAt == null);
+        Assert.Contains(page.Data, u => u.Id == deletedDto.Id && u.DeletedAt != null);
+    }
+
+    [Fact]
+    public async Task GetAll_WithActiveAndIncludeDeleted_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync("/api/v1/users?active=true&includeDeleted=true");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_WithPageSizeAboveLimit_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync("/api/v1/users?pageSize=101");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_WithPageSizeZero_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync("/api/v1/users?pageSize=0");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_WithPageZero_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync("/api/v1/users?page=0");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_PageBeyondTotal_ReturnsEmptyDataAnd200()
+    {
+        await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("Beyond Unico", "beyond.unico@example.com"),
+            TestApiClient.JsonOptions);
+
+        var resp = await _client.GetAsync("/api/v1/users?q=beyond.unico&page=99&pageSize=10");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var page = await resp.Content.ReadFromJsonAsync<PagedUsersDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(page);
+        Assert.Empty(page.Data);
+        Assert.Equal(1, page.Total);
+    }
+
+    [Fact]
+    public async Task GetAll_OrderedByCreatedAt_Descending()
+    {
+        var first = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("Order User AAA", "order.user.aaa@example.com"),
+            TestApiClient.JsonOptions);
+        first.EnsureSuccessStatusCode();
+        var firstDto = await first.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(firstDto);
+
+        await Task.Delay(20);
+
+        var second = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("Order User BBB", "order.user.bbb@example.com"),
+            TestApiClient.JsonOptions);
+        second.EnsureSuccessStatusCode();
+        var secondDto = await second.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(secondDto);
+
+        var page = await GetUsersPageAsync("/api/v1/users?q=Order%20User&pageSize=100");
+        var ordered = page.Data
+            .Where(u => u.Name.StartsWith("Order User", StringComparison.Ordinal))
+            .Select(u => u.Id)
+            .ToList();
+        Assert.Equal(secondDto.Id, ordered[0]);
+        Assert.Equal(firstDto.Id, ordered[1]);
+    }
+
+    [Fact]
+    public async Task GetAll_TotalReflectsFilters_BeforePagination()
+    {
+        for (var i = 0; i < 3; i++)
+        {
+            await _client.PostAsJsonAsync("/api/v1/users",
+                UserCreateBody($"FiltroTot {i}", $"filtrotot.{i}@example.com"),
+                TestApiClient.JsonOptions);
+        }
+        await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("Outro Nome U", "outro.nome.u@example.com"),
+            TestApiClient.JsonOptions);
+
+        var page = await GetUsersPageAsync("/api/v1/users?q=FiltroTot&page=1&pageSize=2");
+        Assert.Equal(3, page.Total);
+        Assert.Equal(2, page.Data.Count);
+    }
+
+    [Fact]
+    public async Task GetAll_CombinedFilters_ApplyTogether()
+    {
+        var aResp = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("Combo Maria User", "combo.maria.user@example.com"),
+            TestApiClient.JsonOptions);
+        aResp.EnsureSuccessStatusCode();
+        var aDto = await aResp.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(aDto);
+        Assert.NotNull(aDto.ClientId);
+
+        await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("Combo Maria Outro", "combo.maria.outro@example.com"),
+            TestApiClient.JsonOptions);
+
+        var page = await GetUsersPageAsync(
+            $"/api/v1/users?q=Combo%20Maria&clientId={aDto.ClientId}&active=true&pageSize=100");
+        Assert.All(page.Data, u => Assert.Equal(aDto.ClientId, u.ClientId));
+        Assert.Contains(page.Data, u => u.Id == aDto.Id);
+        Assert.DoesNotContain(page.Data, u => u.Email == "combo.maria.outro@example.com");
+    }
+
+    [Fact]
+    public async Task GetAll_WithIdsPresent_PreservesMinimalProjectionContract()
+    {
+        // Mesmo passando page/pageSize e demais filtros, o caminho `?ids=` deve permanecer
+        // retornando o array minimal na ordem solicitada (sem envelope paginado).
+        var aResp = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("IdsKeep One", "ids.keep.one@example.com"),
+            TestApiClient.JsonOptions);
+        aResp.EnsureSuccessStatusCode();
+        var aDto = await aResp.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(aDto);
+
+        var bResp = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("IdsKeep Two", "ids.keep.two@example.com"),
+            TestApiClient.JsonOptions);
+        bResp.EnsureSuccessStatusCode();
+        var bDto = await bResp.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(bDto);
+
+        var resp = await _client.GetAsync(
+            $"/api/v1/users?ids={bDto.Id},{aDto.Id}&page=1&pageSize=20&q=ignored");
+        resp.EnsureSuccessStatusCode();
+        using var payload = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.Equal(JsonValueKind.Array, payload.RootElement.ValueKind);
+        var rows = payload.RootElement.EnumerateArray().ToList();
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(bDto.Id, rows[0].GetProperty("id").GetGuid());
+        Assert.Equal(aDto.Id, rows[1].GetProperty("id").GetGuid());
+        Assert.Equal(3, rows[0].EnumerateObject().Count());
+    }
+
+    private async Task<PagedUsersDto> GetUsersPageAsync(string url)
+    {
+        var resp = await _client.GetAsync(url);
+        resp.EnsureSuccessStatusCode();
+        var page = await resp.Content.ReadFromJsonAsync<PagedUsersDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(page);
+        return page;
+    }
+
+    private async Task<PagedUsersDetailDto> GetUsersDetailPageAsync(string url)
+    {
+        var resp = await _client.GetAsync(url);
+        resp.EnsureSuccessStatusCode();
+        var page = await resp.Content.ReadFromJsonAsync<PagedUsersDetailDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(page);
+        return page;
+    }
+
+    private sealed record PagedUsersDto(
+        List<UserDto> Data,
+        int Page,
+        int PageSize,
+        int Total);
+
+    private sealed record PagedUsersDetailDto(
+        List<UserDetailDto> Data,
+        int Page,
+        int PageSize,
+        int Total);
 
     private sealed record LoginDto(string Token);
 

--- a/AuthService/Controllers/Users/UsersController.cs
+++ b/AuthService/Controllers/Users/UsersController.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;
 using AuthService.Auth;
+using AuthService.Controllers.Common;
 using AuthService.Data;
 using AuthService.Models;
 using AuthService.Security;
@@ -295,9 +296,22 @@ public partial class UsersController : ControllerBase
         return CreatedAtAction(nameof(GetById), new { id = user.Id }, ToResponse(user));
     }
 
+    /// <summary>Tamanho de página default quando o cliente não envia <c>pageSize</c>.</summary>
+    public const int DefaultPageSize = 20;
+
+    /// <summary>Limite superior para <c>pageSize</c>; valores acima retornam 400.</summary>
+    public const int MaxPageSize = 100;
+
     [HttpGet]
     [Authorize(Policy = PermissionPolicies.UsersRead)]
-    public async Task<IActionResult> GetAll([FromQuery] string[]? ids = null)
+    public async Task<IActionResult> GetAll(
+        [FromQuery] string[]? ids = null,
+        [FromQuery] string? q = null,
+        [FromQuery] Guid? clientId = null,
+        [FromQuery] bool? active = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = DefaultPageSize,
+        [FromQuery] bool includeDeleted = false)
     {
         if (ids is { Length: > 0 })
         {
@@ -321,10 +335,98 @@ public partial class UsersController : ControllerBase
             return Ok(ordered);
         }
 
-        var users = await _db.Users
-            .OrderBy(u => u.CreatedAt)
+        ValidateGetAllQueryParams(page, pageSize, clientId, active, includeDeleted);
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        var query = BuildUsersListingQuery(q, clientId, active, includeDeleted);
+
+        // Query 1: COUNT pré-paginação refletindo todos os filtros aplicados.
+        var total = await query.CountAsync();
+
+        // Query 2: página corrente, ordenada determinísticamente (CreatedAt DESC com Id como
+        // desempate estável, evitando saltos/duplicação entre páginas em ties de timestamp).
+        var pageUsers = await query
+            .OrderByDescending(u => u.CreatedAt)
+            .ThenBy(u => u.Id)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .AsNoTracking()
             .ToListAsync();
-        return Ok(users.Select(u => ToResponse(u)).ToList());
+
+        var data = pageUsers.Select(u => ToResponse(u)).ToList();
+        return Ok(new PagedResponse<UserResponse>(data, page, pageSize, total));
+    }
+
+    /// <summary>
+    /// Valida os query params de <see cref="GetAll"/> em modo listagem (sem <c>ids</c>) e
+    /// acumula erros em <c>ModelState</c> para resposta unificada via <c>ValidationProblem</c>.
+    /// </summary>
+    private void ValidateGetAllQueryParams(int page, int pageSize, Guid? clientId, bool? active, bool includeDeleted)
+    {
+        if (page <= 0)
+            ModelState.AddModelError(nameof(page), "page deve ser maior ou igual a 1.");
+
+        if (pageSize <= 0 || pageSize > MaxPageSize)
+            ModelState.AddModelError(nameof(pageSize), $"pageSize deve estar entre 1 e {MaxPageSize}.");
+
+        if (clientId.HasValue && clientId.Value == Guid.Empty)
+            ModelState.AddModelError(nameof(clientId), "clientId não pode ser Guid.Empty.");
+
+        if (active.HasValue && includeDeleted)
+        {
+            ModelState.AddModelError(
+                nameof(includeDeleted),
+                "active e includeDeleted são mutuamente excludentes.");
+        }
+    }
+
+    /// <summary>
+    /// Compõe o <see cref="IQueryable{User}"/> base aplicando a flag de soft-delete (via
+    /// <c>IgnoreQueryFilters</c>) e os filtros <c>active</c>, <c>clientId</c> e busca textual <c>q</c>.
+    /// </summary>
+    /// <remarks>
+    /// includeDeleted=true expõe soft-deletados; active=false força <c>IgnoreQueryFilters</c> porque
+    /// o query filter global esconderia os registros que ele pretende selecionar. Quando nenhum dos
+    /// dois é informado, o filtro global age e a leitura permanece restrita a usuários ativos.
+    /// </remarks>
+    private IQueryable<UserEntity> BuildUsersListingQuery(string? q, Guid? clientId, bool? active, bool includeDeleted)
+    {
+        IQueryable<UserEntity> query = (includeDeleted || active == false)
+            ? _db.Users.IgnoreQueryFilters()
+            : _db.Users;
+
+        if (active.HasValue)
+        {
+            query = active.Value
+                ? query.Where(u => u.DeletedAt == null)
+                : query.Where(u => u.DeletedAt != null);
+        }
+
+        if (clientId.HasValue)
+            query = query.Where(u => u.ClientId == clientId.Value);
+
+        if (!string.IsNullOrWhiteSpace(q))
+        {
+            var pattern = $"%{EscapeLikePattern(q.Trim())}%";
+            query = query.Where(u =>
+                EF.Functions.ILike(u.Name, pattern, "\\")
+                || EF.Functions.ILike(u.Email, pattern, "\\"));
+        }
+
+        return query;
+    }
+
+    /// <summary>
+    /// Escapa caracteres curinga (<c>%</c>, <c>_</c>) e o caractere de escape (<c>\</c>) na entrada
+    /// do usuário para evitar que sejam interpretados como wildcards no <c>ILIKE</c>.
+    /// </summary>
+    private static string EscapeLikePattern(string value)
+    {
+        return value
+            .Replace("\\", "\\\\")
+            .Replace("%", "\\%")
+            .Replace("_", "\\_");
     }
 
     [HttpGet("{id:guid}")]

--- a/README.md
+++ b/README.md
@@ -315,6 +315,22 @@ Query string: `?prune=false` (padrão). Quando `prune=true`, rotas do sistema qu
 
 **GET** `/api/v1/users/{id}` retorna também os vínculos ativos **`roles`** (lista com `id` inteiro, `userId`, `roleId`, auditoria e `deletedAt`) e **`permissions`** (lista com `id` GUID, `userId`, `permissionId`, auditoria e `deletedAt`). Listagens **`GET /api/v1/users`** e respostas de criação/atualização devolvem `roles` e `permissions` como arrays vazios.
 
+**`GET /api/v1/users`** suporta dois modos:
+
+- **Batch lookup por `ids`** — quando `?ids=<guid>,<guid>...` é informado, retorna um array de objetos `{ id, name, email }` na ordem dos ids enviados (máximo 100 ids por requisição). Demais query params são ignorados.
+- **Listagem paginada** — quando `ids` não é informado, retorna `PagedResponse<UserResponse>` com filtros/busca/paginação server-side via query string:
+
+| Param | Default | Notas |
+|-------|---------|-------|
+| `q` | `""` | Busca case-insensitive (ILIKE) com matching parcial em `Name` e `Email` (OR). Caracteres `%`, `_` e `\` são escapados (literais). |
+| `clientId` | _ausente_ | Filtra por usuários vinculados ao cliente informado. `Guid.Empty` retorna **400**. |
+| `active` | _ausente_ | `true` retorna apenas ativos (`DeletedAt IS NULL`); `false` retorna apenas soft-deletados. Mutuamente excludente com `includeDeleted` (combinar retorna **400**). |
+| `page` | `1` | 1-based. `<= 0` retorna **400**. |
+| `pageSize` | `20` | Máximo `100`. `<= 0` ou `> 100` retornam **400**. |
+| `includeDeleted` | `false` | Quando `true`, inclui usuários soft-deletados (`DeletedAt != null`). Mutuamente excludente com `active`. |
+
+Resposta paginada: `{ data, page, pageSize, total }`. `total` reflete o total após filtros, antes de `Skip/Take`. Ordenação determinística por `CreatedAt` descendente, com `Id` como desempate. Página além do total retorna **200** com `data: []`. Os itens em `data` continuam expondo `roles: []` e `permissions: []` na listagem (como na resposta de criação/atualização) — os vínculos só são hidratados pelo endpoint `GET /api/v1/users/{id}`.
+
 **`POST /api/v1/users/{id}/force-logout`** — admin invalida todas as sessões ativas do usuário-alvo incrementando o `TokenVersion`. Mesmo mecanismo do `GET /auth/logout`, porém aplicado a um terceiro. Caller precisa de `perm:Users.Update`. O `JwtBearerHandler` valida o claim `tv` contra o banco a cada request, então tokens emitidos antes da chamada passam a falhar com 401 automaticamente. Self-target (`id` igual ao caller do JWT) retorna 400 e orienta a usar `/auth/logout`. Usuário inexistente ou soft-deletado retorna 404. Resposta `200 OK`:
 
 ```json


### PR DESCRIPTION
## Summary

- Estende `GET /api/v1/users` (quando `ids` AUSENTE) com paginação server-side: `q` (ILIKE em `Name`/`Email`, escape de `%`/`_`/`\`), `clientId` (`Guid.Empty` retorna 400), `active`, `page` (1-based), `pageSize` (max 100), `includeDeleted` (mutuamente excludente com `active`). Resposta passa a ser `PagedResponse<UserResponse>` com ordenação determinística `CreatedAt DESC + Id` desempate.
- Mantém comportamento atual quando `ids` está presente: retorna `UserMinimalResponse` na ordem do array, sem envelope.
- Atualiza testes existentes que dependiam do envelope antigo (`GetAll_ReturnsOnlyActiveUsers`, `Restore_Deleted_…`, `GetAll_ReturnsEmptyRolesAndPermissions_OnEachUser`) e adiciona 22 novos cobrindo cada AC: paginação multi-página, busca por `Name`/`Email`, case-insensitive, escape de underscore, filtro por `clientId` (válido, inexistente, `Guid.Empty`), `active=true|false`, `includeDeleted=true`, mutex `active`+`includeDeleted`, validação de `page`/`pageSize`, page além do total, ordem `CreatedAt DESC`, total reflete filtros antes da paginação, combinação de filtros, e preservação do contrato `?ids=` quando demais query params são informados.
- README seção `Usuários` documenta os dois modos (`?ids=` vs paginado) e a tabela completa de query params.

## Test plan

- [x] `docker compose --profile test run --rm test` — Build 0 warning / 0 error
- [x] `dotnet format --verify-no-changes --severity warn` — sem diffs
- [x] Suite completa Container Only: **292/0/292** verde (271 baseline + 21 novos efetivos após upgrade do envelope)
- [x] Filtro `UsersApiTests`: **52/0/52**

Closes #166