### PR TITLE
feat(roles): add SystemId required FK and Description to AppRole, scope unique to (SystemId, Code), add PagedResponse listing (#163)

### DIFF
--- a/AuthService.Tests/RolesApiTests.cs
+++ b/AuthService.Tests/RolesApiTests.cs
@@ -9,6 +9,8 @@ namespace AuthService.Tests;
 
 public class RolesApiTests : IAsyncLifetime
 {
+    private const string AuthenticatorSystemCode = "authenticator";
+
     private WebAppFactory _factory = null!;
     private HttpClient _client = null!;
 
@@ -25,61 +27,201 @@ public class RolesApiTests : IAsyncLifetime
         return Task.CompletedTask;
     }
 
+    private async Task<Guid> GetAuthenticatorSystemIdAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var id = await db.Systems
+            .Where(s => s.Code == AuthenticatorSystemCode)
+            .Select(s => (Guid?)s.Id)
+            .FirstOrDefaultAsync();
+        Assert.True(id.HasValue && id.Value != Guid.Empty);
+        return id!.Value;
+    }
+
+    private async Task<Guid> CreateSystemAsync(string code, string name = "Sistema Teste")
+    {
+        var resp = await _client.PostAsJsonAsync("/api/v1/systems",
+            new { name, code, description = (string?)null }, TestApiClient.JsonOptions);
+        resp.EnsureSuccessStatusCode();
+        var dto = await resp.Content.ReadFromJsonAsync<SystemRefDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto);
+        return dto.Id;
+    }
+
+    private async Task<Guid> SoftDeleteSystemAsync(Guid systemId)
+    {
+        var resp = await _client.DeleteAsync($"/api/v1/systems/{systemId}");
+        Assert.Equal(HttpStatusCode.NoContent, resp.StatusCode);
+        return systemId;
+    }
+
+    private static object RoleCreateBody(Guid systemId, string name, string code, string? description = null) =>
+        new { systemId, name, code, description };
+
+    private static object RoleUpdateBody(Guid systemId, string name, string code, string? description = null) =>
+        new { systemId, name, code, description };
+
     [Fact]
     public async Task Create_Post_ReturnsCreated_WithUtcTimestamps_AndNullDeletedAt()
     {
-        var body = new { name = "Administrador", code = "ROLE_ADMIN" };
+        var systemId = await GetAuthenticatorSystemIdAsync();
+        var body = RoleCreateBody(systemId, "Administrador", "ROLE_ADMIN", "Descrição opcional");
         var response = await _client.PostAsJsonAsync("/api/v1/roles", body, TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
         var dto = await response.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
         Assert.NotEqual(Guid.Empty, dto.Id);
+        Assert.Equal(systemId, dto.SystemId);
         Assert.Null(dto.DeletedAt);
         Assert.Equal("Administrador", dto.Name);
         Assert.Equal("ROLE_ADMIN", dto.Code);
+        Assert.Equal("Descrição opcional", dto.Description);
         Assert.True(dto.CreatedAt > DateTime.MinValue);
         Assert.True(dto.UpdatedAt > DateTime.MinValue);
     }
 
     [Fact]
-    public async Task Create_DuplicateCode_ReturnsConflict()
+    public async Task Create_WithoutSystemId_ReturnsBadRequest()
     {
-        await _client.PostAsJsonAsync("/api/v1/roles", new { name = "A", code = "ROLE_ABC" }, TestApiClient.JsonOptions);
+        var response = await _client.PostAsJsonAsync("/api/v1/roles",
+            new { name = "Sem sistema", code = "ROLE_NO_SYS" }, TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
 
-        var response = await _client.PostAsJsonAsync("/api/v1/roles", new { name = "B", code = "ROLE_ABC" }, TestApiClient.JsonOptions);
+    [Fact]
+    public async Task Create_WithEmptySystemId_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(Guid.Empty, "X", "ROLE_EMPTY_SYS"), TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_WithUnknownSystemId_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(Guid.NewGuid(), "X", "ROLE_UNK_SYS"), TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_WithSoftDeletedSystem_ReturnsBadRequest()
+    {
+        var sysId = await CreateSystemAsync("ROLE_SYS_DEL");
+        await SoftDeleteSystemAsync(sysId);
+
+        var response = await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(sysId, "X", "ROLE_DEL_SYS"), TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_DuplicateCode_SameSystem_ReturnsConflict()
+    {
+        var systemId = await GetAuthenticatorSystemIdAsync();
+        await _client.PostAsJsonAsync("/api/v1/roles", RoleCreateBody(systemId, "A", "ROLE_ABC"), TestApiClient.JsonOptions);
+
+        var response = await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(systemId, "B", "ROLE_ABC"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_SameCode_DifferentSystems_BothSucceed()
+    {
+        var system1 = await GetAuthenticatorSystemIdAsync();
+        var system2 = await CreateSystemAsync("ROLE_SCOPE_OTHER");
+
+        var r1 = await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(system1, "Admin1", "ROLE_SHARED_CODE"), TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.Created, r1.StatusCode);
+
+        var r2 = await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(system2, "Admin2", "ROLE_SHARED_CODE"), TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.Created, r2.StatusCode);
+
+        var dto1 = await r1.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
+        var dto2 = await r2.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto1);
+        Assert.NotNull(dto2);
+        Assert.NotEqual(dto1.Id, dto2.Id);
+        Assert.Equal(system1, dto1.SystemId);
+        Assert.Equal(system2, dto2.SystemId);
     }
 
     [Fact]
     public async Task Create_DuplicateCode_NormalizesWhitespace_ReturnsConflict()
     {
-        await _client.PostAsJsonAsync("/api/v1/roles", new { name = "A", code = "ROLE_WS" }, TestApiClient.JsonOptions);
+        var systemId = await GetAuthenticatorSystemIdAsync();
+        await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(systemId, "A", "ROLE_WS"), TestApiClient.JsonOptions);
 
         var response = await _client.PostAsJsonAsync("/api/v1/roles",
-            new { name = "B", code = "  ROLE_WS  " }, TestApiClient.JsonOptions);
+            RoleCreateBody(systemId, "B", "  ROLE_WS  "), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
 
     [Fact]
     public async Task Update_DuplicateCode_NormalizesWhitespace_ReturnsConflict()
     {
-        await _client.PostAsJsonAsync("/api/v1/roles", new { name = "A", code = "ROLE_CA" }, TestApiClient.JsonOptions);
-        var b = await _client.PostAsJsonAsync("/api/v1/roles", new { name = "B", code = "ROLE_CB" }, TestApiClient.JsonOptions);
+        var systemId = await GetAuthenticatorSystemIdAsync();
+        await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(systemId, "A", "ROLE_CA"), TestApiClient.JsonOptions);
+        var b = await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(systemId, "B", "ROLE_CB"), TestApiClient.JsonOptions);
         var dtoB = await b.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dtoB);
 
         var put = await _client.PutAsJsonAsync($"/api/v1/roles/{dtoB.Id}",
-            new { name = "B2", code = "  ROLE_CA  " }, TestApiClient.JsonOptions);
+            RoleUpdateBody(systemId, "B2", "  ROLE_CA  "), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.Conflict, put.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_TryingToChangeSystemId_ReturnsBadRequest()
+    {
+        var system1 = await GetAuthenticatorSystemIdAsync();
+        var system2 = await CreateSystemAsync("ROLE_IMM_OTHER");
+
+        var create = await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(system1, "Original", "ROLE_IMM"), TestApiClient.JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto);
+
+        var put = await _client.PutAsJsonAsync($"/api/v1/roles/{dto.Id}",
+            RoleUpdateBody(system2, "Outro nome", "ROLE_IMM"), TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_SameSystemId_AllowsChangingNameAndDescription()
+    {
+        var systemId = await GetAuthenticatorSystemIdAsync();
+
+        var create = await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(systemId, "Original", "ROLE_DESC1", "antes"), TestApiClient.JsonOptions);
+        var dto = await create.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto);
+
+        var put = await _client.PutAsJsonAsync($"/api/v1/roles/{dto.Id}",
+            RoleUpdateBody(systemId, "Atualizado", "ROLE_DESC1", "depois"), TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.OK, put.StatusCode);
+        var updated = await put.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(updated);
+        Assert.Equal("Atualizado", updated.Name);
+        Assert.Equal("depois", updated.Description);
+        Assert.Equal(systemId, updated.SystemId);
     }
 
     [Fact]
     public async Task Create_ConcurrentSameCode_OneCreatedOneConflict()
     {
+        var systemId = await GetAuthenticatorSystemIdAsync();
         const string code = "ROLE_CONCURRENT";
-        var bodyA = new { name = "A", code };
-        var bodyB = new { name = "B", code };
+        var bodyA = RoleCreateBody(systemId, "A", code);
+        var bodyB = RoleCreateBody(systemId, "B", code);
         var t1 = _client.PostAsJsonAsync("/api/v1/roles", bodyA, TestApiClient.JsonOptions);
         var t2 = _client.PostAsJsonAsync("/api/v1/roles", bodyB, TestApiClient.JsonOptions);
         await Task.WhenAll(t1, t2);
@@ -94,32 +236,48 @@ public class RolesApiTests : IAsyncLifetime
     [Fact]
     public async Task Create_WhitespaceOnlyName_ReturnsBadRequest()
     {
-        var response = await _client.PostAsJsonAsync("/api/v1/roles", new { name = "   ", code = "ROLE_X1" }, TestApiClient.JsonOptions);
+        var systemId = await GetAuthenticatorSystemIdAsync();
+        var response = await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(systemId, "   ", "ROLE_X1"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]
     public async Task Create_WhitespaceOnlyCode_ReturnsBadRequest()
     {
-        var response = await _client.PostAsJsonAsync("/api/v1/roles", new { name = "N1", code = "\t  " }, TestApiClient.JsonOptions);
+        var systemId = await GetAuthenticatorSystemIdAsync();
+        var response = await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(systemId, "N1", "\t  "), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]
     public async Task Create_NameExceedsMaxLength_ReturnsBadRequest()
     {
+        var systemId = await GetAuthenticatorSystemIdAsync();
         var name81 = new string('n', 81);
         var response = await _client.PostAsJsonAsync("/api/v1/roles",
-            new { name = name81, code = "ROLE_LEN_NAME" }, TestApiClient.JsonOptions);
+            RoleCreateBody(systemId, name81, "ROLE_LEN_NAME"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]
     public async Task Create_CodeExceedsMaxLength_ReturnsBadRequest()
     {
+        var systemId = await GetAuthenticatorSystemIdAsync();
         var code51 = new string('c', 51);
         var response = await _client.PostAsJsonAsync("/api/v1/roles",
-            new { name = "Nome válido", code = code51 }, TestApiClient.JsonOptions);
+            RoleCreateBody(systemId, "Nome válido", code51), TestApiClient.JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_DescriptionExceedsMaxLength_ReturnsBadRequest()
+    {
+        var systemId = await GetAuthenticatorSystemIdAsync();
+        var desc501 = new string('d', 501);
+        var response = await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(systemId, "Nome", "ROLE_LEN_DESC", desc501), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
@@ -129,7 +287,9 @@ public class RolesApiTests : IAsyncLifetime
     [Fact]
     public async Task Restore_ActiveRole_ReturnsNotFound()
     {
-        var create = await _client.PostAsJsonAsync("/api/v1/roles", new { name = "Ativo", code = "ROLE_ACTIVE_R" }, TestApiClient.JsonOptions);
+        var systemId = await GetAuthenticatorSystemIdAsync();
+        var create = await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(systemId, "Ativo", "ROLE_ACTIVE_R"), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
@@ -140,38 +300,158 @@ public class RolesApiTests : IAsyncLifetime
     [Fact]
     public async Task Put_WhitespaceOnlyName_ReturnsBadRequest()
     {
-        var create = await _client.PostAsJsonAsync("/api/v1/roles", new { name = "S", code = "ROLE_W1" }, TestApiClient.JsonOptions);
+        var systemId = await GetAuthenticatorSystemIdAsync();
+        var create = await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(systemId, "S", "ROLE_W1"), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
         var put = await _client.PutAsJsonAsync($"/api/v1/roles/{dto.Id}",
-            new { name = "   ", code = "ROLE_W1" }, TestApiClient.JsonOptions);
+            RoleUpdateBody(systemId, "   ", "ROLE_W1"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_NoFilters_UsesDefaultEnvelope()
+    {
+        var page = await GetRolesPageAsync("/api/v1/roles");
+        Assert.Equal(1, page.Page);
+        Assert.Equal(20, page.PageSize);
+        Assert.True(page.Total >= page.Data.Count);
     }
 
     [Fact]
     public async Task GetAll_ReturnsOnlyActiveRoles()
     {
-        await _client.PostAsJsonAsync("/api/v1/roles", new { name = "Ativo", code = "ROLE_ATIVO" }, TestApiClient.JsonOptions);
+        var systemId = await GetAuthenticatorSystemIdAsync();
+        await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(systemId, "Ativo", "ROLE_ATIVO"), TestApiClient.JsonOptions);
 
-        var other = await _client.PostAsJsonAsync("/api/v1/roles", new { name = "Outro", code = "ROLE_OUTRO" }, TestApiClient.JsonOptions);
+        var other = await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(systemId, "Outro", "ROLE_OUTRO"), TestApiClient.JsonOptions);
         var toDelete = await other.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(toDelete);
         await _client.DeleteAsync($"/api/v1/roles/{toDelete.Id}");
 
-        var listResp = await _client.GetAsync("/api/v1/roles");
-        listResp.EnsureSuccessStatusCode();
-        var list = await listResp.Content.ReadFromJsonAsync<List<RoleDto>>(TestApiClient.JsonOptions);
-        Assert.NotNull(list);
-        Assert.All(list, r => Assert.Null(r.DeletedAt));
-        Assert.Contains(list, r => r.Code == "ROLE_ATIVO");
-        Assert.DoesNotContain(list, r => r.Code == "ROLE_OUTRO");
+        var page = await GetRolesPageAsync("/api/v1/roles?pageSize=100");
+        Assert.All(page.Data, r => Assert.Null(r.DeletedAt));
+        Assert.Contains(page.Data, r => r.Code == "ROLE_ATIVO");
+        Assert.DoesNotContain(page.Data, r => r.Code == "ROLE_OUTRO");
+    }
+
+    [Fact]
+    public async Task GetAll_WithSystemIdFilter_ReturnsOnlyMatching()
+    {
+        var system1 = await GetAuthenticatorSystemIdAsync();
+        var system2 = await CreateSystemAsync("ROLE_FILT_SYS");
+
+        await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(system1, "S1A", "ROLE_FILT_S1A"), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(system1, "S1B", "ROLE_FILT_S1B"), TestApiClient.JsonOptions);
+        await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(system2, "S2", "ROLE_FILT_S2"), TestApiClient.JsonOptions);
+
+        var page = await GetRolesPageAsync($"/api/v1/roles?systemId={system2}&pageSize=100");
+        Assert.All(page.Data, r => Assert.Equal(system2, r.SystemId));
+        Assert.Contains(page.Data, r => r.Code == "ROLE_FILT_S2");
+        Assert.DoesNotContain(page.Data, r => r.Code == "ROLE_FILT_S1A");
+        Assert.DoesNotContain(page.Data, r => r.Code == "ROLE_FILT_S1B");
+    }
+
+    [Fact]
+    public async Task GetAll_WithEmptySystemId_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync($"/api/v1/roles?systemId={Guid.Empty}");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_WithSearchQ_PartialMatchOnCode()
+    {
+        var systemId = await GetAuthenticatorSystemIdAsync();
+        await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(systemId, "Algo", "ROLE_QSEARCH_UNIQUE"), TestApiClient.JsonOptions);
+
+        var page = await GetRolesPageAsync("/api/v1/roles?q=QSEARCH_UNIQUE&pageSize=100");
+        Assert.Contains(page.Data, r => r.Code == "ROLE_QSEARCH_UNIQUE");
+    }
+
+    [Fact]
+    public async Task GetAll_WithSearchQ_IsCaseInsensitive()
+    {
+        var systemId = await GetAuthenticatorSystemIdAsync();
+        await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(systemId, "Roberto", "ROLE_CI_TEST"), TestApiClient.JsonOptions);
+
+        var lower = await GetRolesPageAsync("/api/v1/roles?q=roberto&pageSize=100");
+        var upper = await GetRolesPageAsync("/api/v1/roles?q=ROBERTO&pageSize=100");
+        Assert.Contains(lower.Data, r => r.Code == "ROLE_CI_TEST");
+        Assert.Contains(upper.Data, r => r.Code == "ROLE_CI_TEST");
+    }
+
+    [Fact]
+    public async Task GetAll_WithPagination_ReturnsCorrectSubset()
+    {
+        var systemId = await CreateSystemAsync("ROLE_PG_SYS");
+        for (var i = 0; i < 5; i++)
+        {
+            await _client.PostAsJsonAsync("/api/v1/roles",
+                RoleCreateBody(systemId, $"Pg {i}", $"ROLE_PAG_{i:D2}"), TestApiClient.JsonOptions);
+        }
+
+        var first = await GetRolesPageAsync($"/api/v1/roles?systemId={systemId}&page=1&pageSize=2");
+        var second = await GetRolesPageAsync($"/api/v1/roles?systemId={systemId}&page=2&pageSize=2");
+        var third = await GetRolesPageAsync($"/api/v1/roles?systemId={systemId}&page=3&pageSize=2");
+
+        Assert.Equal(2, first.Data.Count);
+        Assert.Equal(2, second.Data.Count);
+        Assert.Single(third.Data);
+        Assert.Equal(5, first.Total);
+        Assert.Equal(5, second.Total);
+        Assert.Equal(5, third.Total);
+
+        var ids = first.Data.Concat(second.Data).Concat(third.Data).Select(r => r.Id).ToList();
+        Assert.Equal(ids.Count, ids.Distinct().Count());
+    }
+
+    [Fact]
+    public async Task GetAll_PageZero_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync("/api/v1/roles?page=0");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_PageSizeOverMax_ReturnsBadRequest()
+    {
+        var resp = await _client.GetAsync("/api/v1/roles?pageSize=101");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_IncludeDeletedTrue_ReturnsSoftDeletedRoles()
+    {
+        var systemId = await CreateSystemAsync("ROLE_DEL_SYS");
+        var c = await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(systemId, "Para deletar", "ROLE_DEL_TARGET"), TestApiClient.JsonOptions);
+        var dto = await c.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(dto);
+        await _client.DeleteAsync($"/api/v1/roles/{dto.Id}");
+
+        var defaultPage = await GetRolesPageAsync($"/api/v1/roles?systemId={systemId}&pageSize=100");
+        Assert.DoesNotContain(defaultPage.Data, r => r.Code == "ROLE_DEL_TARGET");
+
+        var allPage = await GetRolesPageAsync($"/api/v1/roles?systemId={systemId}&includeDeleted=true&pageSize=100");
+        Assert.Contains(allPage.Data, r => r.Code == "ROLE_DEL_TARGET" && r.DeletedAt is not null);
     }
 
     [Fact]
     public async Task GetById_Active_ReturnsOk_Deleted_Returns404()
     {
-        var create = await _client.PostAsJsonAsync("/api/v1/roles", new { name = "S", code = "ROLE_S1" }, TestApiClient.JsonOptions);
+        var systemId = await GetAuthenticatorSystemIdAsync();
+        var create = await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(systemId, "S", "ROLE_S1"), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
@@ -186,24 +466,28 @@ public class RolesApiTests : IAsyncLifetime
     [Fact]
     public async Task Update_Active_ReturnsOk_Deleted_Returns404()
     {
-        var create = await _client.PostAsJsonAsync("/api/v1/roles", new { name = "S", code = "ROLE_U1" }, TestApiClient.JsonOptions);
+        var systemId = await GetAuthenticatorSystemIdAsync();
+        var create = await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(systemId, "S", "ROLE_U1"), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
         var putOk = await _client.PutAsJsonAsync($"/api/v1/roles/{dto.Id}",
-            new { name = "S2", code = "ROLE_U1" }, TestApiClient.JsonOptions);
+            RoleUpdateBody(systemId, "S2", "ROLE_U1"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.OK, putOk.StatusCode);
 
         await _client.DeleteAsync($"/api/v1/roles/{dto.Id}");
         var put404 = await _client.PutAsJsonAsync($"/api/v1/roles/{dto.Id}",
-            new { name = "S3", code = "ROLE_U1" }, TestApiClient.JsonOptions);
+            RoleUpdateBody(systemId, "S3", "ROLE_U1"), TestApiClient.JsonOptions);
         Assert.Equal(HttpStatusCode.NotFound, put404.StatusCode);
     }
 
     [Fact]
     public async Task Delete_SoftDelete_ThenDeleteAgain_Returns404()
     {
-        var create = await _client.PostAsJsonAsync("/api/v1/roles", new { name = "S", code = "ROLE_D1" }, TestApiClient.JsonOptions);
+        var systemId = await GetAuthenticatorSystemIdAsync();
+        var create = await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(systemId, "S", "ROLE_D1"), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
@@ -224,7 +508,9 @@ public class RolesApiTests : IAsyncLifetime
     [Fact]
     public async Task Restore_Deleted_ThenOperationsWorkAgain()
     {
-        var create = await _client.PostAsJsonAsync("/api/v1/roles", new { name = "S", code = "ROLE_R1" }, TestApiClient.JsonOptions);
+        var systemId = await GetAuthenticatorSystemIdAsync();
+        var create = await _client.PostAsJsonAsync("/api/v1/roles",
+            RoleCreateBody(systemId, "S", "ROLE_R1"), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<RoleDto>(TestApiClient.JsonOptions);
         Assert.NotNull(dto);
 
@@ -243,11 +529,30 @@ public class RolesApiTests : IAsyncLifetime
         Assert.Null(restored.DeletedAt);
     }
 
+    private async Task<PagedRolesDto> GetRolesPageAsync(string url)
+    {
+        var resp = await _client.GetAsync(url);
+        resp.EnsureSuccessStatusCode();
+        var page = await resp.Content.ReadFromJsonAsync<PagedRolesDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(page);
+        return page;
+    }
+
+    private sealed record PagedRolesDto(
+        List<RoleDto> Data,
+        int Page,
+        int PageSize,
+        int Total);
+
     private sealed record RoleDto(
         Guid Id,
+        Guid SystemId,
         string Name,
         string Code,
+        string? Description,
         DateTime CreatedAt,
         DateTime UpdatedAt,
         DateTime? DeletedAt);
+
+    private sealed record SystemRefDto(Guid Id, string Code, string Name);
 }

--- a/AuthService/Controllers/Common/PagingQueryHelper.cs
+++ b/AuthService/Controllers/Common/PagingQueryHelper.cs
@@ -1,0 +1,74 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace AuthService.Controllers.Common;
+
+/// <summary>
+/// Helpers reutilizáveis para validação de query string de listagens paginadas
+/// (<c>page</c>, <c>pageSize</c>, filtros opcionais por <c>systemId</c>) e para
+/// escapar entradas usadas em padrões <c>ILIKE</c>. Centraliza a aplicação dos
+/// limites canônicos de paginação para que os controllers permaneçam declarativos.
+/// </summary>
+internal static class PagingQueryHelper
+{
+    /// <summary>Adiciona em <paramref name="modelState"/> os erros padronizados para <c>page</c>/<c>pageSize</c>.</summary>
+    public static void ValidatePaging(ModelStateDictionary modelState, int page, int pageSize, int maxPageSize)
+    {
+        if (page <= 0)
+            modelState.AddModelError(nameof(page), "page deve ser maior ou igual a 1.");
+
+        if (pageSize <= 0 || pageSize > maxPageSize)
+            modelState.AddModelError(nameof(pageSize), $"pageSize deve estar entre 1 e {maxPageSize}.");
+    }
+
+    /// <summary>Valida que <paramref name="systemId"/>, quando informado, não seja <see cref="Guid.Empty"/>.</summary>
+    public static void ValidateOptionalSystemId(ModelStateDictionary modelState, Guid? systemId, string fieldName = "systemId")
+    {
+        if (systemId.HasValue && systemId.Value == Guid.Empty)
+            modelState.AddModelError(fieldName, "systemId inválido.");
+    }
+
+    /// <summary>
+    /// Escapa caracteres curinga (<c>%</c>, <c>_</c>) e o caractere de escape (<c>\</c>) na entrada do usuário
+    /// para evitar que sejam interpretados como wildcards no <c>ILIKE</c>. Mantém o termo como busca literal parcial.
+    /// </summary>
+    public static string EscapeLikePattern(string value)
+    {
+        return value
+            .Replace("\\", "\\\\")
+            .Replace("%", "\\%")
+            .Replace("_", "\\_");
+    }
+
+    /// <summary>
+    /// Valida o trio canônico <c>Name</c>/<c>Code</c>/<c>Description</c> nas mesmas regras usadas
+    /// por todos os controllers do catálogo (não-vazio após trim, max length consistente). Adiciona
+    /// erros em <paramref name="modelState"/> usando os nomes de propriedade dos requests.
+    /// </summary>
+    public static void ValidateNameCodeDescription(
+        ModelStateDictionary modelState,
+        string name,
+        string code,
+        string? descriptionOrNull,
+        string nameField = "Name",
+        string codeField = "Code",
+        string descriptionField = "Description",
+        int nameMax = 80,
+        int codeMax = 50,
+        int descriptionMax = 500)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            modelState.AddModelError(nameField, $"{nameField} é obrigatório e não pode ser apenas espaços.");
+
+        if (string.IsNullOrWhiteSpace(code))
+            modelState.AddModelError(codeField, $"{codeField} é obrigatório e não pode ser apenas espaços.");
+
+        if (name.Length > nameMax)
+            modelState.AddModelError(nameField, $"{nameField} deve ter no máximo {nameMax} caracteres.");
+
+        if (code.Length > codeMax)
+            modelState.AddModelError(codeField, $"{codeField} deve ter no máximo {codeMax} caracteres.");
+
+        if (descriptionOrNull is not null && descriptionOrNull.Length > descriptionMax)
+            modelState.AddModelError(descriptionField, $"{descriptionField} deve ter no máximo {descriptionMax} caracteres.");
+    }
+}

--- a/AuthService/Controllers/Roles/RolesController.cs
+++ b/AuthService/Controllers/Roles/RolesController.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using AuthService.Auth;
+using AuthService.Controllers.Common;
 using AuthService.Data;
 using AuthService.Models;
 using Microsoft.AspNetCore.Authorization;
@@ -25,6 +26,9 @@ public partial class RolesController : ControllerBase
 
     public class CreateRoleRequest
     {
+        [Required(ErrorMessage = "SystemId é obrigatório.")]
+        public Guid? SystemId { get; set; }
+
         [Required(ErrorMessage = "Name é obrigatório.")]
         [MaxLength(80, ErrorMessage = "Name deve ter no máximo 80 caracteres.")]
         public string Name { get; set; } = string.Empty;
@@ -32,10 +36,16 @@ public partial class RolesController : ControllerBase
         [Required(ErrorMessage = "Code é obrigatório.")]
         [MaxLength(50, ErrorMessage = "Code deve ter no máximo 50 caracteres.")]
         public string Code { get; set; } = string.Empty;
+
+        [MaxLength(500, ErrorMessage = "Description deve ter no máximo 500 caracteres.")]
+        public string? Description { get; set; }
     }
 
     public class UpdateRoleRequest
     {
+        [Required(ErrorMessage = "SystemId é obrigatório.")]
+        public Guid? SystemId { get; set; }
+
         [Required(ErrorMessage = "Name é obrigatório.")]
         [MaxLength(80, ErrorMessage = "Name deve ter no máximo 80 caracteres.")]
         public string Name { get; set; } = string.Empty;
@@ -43,24 +53,30 @@ public partial class RolesController : ControllerBase
         [Required(ErrorMessage = "Code é obrigatório.")]
         [MaxLength(50, ErrorMessage = "Code deve ter no máximo 50 caracteres.")]
         public string Code { get; set; } = string.Empty;
+
+        [MaxLength(500, ErrorMessage = "Description deve ter no máximo 500 caracteres.")]
+        public string? Description { get; set; }
     }
 
     public record RoleResponse(
         Guid Id,
+        Guid SystemId,
         string Name,
         string Code,
+        string? Description,
         DateTime CreatedAt,
         DateTime UpdatedAt,
         DateTime? DeletedAt
     );
 
     private static RoleResponse ToResponse(AppRole e) =>
-        new(e.Id, e.Name, e.Code, e.CreatedAt, e.UpdatedAt, e.DeletedAt);
+        new(e.Id, e.SystemId, e.Name, e.Code, e.Description, e.CreatedAt, e.UpdatedAt, e.DeletedAt);
 
     private static void ValidateNormalizedFields(
         ModelStateDictionary modelState,
         string name,
-        string code)
+        string code,
+        string? descriptionOrNull)
     {
         if (string.IsNullOrWhiteSpace(name))
             modelState.AddModelError(nameof(CreateRoleRequest.Name), "Name é obrigatório e não pode ser apenas espaços.");
@@ -73,10 +89,22 @@ public partial class RolesController : ControllerBase
 
         if (code.Length > 50)
             modelState.AddModelError(nameof(CreateRoleRequest.Code), "Code deve ter no máximo 50 caracteres.");
+
+        if (descriptionOrNull is { Length: > 500 })
+            modelState.AddModelError(nameof(CreateRoleRequest.Description), "Description deve ter no máximo 500 caracteres.");
     }
 
     private static ConflictObjectResult UniqueConflictResult() =>
-        new(new { message = "Já existe um role com este Code." });
+        new(new { message = "Já existe um role com este Code neste sistema." });
+
+    private async Task<bool> SystemExistsAndActiveAsync(Guid systemId) =>
+        systemId != Guid.Empty && await _db.Systems.AnyAsync(s => s.Id == systemId);
+
+    private ActionResult InvalidSystemIdResult()
+    {
+        ModelState.AddModelError(nameof(CreateRoleRequest.SystemId), "SystemId inválido ou sistema inativo.");
+        return ValidationProblem(ModelState);
+    }
 
     [HttpPost]
     [Authorize(Policy = PermissionPolicies.RolesCreate)]
@@ -85,24 +113,32 @@ public partial class RolesController : ControllerBase
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);
 
+        var systemId = request.SystemId!.Value;
+
+        if (!await SystemExistsAndActiveAsync(systemId))
+            return InvalidSystemIdResult();
+
         var name = request.Name.Trim();
         var code = request.Code.Trim();
+        var description = string.IsNullOrWhiteSpace(request.Description) ? null : request.Description.Trim();
 
-        ValidateNormalizedFields(ModelState, name, code);
+        ValidateNormalizedFields(ModelState, name, code, description);
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);
 
-        if (await _db.Roles.IgnoreQueryFilters().AnyAsync(r => r.Code == code))
+        if (await _db.Roles.IgnoreQueryFilters().AnyAsync(r => r.SystemId == systemId && r.Code == code))
         {
-            _logger.LogWarning("Conflito ao criar role: já existe Code {Code}.", code);
+            _logger.LogWarning("Conflito ao criar role: já existe Code {Code} no sistema {SystemId}.", code, systemId);
             return UniqueConflictResult();
         }
 
         var now = DateTime.UtcNow;
         var entity = new AppRole
         {
+            SystemId = systemId,
             Name = name,
             Code = code,
+            Description = description,
             CreatedAt = now,
             UpdatedAt = now,
             DeletedAt = null
@@ -115,29 +151,90 @@ public partial class RolesController : ControllerBase
         }
         catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
         {
-            _logger.LogWarning(ex, "Conflito de unicidade ao criar role com Code {Code}.", code);
+            _logger.LogWarning(ex, "Conflito de unicidade ao criar role com Code {Code} no sistema {SystemId}.", code, systemId);
             return UniqueConflictResult();
+        }
+        catch (DbUpdateException ex) when (IsForeignKeyViolation(ex))
+        {
+            return InvalidSystemIdResult();
         }
 
         LogRoleCreated(entity.Id, code);
         return CreatedAtAction(nameof(GetById), new { id = entity.Id }, ToResponse(entity));
     }
 
+    /// <summary>Tamanho de página default quando o cliente não envia <c>pageSize</c>.</summary>
+    public const int DefaultPageSize = 20;
+
+    /// <summary>Limite superior para <c>pageSize</c>; valores acima retornam 400.</summary>
+    public const int MaxPageSize = 100;
+
     [HttpGet]
     [Authorize(Policy = PermissionPolicies.RolesRead)]
-    public async Task<IActionResult> GetAll()
+    public async Task<IActionResult> GetAll(
+        [FromQuery] Guid? systemId = null,
+        [FromQuery] string? q = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = DefaultPageSize,
+        [FromQuery] bool includeDeleted = false)
     {
-        var list = await _db.Roles
-            .OrderBy(r => r.CreatedAt)
+        if (page <= 0)
+            ModelState.AddModelError(nameof(page), "page deve ser maior ou igual a 1.");
+
+        if (pageSize <= 0 || pageSize > MaxPageSize)
+            ModelState.AddModelError(nameof(pageSize), $"pageSize deve estar entre 1 e {MaxPageSize}.");
+
+        if (systemId.HasValue && systemId.Value == Guid.Empty)
+            ModelState.AddModelError(nameof(systemId), "systemId inválido.");
+
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        IQueryable<AppRole> query = includeDeleted
+            ? _db.Roles.IgnoreQueryFilters()
+            : _db.Roles;
+
+        if (systemId.HasValue)
+            query = query.Where(r => r.SystemId == systemId.Value);
+
+        if (!string.IsNullOrWhiteSpace(q))
+        {
+            var pattern = $"%{EscapeLikePattern(q.Trim())}%";
+            query = query.Where(r =>
+                EF.Functions.ILike(r.Code, pattern, "\\") || EF.Functions.ILike(r.Name, pattern, "\\"));
+        }
+
+        var total = await query.CountAsync();
+
+        var data = await query
+            .OrderBy(r => r.Code)
+            .ThenBy(r => r.Id)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
             .Select(r => new RoleResponse(
                 r.Id,
+                r.SystemId,
                 r.Name,
                 r.Code,
+                r.Description,
                 r.CreatedAt,
                 r.UpdatedAt,
                 r.DeletedAt))
             .ToListAsync();
-        return Ok(list);
+
+        return Ok(new PagedResponse<RoleResponse>(data, page, pageSize, total));
+    }
+
+    /// <summary>
+    /// Escapa caracteres curinga (<c>%</c>, <c>_</c>) e o caractere de escape (<c>\</c>) na entrada do usuário
+    /// para evitar que sejam interpretados como wildcards no <c>ILIKE</c>. Mantém o termo como busca literal parcial.
+    /// </summary>
+    private static string EscapeLikePattern(string value)
+    {
+        return value
+            .Replace("\\", "\\\\")
+            .Replace("%", "\\%")
+            .Replace("_", "\\_");
     }
 
     [HttpGet("{id:guid}")]
@@ -157,25 +254,39 @@ public partial class RolesController : ControllerBase
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);
 
-        var name = request.Name.Trim();
-        var code = request.Code.Trim();
-
-        ValidateNormalizedFields(ModelState, name, code);
-        if (!ModelState.IsValid)
-            return ValidationProblem(ModelState);
-
         var entity = await _db.Roles.FirstOrDefaultAsync(r => r.Id == id);
         if (entity is null)
             return NotFound(new { message = "Role não encontrado." });
 
-        if (await _db.Roles.IgnoreQueryFilters().AnyAsync(r => r.Id != id && r.Code == code))
+        var systemId = request.SystemId!.Value;
+
+        // SystemId é imutável após criação. Tentativa de mudar retorna 400.
+        if (systemId != entity.SystemId)
         {
-            _logger.LogWarning("Conflito ao atualizar role {RoleId}: Code {Code} já em uso.", id, code);
-            return new ConflictObjectResult(new { message = "Já existe outro role com este Code." });
+            ModelState.AddModelError(nameof(UpdateRoleRequest.SystemId),
+                "SystemId é imutável após a criação do role.");
+            return ValidationProblem(ModelState);
+        }
+
+        var name = request.Name.Trim();
+        var code = request.Code.Trim();
+        var description = string.IsNullOrWhiteSpace(request.Description) ? null : request.Description.Trim();
+
+        ValidateNormalizedFields(ModelState, name, code, description);
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        if (await _db.Roles.IgnoreQueryFilters()
+            .AnyAsync(r => r.Id != id && r.SystemId == entity.SystemId && r.Code == code))
+        {
+            _logger.LogWarning("Conflito ao atualizar role {RoleId}: Code {Code} já em uso no sistema {SystemId}.",
+                id, code, entity.SystemId);
+            return new ConflictObjectResult(new { message = "Já existe outro role com este Code neste sistema." });
         }
 
         entity.Name = name;
         entity.Code = code;
+        entity.Description = description;
         entity.UpdatedAt = DateTime.UtcNow;
 
         try
@@ -185,7 +296,7 @@ public partial class RolesController : ControllerBase
         catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
         {
             _logger.LogWarning(ex, "Conflito de unicidade ao atualizar role {RoleId} para Code {Code}.", id, code);
-            return new ConflictObjectResult(new { message = "Já existe outro role com este Code." });
+            return new ConflictObjectResult(new { message = "Já existe outro role com este Code neste sistema." });
         }
 
         LogRoleUpdated(id);

--- a/AuthService/Controllers/Roles/RolesController.cs
+++ b/AuthService/Controllers/Roles/RolesController.cs
@@ -60,28 +60,6 @@ public partial class RolesController : ControllerBase
     private static RoleResponse ToResponse(AppRole e) =>
         new(e.Id, e.SystemId, e.Name, e.Code, e.Description, e.CreatedAt, e.UpdatedAt, e.DeletedAt);
 
-    private static void ValidateNormalizedFields(
-        ModelStateDictionary modelState,
-        string name,
-        string code,
-        string? descriptionOrNull)
-    {
-        if (string.IsNullOrWhiteSpace(name))
-            modelState.AddModelError(nameof(CreateRoleRequest.Name), "Name é obrigatório e não pode ser apenas espaços.");
-
-        if (string.IsNullOrWhiteSpace(code))
-            modelState.AddModelError(nameof(CreateRoleRequest.Code), "Code é obrigatório e não pode ser apenas espaços.");
-
-        if (name.Length > 80)
-            modelState.AddModelError(nameof(CreateRoleRequest.Name), "Name deve ter no máximo 80 caracteres.");
-
-        if (code.Length > 50)
-            modelState.AddModelError(nameof(CreateRoleRequest.Code), "Code deve ter no máximo 50 caracteres.");
-
-        if (descriptionOrNull is { Length: > 500 })
-            modelState.AddModelError(nameof(CreateRoleRequest.Description), "Description deve ter no máximo 500 caracteres.");
-    }
-
     private const string RoleNotFoundMessage = "Role não encontrado.";
 
     private static ConflictObjectResult UniqueConflictResult() =>
@@ -115,7 +93,7 @@ public partial class RolesController : ControllerBase
         var code = request.Code.Trim();
         var description = string.IsNullOrWhiteSpace(request.Description) ? null : request.Description.Trim();
 
-        ValidateNormalizedFields(ModelState, name, code, description);
+        PagingQueryHelper.ValidateNameCodeDescription(ModelState, name, code, description);
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);
 
@@ -171,15 +149,8 @@ public partial class RolesController : ControllerBase
         [FromQuery] int pageSize = DefaultPageSize,
         [FromQuery] bool includeDeleted = false)
     {
-        if (page <= 0)
-            ModelState.AddModelError(nameof(page), "page deve ser maior ou igual a 1.");
-
-        if (pageSize <= 0 || pageSize > MaxPageSize)
-            ModelState.AddModelError(nameof(pageSize), $"pageSize deve estar entre 1 e {MaxPageSize}.");
-
-        if (systemId.HasValue && systemId.Value == Guid.Empty)
-            ModelState.AddModelError(nameof(systemId), "systemId inválido.");
-
+        PagingQueryHelper.ValidatePaging(ModelState, page, pageSize, MaxPageSize);
+        PagingQueryHelper.ValidateOptionalSystemId(ModelState, systemId);
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);
 
@@ -192,7 +163,7 @@ public partial class RolesController : ControllerBase
 
         if (!string.IsNullOrWhiteSpace(q))
         {
-            var pattern = $"%{EscapeLikePattern(q.Trim())}%";
+            var pattern = $"%{PagingQueryHelper.EscapeLikePattern(q.Trim())}%";
             query = query.Where(r =>
                 EF.Functions.ILike(r.Code, pattern, "\\") || EF.Functions.ILike(r.Name, pattern, "\\"));
         }
@@ -216,18 +187,6 @@ public partial class RolesController : ControllerBase
             .ToListAsync();
 
         return Ok(new PagedResponse<RoleResponse>(data, page, pageSize, total));
-    }
-
-    /// <summary>
-    /// Escapa caracteres curinga (<c>%</c>, <c>_</c>) e o caractere de escape (<c>\</c>) na entrada do usuário
-    /// para evitar que sejam interpretados como wildcards no <c>ILIKE</c>. Mantém o termo como busca literal parcial.
-    /// </summary>
-    private static string EscapeLikePattern(string value)
-    {
-        return value
-            .Replace("\\", "\\\\")
-            .Replace("%", "\\%")
-            .Replace("_", "\\_");
     }
 
     [HttpGet("{id:guid}")]
@@ -265,7 +224,7 @@ public partial class RolesController : ControllerBase
         var code = request.Code.Trim();
         var description = string.IsNullOrWhiteSpace(request.Description) ? null : request.Description.Trim();
 
-        ValidateNormalizedFields(ModelState, name, code, description);
+        PagingQueryHelper.ValidateNameCodeDescription(ModelState, name, code, description);
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);
 

--- a/AuthService/Controllers/Roles/RolesController.cs
+++ b/AuthService/Controllers/Roles/RolesController.cs
@@ -24,7 +24,8 @@ public partial class RolesController : ControllerBase
         _logger = logger;
     }
 
-    public class CreateRoleRequest
+    /// <summary>Payload base com os campos compartilhados entre Create e Update de roles.</summary>
+    public abstract class RoleRequestBase
     {
         [Required(ErrorMessage = "SystemId é obrigatório.")]
         public Guid? SystemId { get; set; }
@@ -41,22 +42,9 @@ public partial class RolesController : ControllerBase
         public string? Description { get; set; }
     }
 
-    public class UpdateRoleRequest
-    {
-        [Required(ErrorMessage = "SystemId é obrigatório.")]
-        public Guid? SystemId { get; set; }
+    public sealed class CreateRoleRequest : RoleRequestBase { }
 
-        [Required(ErrorMessage = "Name é obrigatório.")]
-        [MaxLength(80, ErrorMessage = "Name deve ter no máximo 80 caracteres.")]
-        public string Name { get; set; } = string.Empty;
-
-        [Required(ErrorMessage = "Code é obrigatório.")]
-        [MaxLength(50, ErrorMessage = "Code deve ter no máximo 50 caracteres.")]
-        public string Code { get; set; } = string.Empty;
-
-        [MaxLength(500, ErrorMessage = "Description deve ter no máximo 500 caracteres.")]
-        public string? Description { get; set; }
-    }
+    public sealed class UpdateRoleRequest : RoleRequestBase { }
 
     public record RoleResponse(
         Guid Id,
@@ -94,8 +82,13 @@ public partial class RolesController : ControllerBase
             modelState.AddModelError(nameof(CreateRoleRequest.Description), "Description deve ter no máximo 500 caracteres.");
     }
 
+    private const string RoleNotFoundMessage = "Role não encontrado.";
+
     private static ConflictObjectResult UniqueConflictResult() =>
         new(new { message = "Já existe um role com este Code neste sistema." });
+
+    private static NotFoundObjectResult RoleNotFoundResult() =>
+        new(new { message = RoleNotFoundMessage });
 
     private async Task<bool> SystemExistsAndActiveAsync(Guid systemId) =>
         systemId != Guid.Empty && await _db.Systems.AnyAsync(s => s.Id == systemId);
@@ -243,7 +236,7 @@ public partial class RolesController : ControllerBase
     {
         var entity = await _db.Roles.FirstOrDefaultAsync(r => r.Id == id);
         if (entity is null)
-            return NotFound(new { message = "Role não encontrado." });
+            return RoleNotFoundResult();
         return Ok(ToResponse(entity));
     }
 
@@ -256,7 +249,7 @@ public partial class RolesController : ControllerBase
 
         var entity = await _db.Roles.FirstOrDefaultAsync(r => r.Id == id);
         if (entity is null)
-            return NotFound(new { message = "Role não encontrado." });
+            return RoleNotFoundResult();
 
         var systemId = request.SystemId!.Value;
 
@@ -309,7 +302,7 @@ public partial class RolesController : ControllerBase
     {
         var entity = await _db.Roles.FirstOrDefaultAsync(r => r.Id == id);
         if (entity is null)
-            return NotFound(new { message = "Role não encontrado." });
+            return RoleNotFoundResult();
 
         entity.DeletedAt = DateTime.UtcNow;
         entity.UpdatedAt = DateTime.UtcNow;
@@ -363,7 +356,7 @@ public partial class RolesController : ControllerBase
 
         var roleExists = await _db.Roles.AnyAsync(r => r.Id == roleId);
         if (!roleExists)
-            return NotFound(new { message = "Role não encontrado." });
+            return RoleNotFoundResult();
 
         var permissionExists = await _db.Permissions.AnyAsync(p => p.Id == permissionId);
         if (!permissionExists)

--- a/AuthService/Data/AppDbContext.cs
+++ b/AuthService/Data/AppDbContext.cs
@@ -37,6 +37,14 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
                 .OnDelete(DeleteBehavior.Restrict);
         });
 
+        modelBuilder.Entity<AppRole>(entity =>
+        {
+            entity.HasOne<AppSystem>()
+                .WithMany()
+                .HasForeignKey(r => r.SystemId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
         modelBuilder.Entity<Client>(entity =>
         {
             entity.HasIndex(c => c.Cpf)

--- a/AuthService/Data/Migrations/20260501191342_AddRoleSystemIdAndDescription.Designer.cs
+++ b/AuthService/Data/Migrations/20260501191342_AddRoleSystemIdAndDescription.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AuthService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace AuthService.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260501191342_AddRoleSystemIdAndDescription")]
+    partial class AddRoleSystemIdAndDescription
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AuthService/Data/Migrations/20260501191342_AddRoleSystemIdAndDescription.cs
+++ b/AuthService/Data/Migrations/20260501191342_AddRoleSystemIdAndDescription.cs
@@ -1,0 +1,110 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AuthService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRoleSystemIdAndDescription : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // 1) Adiciona Description como NULL (campo opcional max 500).
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "Roles",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+
+            // 2) Adiciona SystemId como nullable (transitório) para permitir backfill em bases pré-existentes
+            //    sem violar NOT NULL antes da population.
+            migrationBuilder.AddColumn<Guid>(
+                name: "SystemId",
+                table: "Roles",
+                type: "uuid",
+                nullable: true);
+
+            // 3) Backfill: roles pré-existentes apontam para o sistema 'authenticator'. Idempotente:
+            //    se o sistema 'authenticator' não existir (cenário improvável já que SystemSeeder roda
+            //    no startup), o UPDATE não atualiza nenhuma linha e o ALTER NOT NULL adiante falhará,
+            //    sinalizando o erro. Em bases novas (sem roles), o UPDATE é no-op e a sequência é segura.
+            migrationBuilder.Sql(@"
+                UPDATE ""Roles""
+                SET ""SystemId"" = (SELECT ""Id"" FROM ""Systems"" WHERE ""Code"" = 'authenticator' LIMIT 1)
+                WHERE ""SystemId"" IS NULL;
+            ");
+
+            // 4) Promove SystemId para NOT NULL após o backfill.
+            migrationBuilder.AlterColumn<Guid>(
+                name: "SystemId",
+                table: "Roles",
+                type: "uuid",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            // 5) Drop do índice único global antigo (UX_Roles_Code) — substituído pelo escopo (SystemId, Code).
+            migrationBuilder.DropIndex(
+                name: "UX_Roles_Code",
+                table: "Roles");
+
+            // 6) Index simples por SystemId para acelerar lookups por sistema.
+            migrationBuilder.CreateIndex(
+                name: "IX_Roles_SystemId",
+                table: "Roles",
+                column: "SystemId");
+
+            // 7) Unique scoped: (SystemId, Code) — Code passa a ser único POR sistema.
+            migrationBuilder.CreateIndex(
+                name: "UX_Roles_SystemId_Code",
+                table: "Roles",
+                columns: new[] { "SystemId", "Code" },
+                unique: true);
+
+            // 8) FK com onDelete: Restrict (não permitir apagar Sistema referenciado por roles).
+            migrationBuilder.AddForeignKey(
+                name: "FK_Roles_Systems_SystemId",
+                table: "Roles",
+                column: "SystemId",
+                principalTable: "Systems",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Reverte na ordem inversa.
+            migrationBuilder.DropForeignKey(
+                name: "FK_Roles_Systems_SystemId",
+                table: "Roles");
+
+            migrationBuilder.DropIndex(
+                name: "UX_Roles_SystemId_Code",
+                table: "Roles");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Roles_SystemId",
+                table: "Roles");
+
+            // Recria o índice único global anterior.
+            migrationBuilder.CreateIndex(
+                name: "UX_Roles_Code",
+                table: "Roles",
+                column: "Code",
+                unique: true);
+
+            migrationBuilder.DropColumn(
+                name: "SystemId",
+                table: "Roles");
+
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "Roles");
+        }
+    }
+}

--- a/AuthService/Data/Migrations/20260501191342_AddRoleSystemIdAndDescription.cs
+++ b/AuthService/Data/Migrations/20260501191342_AddRoleSystemIdAndDescription.cs
@@ -8,6 +8,8 @@ namespace AuthService.Data.Migrations
     /// <inheritdoc />
     public partial class AddRoleSystemIdAndDescription : Migration
     {
+        private static readonly string[] SystemIdCodeColumns = ["SystemId", "Code"];
+
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
@@ -62,7 +64,7 @@ namespace AuthService.Data.Migrations
             migrationBuilder.CreateIndex(
                 name: "UX_Roles_SystemId_Code",
                 table: "Roles",
-                columns: new[] { "SystemId", "Code" },
+                columns: SystemIdCodeColumns,
                 unique: true);
 
             // 8) FK com onDelete: Restrict (não permitir apagar Sistema referenciado por roles).

--- a/AuthService/Data/RootRolePermissionsSeeder.cs
+++ b/AuthService/Data/RootRolePermissionsSeeder.cs
@@ -14,15 +14,6 @@ public static class RootRolePermissionsSeeder
 
     public static async Task EnsureRootRolePermissionsAsync(AppDbContext db, CancellationToken cancellationToken = default)
     {
-        var rootRoleId = await db.Roles.AsNoTracking()
-            .Where(r => r.Code == RootUserSeeder.RootRoleCode)
-            .Select(r => (Guid?)r.Id)
-            .FirstOrDefaultAsync(cancellationToken);
-
-        if (rootRoleId is null || rootRoleId == Guid.Empty)
-            throw new InvalidOperationException(
-                $"Role '{RootUserSeeder.RootRoleCode}' não encontrada. Execute o RootUserSeeder antes do RootRolePermissionsSeeder.");
-
         var systemId = await db.Systems.AsNoTracking()
             .Where(s => s.Code == SystemCode)
             .Select(s => (Guid?)s.Id)
@@ -31,6 +22,15 @@ public static class RootRolePermissionsSeeder
         if (systemId is null || systemId == Guid.Empty)
             throw new InvalidOperationException(
                 $"Sistema '{SystemCode}' não encontrado. Execute o SystemSeeder antes do RootRolePermissionsSeeder.");
+
+        var rootRoleId = await db.Roles.AsNoTracking()
+            .Where(r => r.SystemId == systemId.Value && r.Code == RootUserSeeder.RootRoleCode)
+            .Select(r => (Guid?)r.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (rootRoleId is null || rootRoleId == Guid.Empty)
+            throw new InvalidOperationException(
+                $"Role '{RootUserSeeder.RootRoleCode}' não encontrada no sistema '{SystemCode}'. Execute o RootUserSeeder antes do RootRolePermissionsSeeder.");
 
         var permissionIds = await (
             from p in db.Permissions

--- a/AuthService/Data/RootUserSeeder.cs
+++ b/AuthService/Data/RootUserSeeder.cs
@@ -11,6 +11,7 @@ public static class RootUserSeeder
     public const string RootName = "Root";
     public const string RootRoleCode = "root";
     public const string RootRoleName = "Root";
+    private const string AuthenticatorSystemCode = "authenticator";
 
     private const string PasswordEnvVar = "DEFAULT_SYSTEM_USER_PASSWORD";
 
@@ -20,8 +21,9 @@ public static class RootUserSeeder
         var email = RootEmail.Trim().ToLowerInvariant();
         var password = ResolvePassword();
 
+        var systemId = await ResolveAuthenticatorSystemIdAsync(db, cancellationToken);
         var client = await EnsureClientAsync(db, email, utc, cancellationToken);
-        var role = await EnsureRoleAsync(db, utc, cancellationToken);
+        var role = await EnsureRoleAsync(db, systemId, utc, cancellationToken);
         await db.SaveChangesAsync(cancellationToken);
 
         var user = await EnsureUserAsync(db, email, password, client.Id, utc, cancellationToken);
@@ -29,6 +31,22 @@ public static class RootUserSeeder
 
         await EnsureUserRoleAsync(db, user.Id, role.Id, utc, cancellationToken);
         await db.SaveChangesAsync(cancellationToken);
+    }
+
+    private static async Task<Guid> ResolveAuthenticatorSystemIdAsync(
+        AppDbContext db,
+        CancellationToken cancellationToken)
+    {
+        var systemId = await db.Systems.AsNoTracking()
+            .Where(s => s.Code == AuthenticatorSystemCode)
+            .Select(s => (Guid?)s.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (systemId is null || systemId == Guid.Empty)
+            throw new InvalidOperationException(
+                $"Sistema '{AuthenticatorSystemCode}' não encontrado. Execute o SystemSeeder antes do RootUserSeeder.");
+
+        return systemId.Value;
     }
 
     private static string ResolvePassword()
@@ -80,11 +98,12 @@ public static class RootUserSeeder
 
     private static async Task<AppRole> EnsureRoleAsync(
         AppDbContext db,
+        Guid systemId,
         DateTime utc,
         CancellationToken cancellationToken)
     {
         var existing = await db.Roles.IgnoreQueryFilters()
-            .FirstOrDefaultAsync(r => r.Code == RootRoleCode, cancellationToken);
+            .FirstOrDefaultAsync(r => r.SystemId == systemId && r.Code == RootRoleCode, cancellationToken);
 
         if (existing is not null)
         {
@@ -97,6 +116,7 @@ public static class RootUserSeeder
 
         var role = new AppRole
         {
+            SystemId = systemId,
             Name = RootRoleName,
             Code = RootRoleCode,
             CreatedAt = utc,

--- a/AuthService/Models/AppRole.cs
+++ b/AuthService/Models/AppRole.cs
@@ -4,7 +4,8 @@ using Microsoft.EntityFrameworkCore;
 
 namespace AuthService.Models;
 
-[Index(nameof(Code), IsUnique = true, Name = "UX_Roles_Code")]
+[Index(nameof(SystemId), nameof(Code), IsUnique = true, Name = "UX_Roles_SystemId_Code")]
+[Index(nameof(SystemId), Name = "IX_Roles_SystemId")]
 [Index(nameof(DeletedAt), Name = "IX_Roles_DeletedAt")]
 [Table("Roles")]
 public class AppRole : ISoftDelete
@@ -13,12 +14,18 @@ public class AppRole : ISoftDelete
     public Guid Id { get; set; } = Guid.NewGuid();
 
     [Required]
+    public Guid SystemId { get; set; }
+
+    [Required]
     [StringLength(80)]
     public string Name { get; set; } = string.Empty;
 
     [Required]
     [StringLength(50)]
     public string Code { get; set; } = string.Empty;
+
+    [StringLength(500)]
+    public string? Description { get; set; }
 
     [Required]
     public DateTime CreatedAt { get; set; }

--- a/README.md
+++ b/README.md
@@ -412,6 +412,20 @@ Resposta paginada: `{ data, page, pageSize, total }`. `total` reflete o total ap
 | `POST` | `/api/v1/roles/{id}/permissions` | Sim | `perm:Roles.Update` |
 | `DELETE` | `/api/v1/roles/{id}/permissions/{permissionId}` | Sim | `perm:Roles.Update` |
 
+Corpo de criação/atualização: `systemId` (obrigatório, sistema deve existir e estar ativo), `name`, `code`, `description` (opcional, máx. 500). `systemId` é **imutável** após criação — tentativa de alterá-lo no `PUT` retorna 400. `code` é único **por sistema** (mesmo `code` pode coexistir em sistemas diferentes); conflito retorna 409 com mensagem "Já existe um role com este Code neste sistema."
+
+Listagem `GET /api/v1/roles` com paginação server-side (envelope `PagedResponse<RoleResponse>` — `{ data, page, pageSize, total }`):
+
+| Param | Default | Notas |
+|-------|---------|-------|
+| `systemId` | _ausente_ | UUID do sistema. Quando ausente, lista todas as roles (cenário admin). `Guid.Empty` retorna 400. |
+| `q` | `""` | ILIKE em `Code`/`Name` (caracteres `%`/`_`/`\` escapados). |
+| `page` | `1` | 1-based. `<= 0` retorna 400. |
+| `pageSize` | `20` | Máximo `100`; valores fora do intervalo retornam 400. |
+| `includeDeleted` | `false` | Quando `true`, inclui registros *soft-deleted*. |
+
+Ordenação determinística por `Code ASC, Id ASC`.
+
 ### Permissões — `/api/v1/permissions`
 
 | Método | Endpoint | Auth | Permissão |


### PR DESCRIPTION
## Resumo

Implementa #163: torna roles escopadas por sistema. `AppRole` ganha `SystemId` (FK obrigatória para `Systems`) e `Description` (opcional, máx. 500). Unicidade de `Code` deixa de ser global e passa a ser **por sistema** (`UX_Roles_SystemId_Code`). `GET /roles` evolui para `PagedResponse` com `systemId`, `q`, `page`, `pageSize`, `includeDeleted`, espelhando `RoutesController.GetAll`.

## Mudanças

- **Modelo `AppRole`**: novo `SystemId Guid NOT NULL` com `[Index(SystemId)]`, novo `Description string?` (max 500), substitui `[Index(Code, Unique)]` por `[Index(SystemId, Code, Unique)]`.
- **Migration `AddRoleSystemIdAndDescription`**: ADD `Description` nullable, ADD `SystemId` nullable, **backfill** roles existentes apontando para o sistema `authenticator`, ALTER `SystemId` NOT NULL, drop `UX_Roles_Code`, cria `IX_Roles_SystemId`, `UX_Roles_SystemId_Code`, e `FK_Roles_Systems_SystemId` (`onDelete: Restrict`). `Down` reverte.
- **`RolesController`**:
  - `CreateRoleRequest`: `SystemId` obrigatório (sistema deve existir e estar ativo, `Guid.Empty` retorna 400 em `ModelState[SystemId]`); `Description` opcional, max 500.
  - `UpdateRoleRequest`: `SystemId` **imutável**; tentativa de mudar retorna 400 em `ModelState[SystemId]`.
  - `RoleResponse`: ganha `SystemId` e `Description`.
  - `GET /roles`: `PagedResponse<RoleResponse>` com `systemId`, `q` (ILIKE em `Code`/`Name` com escape de `%`/`_`/`\`), `page`, `pageSize` (1-100), `includeDeleted`. Ordenação `Code ASC, Id`.
  - 409 de Code agora é por sistema: "Já existe um role com este Code neste sistema."
- **Seeders**:
  - `RootUserSeeder`: cria role `root` com `SystemId = authenticator.Id`. Lookup atualizado para `(SystemId, Code)`.
  - `RootRolePermissionsSeeder`: ordem dos lookups invertida — resolve `SystemId` antes para localizar a role root.
- **Testes**: `RolesApiTests` adapta payloads existentes (todos enviam `systemId`) e adiciona cobertura: criar com `systemId` `Guid.Empty`/inexistente/soft-deleted (400), update tentando mudar `systemId` (400), update preservando `systemId` (200), descrição com 501 chars (400), filtro por `systemId`, mesmo Code em sistemas diferentes (Created), `PagedResponse` default envelope, `page=0`/`pageSize=101` (400), `includeDeleted=true`, search `q` parcial e case-insensitive, paginação determinística.
- **README**: tabela de query string em "Papéis (roles)" alinhada à de routes; menção a `systemId`/`description`/`code escopo`/`imutabilidade`.

## Validação

- Container Only.
- `dotnet build`: 0 warnings, 0 errors.
- `dotnet format` (severity warn): 0 issues.
- `dotnet ef migrations has-pending-model-changes`: "No changes have been made to the model since the last migration."
- `docker compose --profile test run --rm test`: **309/0/309 passed** (baseline subiu de 292 para 309 com +17 testes novos).

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)