### PR TITLE
feat(users): return full UserResponse on GetById + add /users/{id}/effective-permissions endpoint (#167)

### DIFF
--- a/AuthService.Tests/ApiVersioningAndDocsTests.cs
+++ b/AuthService.Tests/ApiVersioningAndDocsTests.cs
@@ -102,6 +102,7 @@ public class ApiVersioningAndDocsTests : IAsyncLifetime
             "/api/v1/tokens/types/{id}/restore",
             "/api/v1/users",
             "/api/v1/users/{id}",
+            "/api/v1/users/{id}/effective-permissions",
             "/api/v1/users/{id}/force-logout",
             "/api/v1/users/{id}/password",
             "/api/v1/users/{id}/restore",

--- a/AuthService.Tests/UsersApiTests.cs
+++ b/AuthService.Tests/UsersApiTests.cs
@@ -171,7 +171,7 @@ public class UsersApiTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task GetById_Active_ReturnsOk_Deleted_Returns404()
+    public async Task GetById_Active_ReturnsFullUserResponse_Deleted_Returns404()
     {
         var create = await _client.PostAsJsonAsync("/api/v1/users", UserCreateBody("S", "g1@example.com"), TestApiClient.JsonOptions);
         var dto = await create.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
@@ -179,18 +179,183 @@ public class UsersApiTests : IAsyncLifetime
 
         var getOk = await _client.GetAsync($"/api/v1/users/{dto.Id}");
         Assert.Equal(HttpStatusCode.OK, getOk.StatusCode);
-        using (var payload = JsonDocument.Parse(await getOk.Content.ReadAsStringAsync()))
-        {
-            var root = payload.RootElement;
-            Assert.Equal(3, root.EnumerateObject().Count());
-            Assert.Equal(dto.Id, root.GetProperty("id").GetGuid());
-            Assert.Equal("S", root.GetProperty("name").GetString());
-            Assert.Equal("g1@example.com", root.GetProperty("email").GetString());
-        }
+        var detail = await getOk.Content.ReadFromJsonAsync<UserDetailDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(detail);
+        Assert.Equal(dto.Id, detail.Id);
+        Assert.Equal("S", detail.Name);
+        Assert.Equal("g1@example.com", detail.Email);
+        Assert.True(detail.Active);
+        Assert.NotNull(detail.Roles);
+        Assert.NotNull(detail.Permissions);
+        Assert.Empty(detail.Roles);
+        Assert.Empty(detail.Permissions);
 
         await _client.DeleteAsync($"/api/v1/users/{dto.Id}");
         var get404 = await _client.GetAsync($"/api/v1/users/{dto.Id}");
         Assert.Equal(HttpStatusCode.NotFound, get404.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsOnlyActiveRoleAndPermissionLinks()
+    {
+        // Cria usuário e permissões/roles, vincula, deleta um vínculo direto + um vínculo de role
+        // e valida que GetById expõe apenas vínculos ativos.
+        var userCreate = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("LinksUser", "links.user@example.com"), TestApiClient.JsonOptions);
+        var user = await userCreate.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(user);
+
+        var (activePermissionId, deletedPermissionId, activeRoleId, deletedRoleId) =
+            await SeedUserLinksAsync(user.Id);
+
+        var resp = await _client.GetAsync($"/api/v1/users/{user.Id}");
+        resp.EnsureSuccessStatusCode();
+        var detail = await resp.Content.ReadFromJsonAsync<UserDetailDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(detail);
+
+        Assert.Single(detail.Permissions);
+        Assert.Equal(activePermissionId, detail.Permissions[0].PermissionId);
+        Assert.DoesNotContain(detail.Permissions, p => p.PermissionId == deletedPermissionId);
+
+        Assert.Single(detail.Roles);
+        Assert.Equal(activeRoleId, detail.Roles[0].RoleId);
+        Assert.DoesNotContain(detail.Roles, r => r.RoleId == deletedRoleId);
+    }
+
+    [Fact]
+    public async Task GetEffectivePermissions_NoLinks_ReturnsEmpty()
+    {
+        var userCreate = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("EmptyEff", "empty.eff@example.com"), TestApiClient.JsonOptions);
+        var user = await userCreate.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(user);
+
+        var resp = await _client.GetAsync($"/api/v1/users/{user.Id}/effective-permissions");
+        resp.EnsureSuccessStatusCode();
+        var rows = await resp.Content.ReadFromJsonAsync<List<EffectivePermissionDto>>(TestApiClient.JsonOptions);
+        Assert.NotNull(rows);
+        Assert.Empty(rows);
+    }
+
+    [Fact]
+    public async Task GetEffectivePermissions_DirectAndRole_MergesSourcesIntoSingleItem()
+    {
+        var userCreate = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("Combined", "combined.eff@example.com"), TestApiClient.JsonOptions);
+        var user = await userCreate.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(user);
+
+        var (sharedPermissionId, role) = await SeedUserSharedPermissionAsync(user.Id);
+
+        var resp = await _client.GetAsync($"/api/v1/users/{user.Id}/effective-permissions");
+        resp.EnsureSuccessStatusCode();
+        var rows = await resp.Content.ReadFromJsonAsync<List<EffectivePermissionDto>>(TestApiClient.JsonOptions);
+        Assert.NotNull(rows);
+
+        var item = Assert.Single(rows, r => r.PermissionId == sharedPermissionId);
+        Assert.Equal(2, item.Sources.Count);
+        Assert.Contains(item.Sources, s => s.Kind == "direct" && s.RoleId is null);
+        Assert.Contains(item.Sources, s => s.Kind == "role" && s.RoleId == role.Id && s.RoleCode == role.Code);
+    }
+
+    [Fact]
+    public async Task GetEffectivePermissions_DeletedRole_DoesNotSurfacePermissionsFromRole()
+    {
+        var userCreate = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("DelRole", "del.role.eff@example.com"), TestApiClient.JsonOptions);
+        var user = await userCreate.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(user);
+
+        var permissionId = await SeedDeletedRoleWithPermissionAsync(user.Id);
+
+        var resp = await _client.GetAsync($"/api/v1/users/{user.Id}/effective-permissions");
+        resp.EnsureSuccessStatusCode();
+        var rows = await resp.Content.ReadFromJsonAsync<List<EffectivePermissionDto>>(TestApiClient.JsonOptions);
+        Assert.NotNull(rows);
+        Assert.DoesNotContain(rows, r => r.PermissionId == permissionId);
+    }
+
+    [Fact]
+    public async Task GetEffectivePermissions_FilterBySystemId_ReturnsOnlyMatchingRows()
+    {
+        var userCreate = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("FilterSys", "filter.sys.eff@example.com"), TestApiClient.JsonOptions);
+        var user = await userCreate.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(user);
+
+        var (permissionId, expectedSystemId) = await SeedDirectPermissionAsync(user.Id);
+
+        // Sistema válido (autenticator é o seedado, mas permissão criada via fluxo controlado garante
+        // que `expectedSystemId` esteja entre os sistemas presentes).
+        var ok = await _client.GetAsync($"/api/v1/users/{user.Id}/effective-permissions?systemId={expectedSystemId}");
+        ok.EnsureSuccessStatusCode();
+        var matching = await ok.Content.ReadFromJsonAsync<List<EffectivePermissionDto>>(TestApiClient.JsonOptions);
+        Assert.NotNull(matching);
+        Assert.Contains(matching, p => p.PermissionId == permissionId);
+        Assert.All(matching, p => Assert.Equal(expectedSystemId, p.SystemId));
+
+        // SystemId desconhecido → array vazio (sem matches).
+        var emptyResp = await _client.GetAsync($"/api/v1/users/{user.Id}/effective-permissions?systemId={Guid.NewGuid()}");
+        emptyResp.EnsureSuccessStatusCode();
+        var empty = await emptyResp.Content.ReadFromJsonAsync<List<EffectivePermissionDto>>(TestApiClient.JsonOptions);
+        Assert.NotNull(empty);
+        Assert.Empty(empty);
+    }
+
+    [Fact]
+    public async Task GetEffectivePermissions_GuidEmptySystemId_ReturnsBadRequest()
+    {
+        var userCreate = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("EmptyGuid", "empty.guid.eff@example.com"), TestApiClient.JsonOptions);
+        var user = await userCreate.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(user);
+
+        var resp = await _client.GetAsync(
+            $"/api/v1/users/{user.Id}/effective-permissions?systemId={Guid.Empty}");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetEffectivePermissions_UnknownOrDeletedUser_Returns404()
+    {
+        var unknown = await _client.GetAsync(
+            $"/api/v1/users/{Guid.NewGuid()}/effective-permissions");
+        Assert.Equal(HttpStatusCode.NotFound, unknown.StatusCode);
+
+        var userCreate = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("DelUser", "del.user.eff@example.com"), TestApiClient.JsonOptions);
+        var user = await userCreate.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(user);
+        await _client.DeleteAsync($"/api/v1/users/{user.Id}");
+
+        var deleted = await _client.GetAsync(
+            $"/api/v1/users/{user.Id}/effective-permissions");
+        Assert.Equal(HttpStatusCode.NotFound, deleted.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetEffectivePermissions_OrderedDeterministically()
+    {
+        var userCreate = await _client.PostAsJsonAsync("/api/v1/users",
+            UserCreateBody("Ordered", "ordered.eff@example.com"), TestApiClient.JsonOptions);
+        var user = await userCreate.Content.ReadFromJsonAsync<UserDto>(TestApiClient.JsonOptions);
+        Assert.NotNull(user);
+
+        await SeedMultiPermissionsAsync(user.Id);
+
+        var resp = await _client.GetAsync($"/api/v1/users/{user.Id}/effective-permissions");
+        resp.EnsureSuccessStatusCode();
+        var rows = await resp.Content.ReadFromJsonAsync<List<EffectivePermissionDto>>(TestApiClient.JsonOptions);
+        Assert.NotNull(rows);
+        Assert.NotEmpty(rows);
+
+        var ordered = rows
+            .OrderBy(r => r.SystemCode, StringComparer.Ordinal)
+            .ThenBy(r => r.RouteCode, StringComparer.Ordinal)
+            .ThenBy(r => r.PermissionTypeCode, StringComparer.Ordinal)
+            .Select(r => r.PermissionId)
+            .ToList();
+        Assert.Equal(ordered, rows.Select(r => r.PermissionId).ToList());
     }
 
     [Fact]
@@ -911,6 +1076,286 @@ public class UsersApiTests : IAsyncLifetime
         return page;
     }
 
+    /// <summary>
+    /// Cria 2 vínculos diretos (Permission e UserPermission) e 2 vínculos via role (Role e UserRole),
+    /// soft-deletando um link de cada categoria, e devolve os ids dos vínculos ativos e deletados
+    /// para validar a projeção de <c>GetById</c> (que filtra apenas links com link e entidade ativos).
+    /// </summary>
+    private async Task<(Guid activePermissionId, Guid deletedPermissionId, Guid activeRoleId, Guid deletedRoleId)>
+        SeedUserLinksAsync(Guid userId)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var system = await db.Systems.AsNoTracking().FirstAsync();
+        var route = await db.Routes.AsNoTracking().Where(r => r.SystemId == system.Id).FirstAsync();
+        var type = await db.PermissionTypes.AsNoTracking().FirstAsync();
+
+        var p1 = new Models.AppPermission
+        {
+            RouteId = route.Id,
+            PermissionTypeId = type.Id,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        var p2 = new Models.AppPermission
+        {
+            RouteId = route.Id,
+            PermissionTypeId = type.Id,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        db.Permissions.AddRange(p1, p2);
+
+        var role1 = new Models.AppRole
+        {
+            SystemId = system.Id,
+            Code = $"role_active_{Guid.NewGuid():N}",
+            Name = "Role Ativa",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        var role2 = new Models.AppRole
+        {
+            SystemId = system.Id,
+            Code = $"role_deleted_{Guid.NewGuid():N}",
+            Name = "Role Inativa",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        db.Roles.AddRange(role1, role2);
+        await db.SaveChangesAsync();
+
+        var nowUtc = DateTime.UtcNow;
+        db.UserPermissions.AddRange(
+            new Models.AppUserPermission
+            {
+                UserId = userId,
+                PermissionId = p1.Id,
+                CreatedAt = nowUtc,
+                UpdatedAt = nowUtc
+            },
+            new Models.AppUserPermission
+            {
+                UserId = userId,
+                PermissionId = p2.Id,
+                CreatedAt = nowUtc,
+                UpdatedAt = nowUtc,
+                DeletedAt = nowUtc
+            });
+
+        db.UserRoles.AddRange(
+            new Models.AppUserRole
+            {
+                UserId = userId,
+                RoleId = role1.Id,
+                CreatedAt = nowUtc,
+                UpdatedAt = nowUtc
+            },
+            new Models.AppUserRole
+            {
+                UserId = userId,
+                RoleId = role2.Id,
+                CreatedAt = nowUtc,
+                UpdatedAt = nowUtc,
+                DeletedAt = nowUtc
+            });
+        await db.SaveChangesAsync();
+
+        return (p1.Id, p2.Id, role1.Id, role2.Id);
+    }
+
+    /// <summary>
+    /// Cria uma única <c>Permission</c> e vincula simultaneamente como <c>UserPermissions</c> direto
+    /// e via uma <c>Role</c> em <c>RolePermissions</c> + <c>UserRoles</c>. Usado para validar que
+    /// <c>GetEffectivePermissions</c> consolida em um único item com 2 sources.
+    /// </summary>
+    private async Task<(Guid permissionId, SeededRole role)> SeedUserSharedPermissionAsync(Guid userId)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var system = await db.Systems.AsNoTracking().FirstAsync();
+        var route = await db.Routes.AsNoTracking().Where(r => r.SystemId == system.Id).FirstAsync();
+        var type = await db.PermissionTypes.AsNoTracking().FirstAsync();
+
+        var permission = new Models.AppPermission
+        {
+            RouteId = route.Id,
+            PermissionTypeId = type.Id,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        var role = new Models.AppRole
+        {
+            SystemId = system.Id,
+            Code = $"role_shared_{Guid.NewGuid():N}",
+            Name = "Role Shared",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        db.Permissions.Add(permission);
+        db.Roles.Add(role);
+        await db.SaveChangesAsync();
+
+        var nowUtc = DateTime.UtcNow;
+        db.UserPermissions.Add(new Models.AppUserPermission
+        {
+            UserId = userId,
+            PermissionId = permission.Id,
+            CreatedAt = nowUtc,
+            UpdatedAt = nowUtc
+        });
+        db.UserRoles.Add(new Models.AppUserRole
+        {
+            UserId = userId,
+            RoleId = role.Id,
+            CreatedAt = nowUtc,
+            UpdatedAt = nowUtc
+        });
+        db.RolePermissions.Add(new Models.AppRolePermission
+        {
+            RoleId = role.Id,
+            PermissionId = permission.Id,
+            CreatedAt = nowUtc,
+            UpdatedAt = nowUtc
+        });
+        await db.SaveChangesAsync();
+
+        return (permission.Id, new SeededRole(role.Id, role.Code, role.Name));
+    }
+
+    /// <summary>
+    /// Cria uma <c>Role</c> com <c>Permission</c> vinculada e a soft-deleta. Vincula a role ao
+    /// usuário e devolve o id da permissão para validar que o endpoint não devolve permissões de
+    /// roles soft-deletadas (filtro global em Roles esconde a entidade alvo do join).
+    /// </summary>
+    private async Task<Guid> SeedDeletedRoleWithPermissionAsync(Guid userId)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var system = await db.Systems.AsNoTracking().FirstAsync();
+        var route = await db.Routes.AsNoTracking().Where(r => r.SystemId == system.Id).FirstAsync();
+        var type = await db.PermissionTypes.AsNoTracking().FirstAsync();
+
+        var permission = new Models.AppPermission
+        {
+            RouteId = route.Id,
+            PermissionTypeId = type.Id,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        var role = new Models.AppRole
+        {
+            SystemId = system.Id,
+            Code = $"role_deleted_{Guid.NewGuid():N}",
+            Name = "Role Deletada",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            DeletedAt = DateTime.UtcNow
+        };
+        db.Permissions.Add(permission);
+        db.Roles.Add(role);
+        await db.SaveChangesAsync();
+
+        var nowUtc = DateTime.UtcNow;
+        db.UserRoles.Add(new Models.AppUserRole
+        {
+            UserId = userId,
+            RoleId = role.Id,
+            CreatedAt = nowUtc,
+            UpdatedAt = nowUtc
+        });
+        db.RolePermissions.Add(new Models.AppRolePermission
+        {
+            RoleId = role.Id,
+            PermissionId = permission.Id,
+            CreatedAt = nowUtc,
+            UpdatedAt = nowUtc
+        });
+        await db.SaveChangesAsync();
+
+        return permission.Id;
+    }
+
+    /// <summary>Cria uma <c>Permission</c> e vincula direto ao usuário, devolvendo o systemId associado.</summary>
+    private async Task<(Guid permissionId, Guid systemId)> SeedDirectPermissionAsync(Guid userId)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var system = await db.Systems.AsNoTracking().FirstAsync();
+        var route = await db.Routes.AsNoTracking().Where(r => r.SystemId == system.Id).FirstAsync();
+        var type = await db.PermissionTypes.AsNoTracking().FirstAsync();
+
+        var permission = new Models.AppPermission
+        {
+            RouteId = route.Id,
+            PermissionTypeId = type.Id,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        db.Permissions.Add(permission);
+        await db.SaveChangesAsync();
+
+        db.UserPermissions.Add(new Models.AppUserPermission
+        {
+            UserId = userId,
+            PermissionId = permission.Id,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+
+        return (permission.Id, system.Id);
+    }
+
+    /// <summary>
+    /// Cria múltiplas permissões em rotas distintas para o usuário, garantindo cenário de ordenação
+    /// não trivial (codes diferentes em SystemCode/RouteCode/PermissionTypeCode).
+    /// </summary>
+    private async Task SeedMultiPermissionsAsync(Guid userId)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var system = await db.Systems.AsNoTracking().FirstAsync();
+        var routes = await db.Routes.AsNoTracking().Where(r => r.SystemId == system.Id).Take(2).ToListAsync();
+        var types = await db.PermissionTypes.AsNoTracking().Take(2).ToListAsync();
+        Assert.True(routes.Count >= 1);
+        Assert.True(types.Count >= 1);
+
+        var permissions = new List<Models.AppPermission>();
+        for (var ri = 0; ri < routes.Count; ri++)
+        {
+            for (var ti = 0; ti < types.Count; ti++)
+            {
+                permissions.Add(new Models.AppPermission
+                {
+                    RouteId = routes[ri].Id,
+                    PermissionTypeId = types[ti].Id,
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow
+                });
+            }
+        }
+        db.Permissions.AddRange(permissions);
+        await db.SaveChangesAsync();
+
+        foreach (var permission in permissions)
+        {
+            db.UserPermissions.Add(new Models.AppUserPermission
+            {
+                UserId = userId,
+                PermissionId = permission.Id,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            });
+        }
+        await db.SaveChangesAsync();
+    }
+
     private async Task<PagedUsersDetailDto> GetUsersDetailPageAsync(string url)
     {
         var resp = await _client.GetAsync(url);
@@ -949,6 +1394,7 @@ public class UsersApiTests : IAsyncLifetime
         Guid Id,
         string Name,
         string Email,
+        Guid? ClientId,
         int Identity,
         bool Active,
         DateTime CreatedAt,
@@ -958,7 +1404,7 @@ public class UsersApiTests : IAsyncLifetime
         List<UserPermissionLinkDto> Permissions);
 
     private sealed record UserRoleLinkDto(
-        int Id,
+        Guid Id,
         Guid UserId,
         Guid RoleId,
         DateTime CreatedAt,
@@ -972,6 +1418,25 @@ public class UsersApiTests : IAsyncLifetime
         DateTime CreatedAt,
         DateTime UpdatedAt,
         DateTime? DeletedAt);
+
+    private sealed record EffectivePermissionDto(
+        Guid PermissionId,
+        string RouteCode,
+        string RouteName,
+        string PermissionTypeCode,
+        string PermissionTypeName,
+        Guid SystemId,
+        string SystemCode,
+        string SystemName,
+        List<EffectiveSourceDto> Sources);
+
+    private sealed record EffectiveSourceDto(
+        string Kind,
+        Guid? RoleId,
+        string? RoleCode,
+        string? RoleName);
+
+    private sealed record SeededRole(Guid Id, string Code, string Name);
 
     private sealed record ClientIdDto(Guid Id);
 

--- a/AuthService/Controllers/Users/UsersController.cs
+++ b/AuthService/Controllers/Users/UsersController.cs
@@ -84,7 +84,7 @@ public partial class UsersController : ControllerBase
     }
 
     public record UserRoleLinkResponse(
-        int Id,
+        Guid Id,
         Guid UserId,
         Guid RoleId,
         DateTime CreatedAt,
@@ -433,11 +433,41 @@ public partial class UsersController : ControllerBase
     [Authorize(Policy = PermissionPolicies.UsersRead)]
     public async Task<IActionResult> GetById(Guid id)
     {
-        var user = await _db.Users.FirstOrDefaultAsync(u => u.Id == id);
+        var user = await _db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == id);
         if (user is null)
             return NotFound(new { message = UserNotFoundMessage });
 
-        return Ok(new UserMinimalResponse(user.Id, user.Name, user.Email));
+        // Vínculos ativos: link com DeletedAt IS NULL E entidade alvo (Role / Permission) também
+        // ativa (sem IgnoreQueryFilters → o query filter global já remove soft-deletados nas
+        // entidades alvo). Usamos EXISTS com o DbSet correspondente para evitar trazer a entidade
+        // alvo no payload e manter as projeções planas.
+        var roles = await _db.UserRoles.AsNoTracking()
+            .Where(ur => ur.UserId == id && _db.Roles.Any(r => r.Id == ur.RoleId))
+            .OrderBy(ur => ur.CreatedAt)
+            .ThenBy(ur => ur.Id)
+            .Select(ur => new UserRoleLinkResponse(
+                ur.Id,
+                ur.UserId,
+                ur.RoleId,
+                ur.CreatedAt,
+                ur.UpdatedAt,
+                ur.DeletedAt))
+            .ToListAsync();
+
+        var permissions = await _db.UserPermissions.AsNoTracking()
+            .Where(up => up.UserId == id && _db.Permissions.Any(p => p.Id == up.PermissionId))
+            .OrderBy(up => up.CreatedAt)
+            .ThenBy(up => up.Id)
+            .Select(up => new UserPermissionLinkResponse(
+                up.Id,
+                up.UserId,
+                up.PermissionId,
+                up.CreatedAt,
+                up.UpdatedAt,
+                up.DeletedAt))
+            .ToListAsync();
+
+        return Ok(ToResponse(user, roles, permissions));
     }
 
     [HttpPut("{id:guid}")]
@@ -591,6 +621,221 @@ public partial class UsersController : ControllerBase
         Level = LogLevel.Information,
         Message = "ForceLogout: target {UserId}, by {CallerId}, newTokenVersion={NewTokenVersion}")]
     private partial void LogForceLogoutCompleted(Guid userId, Guid callerId, int newTokenVersion);
+
+    /// <summary>
+    /// Origem de uma permissão na resposta de <see cref="GetEffectivePermissions"/>: <c>direct</c>
+    /// (vinculada diretamente ao usuário) ou <c>role</c> (herdada de uma role do usuário).
+    /// Os campos <c>RoleId</c>, <c>RoleCode</c> e <c>RoleName</c> são preenchidos somente quando
+    /// <c>Kind = "role"</c>.
+    /// </summary>
+    public record EffectivePermissionSource(
+        string Kind,
+        Guid? RoleId = null,
+        string? RoleCode = null,
+        string? RoleName = null);
+
+    public record EffectivePermissionResponse(
+        Guid PermissionId,
+        string RouteCode,
+        string RouteName,
+        string PermissionTypeCode,
+        string PermissionTypeName,
+        Guid SystemId,
+        string SystemCode,
+        string SystemName,
+        IReadOnlyList<EffectivePermissionSource> Sources);
+
+    /// <summary>
+    /// Retorna a união consolidada das permissões efetivas do usuário (diretas + via roles), com
+    /// a origem agregada por permissão. Apenas vínculos ativos (<c>DeletedAt IS NULL</c> nos links
+    /// e nas entidades alvo) compõem o resultado: o filtro global já esconde Permissions, Routes,
+    /// Systems, PermissionTypes e Roles soft-deletados; os links UserPermissions/UserRoles/RolePermissions
+    /// recebem o predicado <c>DeletedAt == null</c> explícito porque ainda não têm query filter global.
+    ///
+    /// Filtro opcional <c>?systemId=</c> restringe pelas permissões cuja rota pertence ao sistema.
+    /// Ordenação determinística: <c>SystemCode</c>, <c>RouteCode</c>, <c>PermissionTypeCode</c>.
+    /// 404 quando o usuário não existe ou está soft-deletado. Política <c>perm:Users.Read</c>.
+    /// </summary>
+    [HttpGet("{id:guid}/effective-permissions")]
+    [Authorize(Policy = PermissionPolicies.UsersRead)]
+    public async Task<IActionResult> GetEffectivePermissions(
+        Guid id,
+        [FromQuery] Guid? systemId = null)
+    {
+        if (systemId.HasValue && systemId.Value == Guid.Empty)
+        {
+            ModelState.AddModelError(nameof(systemId), "systemId inválido.");
+            return ValidationProblem(ModelState);
+        }
+
+        var userExists = await _db.Users.AsNoTracking().AnyAsync(u => u.Id == id);
+        if (!userExists)
+            return NotFound(new { message = UserNotFoundMessage });
+
+        // Direct: permissions vinculadas ao usuário (link ativo + permission ativa).
+        // O filtro global em Permissions/Routes/Systems/PermissionTypes garante que só ativos
+        // são acessíveis sem IgnoreQueryFilters; aqui aplicamos `up.DeletedAt == null` no link.
+        var directBase =
+            from up in _db.UserPermissions.AsNoTracking()
+            where up.UserId == id && up.DeletedAt == null
+            join p in _db.Permissions.AsNoTracking() on up.PermissionId equals p.Id
+            join r in _db.Routes.AsNoTracking() on p.RouteId equals r.Id
+            join s in _db.Systems.AsNoTracking() on r.SystemId equals s.Id
+            join t in _db.PermissionTypes.AsNoTracking() on p.PermissionTypeId equals t.Id
+            select new
+            {
+                PermissionId = p.Id,
+                RouteCode = r.Code,
+                RouteName = r.Name,
+                PermissionTypeCode = t.Code,
+                PermissionTypeName = t.Name,
+                SystemId = s.Id,
+                SystemCode = s.Code,
+                SystemName = s.Name
+            };
+
+        if (systemId.HasValue)
+            directBase = directBase.Where(x => x.SystemId == systemId.Value);
+
+        // Role-based: permissions herdadas via UserRoles → RolePermissions. Filtra link ativo
+        // tanto em UserRoles quanto em RolePermissions; a Role precisa estar ativa (filter global).
+        var roleBase =
+            from ur in _db.UserRoles.AsNoTracking()
+            where ur.UserId == id && ur.DeletedAt == null
+            join role in _db.Roles.AsNoTracking() on ur.RoleId equals role.Id
+            join rp in _db.RolePermissions.AsNoTracking() on role.Id equals rp.RoleId
+            where rp.DeletedAt == null
+            join p in _db.Permissions.AsNoTracking() on rp.PermissionId equals p.Id
+            join r in _db.Routes.AsNoTracking() on p.RouteId equals r.Id
+            join s in _db.Systems.AsNoTracking() on r.SystemId equals s.Id
+            join t in _db.PermissionTypes.AsNoTracking() on p.PermissionTypeId equals t.Id
+            select new
+            {
+                PermissionId = p.Id,
+                RouteCode = r.Code,
+                RouteName = r.Name,
+                PermissionTypeCode = t.Code,
+                PermissionTypeName = t.Name,
+                SystemId = s.Id,
+                SystemCode = s.Code,
+                SystemName = s.Name,
+                RoleId = role.Id,
+                RoleCode = role.Code,
+                RoleName = role.Name
+            };
+
+        if (systemId.HasValue)
+            roleBase = roleBase.Where(x => x.SystemId == systemId.Value);
+
+        // Materializa as duas faces em paralelo (duas queries independentes, sem UNION SQL para
+        // evitar limitações de tradução com tipos heterogêneos). O agrupamento por PermissionId e
+        // a consolidação do array `sources` ocorre em memória — N proporcional ao total de linhas
+        // efetivas (sem N+1; cada DbSet é tocado no máximo duas vezes em todo o handler).
+        var directList = await directBase.ToListAsync();
+        var roleList = await roleBase.ToListAsync();
+
+        var rows = new List<EffectivePermissionRow>(directList.Count + roleList.Count);
+        foreach (var d in directList)
+        {
+            rows.Add(new EffectivePermissionRow(
+                d.PermissionId,
+                d.RouteCode,
+                d.RouteName,
+                d.PermissionTypeCode,
+                d.PermissionTypeName,
+                d.SystemId,
+                d.SystemCode,
+                d.SystemName,
+                "direct",
+                null,
+                null,
+                null));
+        }
+        foreach (var rrow in roleList)
+        {
+            rows.Add(new EffectivePermissionRow(
+                rrow.PermissionId,
+                rrow.RouteCode,
+                rrow.RouteName,
+                rrow.PermissionTypeCode,
+                rrow.PermissionTypeName,
+                rrow.SystemId,
+                rrow.SystemCode,
+                rrow.SystemName,
+                "role",
+                rrow.RoleId,
+                rrow.RoleCode,
+                rrow.RoleName));
+        }
+
+        var result = rows
+            .GroupBy(x => x.PermissionId)
+            .Select(g =>
+            {
+                var first = g.First();
+                var sources = g
+                    .Select(BuildSource)
+                    .Distinct(EffectivePermissionSourceComparer.Instance)
+                    .OrderBy(s => s.Kind, StringComparer.Ordinal)
+                    .ThenBy(s => s.RoleCode, StringComparer.Ordinal)
+                    .ToList();
+                return new EffectivePermissionResponse(
+                    first.PermissionId,
+                    first.RouteCode,
+                    first.RouteName,
+                    first.PermissionTypeCode,
+                    first.PermissionTypeName,
+                    first.SystemId,
+                    first.SystemCode,
+                    first.SystemName,
+                    sources);
+            })
+            .OrderBy(p => p.SystemCode, StringComparer.Ordinal)
+            .ThenBy(p => p.RouteCode, StringComparer.Ordinal)
+            .ThenBy(p => p.PermissionTypeCode, StringComparer.Ordinal)
+            .ToList();
+
+        return Ok(result);
+    }
+
+    private static EffectivePermissionSource BuildSource(EffectivePermissionRow row) =>
+        row.SourceKind == "role"
+            ? new EffectivePermissionSource(row.SourceKind, row.RoleId, row.RoleCode, row.RoleName)
+            : new EffectivePermissionSource(row.SourceKind);
+
+    /// <summary>
+    /// Linha plana intermediária entre a query SQL e o agrupamento por <c>PermissionId</c>. Cada
+    /// permissão pode aparecer múltiplas vezes (uma por origem); a consolidação acontece em memória.
+    /// </summary>
+    private sealed record EffectivePermissionRow(
+        Guid PermissionId,
+        string RouteCode,
+        string RouteName,
+        string PermissionTypeCode,
+        string PermissionTypeName,
+        Guid SystemId,
+        string SystemCode,
+        string SystemName,
+        string SourceKind,
+        Guid? RoleId,
+        string? RoleCode,
+        string? RoleName);
+
+    private sealed class EffectivePermissionSourceComparer : IEqualityComparer<EffectivePermissionSource>
+    {
+        public static readonly EffectivePermissionSourceComparer Instance = new();
+
+        public bool Equals(EffectivePermissionSource? x, EffectivePermissionSource? y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (x is null || y is null) return false;
+            return string.Equals(x.Kind, y.Kind, StringComparison.Ordinal)
+                && Nullable.Equals(x.RoleId, y.RoleId);
+        }
+
+        public int GetHashCode(EffectivePermissionSource obj) =>
+            HashCode.Combine(obj.Kind, obj.RoleId);
+    }
 
     public class AssignPermissionRequest
     {

--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Query string: `?prune=false` (padrão). Quando `prune=true`, rotas do sistema qu
 | `POST` | `/api/v1/users` | Sim | `perm:Users.Create` |
 | `GET` | `/api/v1/users` | Sim | `perm:Users.Read` |
 | `GET` | `/api/v1/users/{id}` | Sim | `perm:Users.Read` |
+| `GET` | `/api/v1/users/{id}/effective-permissions` | Sim | `perm:Users.Read` |
 | `PUT` | `/api/v1/users/{id}` | Sim | `perm:Users.Update` |
 | `PUT` | `/api/v1/users/{id}/password` | Sim | `perm:Users.Update` |
 | `DELETE` | `/api/v1/users/{id}` | Sim | `perm:Users.Delete` |
@@ -313,7 +314,9 @@ Query string: `?prune=false` (padrão). Quando `prune=true`, rotas do sistema qu
 
 **POST:** `name`, `email`, `password`, `identity`, `active` (opcional, padrão `true`). **PUT** usuário: `name`, `email`, `identity`, `active` (sem senha). Email normalizado (ex.: minúsculas).
 
-**GET** `/api/v1/users/{id}` retorna também os vínculos ativos **`roles`** (lista com `id` inteiro, `userId`, `roleId`, auditoria e `deletedAt`) e **`permissions`** (lista com `id` GUID, `userId`, `permissionId`, auditoria e `deletedAt`). Listagens **`GET /api/v1/users`** e respostas de criação/atualização devolvem `roles` e `permissions` como arrays vazios.
+**GET** `/api/v1/users/{id}` retorna o `UserResponse` completo com `id`, `name`, `email`, `clientId`, `identity`, `active`, auditoria e os vínculos ativos **`roles`** (lista com `id` GUID, `userId`, `roleId`, auditoria e `deletedAt`) e **`permissions`** (lista com `id` GUID, `userId`, `permissionId`, auditoria e `deletedAt`). Apenas vínculos ativos aparecem (link e entidade alvo com `DeletedAt IS NULL`). Listagens **`GET /api/v1/users`** e respostas de criação/atualização devolvem `roles` e `permissions` como arrays vazios.
+
+**`GET /api/v1/users/{id}/effective-permissions`** retorna a união consolidada das permissões efetivas do usuário, juntando permissões diretas (`UserPermissions`) e herdadas via roles (`UserRoles → RolePermissions`), com a origem agregada por permissão. Apenas vínculos ativos compõem o resultado (link e entidade alvo com `DeletedAt IS NULL`). Cada item traz a permissão denormalizada (`routeCode`, `routeName`, `permissionTypeCode`, `permissionTypeName`, `systemId`, `systemCode`, `systemName`) e um array `sources` com todas as origens — uma permissão pode aparecer simultaneamente como `{ "kind": "direct" }` e como `{ "kind": "role", "roleId", "roleCode", "roleName" }` (uma entrada por role). Filtro opcional `?systemId=<guid>` restringe pelas permissões cuja rota pertence ao sistema (`Guid.Empty` retorna **400**). Ordenação determinística: `systemCode`, `routeCode`, `permissionTypeCode`. **404** quando o usuário não existe ou está soft-deletado. Usuário sem permissões diretas e sem roles ativas retorna `[]`.
 
 **`GET /api/v1/users`** suporta dois modos:
 


### PR DESCRIPTION
## Resumo

- `GET /api/v1/users/{id}` passa a retornar o `UserResponse` completo (id, name, email, clientId, identity, active, audit) com `roles` e `permissions` populados apenas para vínculos ativos (link + entidade alvo com `DeletedAt IS NULL`). Antes retornava `UserMinimalResponse(Id, Name, Email)`.
- Novo endpoint `GET /api/v1/users/{id}/effective-permissions` devolve a união consolidada das permissões efetivas (diretas + herdadas via roles) com `sources` agregadas por permissão (`{ kind: "direct" }` e/ou `{ kind: "role", roleId, roleCode, roleName }`).
- Filtro opcional `?systemId=<guid>` (Guid.Empty → 400). Ordenação determinística: `systemCode`, `routeCode`, `permissionTypeCode`. 404 quando o usuário não existe ou está soft-deletado. Política `perm:Users.Read`.
- `UserRoleLinkResponse.Id` corrigido de `int` para `Guid` (paridade com `AppUserRole.Id`, que já é Guid desde a migration `UserRolesIdToGuid`).
- README atualizado (seção `Usuários`) corrigindo o contrato de `GetById` e documentando o novo endpoint; teste do catálogo Swagger atualizado para incluir `/api/v1/users/{id}/effective-permissions`.

## Detalhes técnicos

- Sem N+1: GetById faz 1 query no usuário, 1 nas Roles ativas e 1 nas Permissions ativas; o novo endpoint faz 1 query AnyAsync + 2 queries materializadas (direta e via roles) com joins denormalizados (`Routes`, `Systems`, `PermissionTypes`, `Roles`).
- Sem `IgnoreQueryFilters` nas entidades alvo: o filtro global de soft-delete já remove permissões/rotas/sistemas/tipos/roles soft-deletados; nos links (`UserPermissions`, `UserRoles`, `RolePermissions`) o predicado `DeletedAt == null` é aplicado explicitamente.
- Agregação `sources` em memória após o materialize (N proporcional ao total de linhas efetivas).

## Plano de testes

- [x] `dotnet build /p:TreatWarningsAsErrors=true` via Docker SDK 10.0 (0 warnings, 0 errors)
- [x] `dotnet format --verify-no-changes` via Docker SDK 10.0
- [x] `docker compose --profile test run --rm test` (338 passed / 0 failed)
- [x] Cobertura nova: GetById com roles/permissions ativos, GetById só com vínculos ativos (deleta um link e um role), array vazio sem vínculos, single item com sources `direct + role`, role soft-deletada não aparece, filtro `?systemId=` válido vs. desconhecido, `Guid.Empty` → 400, 404 para usuário inexistente/soft-deletado, ordenação determinística por (systemCode, routeCode, permissionTypeCode).

Closes #167